### PR TITLE
v2 release

### DIFF
--- a/.env
+++ b/.env
@@ -25,10 +25,10 @@ fi
 export IMAGE=aws-do-eks
 ## VERSION: [optional] - Version tag for this Docker image. Example: v20180302
 #export VERSION=v$(date +%Y%m%d)
-export VERSION=v1
+export VERSION=v2-20211005
 export TAG=$(if [ -z "${VERSION}" ]; then echo ""; else echo ":${VERSION}"; fi) 
 ## BUILD_OPTS: [optional] - arguments for the docker image build command
-export BUILD_OPTS="--build-arg http_proxy=${http_proxy} --build-arg https_proxy=${https_proxy} --build-arg no_proxy=${no_proxy}"
+export BUILD_OPTS="--progress plain --build-arg http_proxy=${http_proxy} --build-arg https_proxy=${https_proxy} --build-arg no_proxy=${no_proxy}"
 
 # Docker container runtime settings
 ## CONTAINER_NAME: [optional] - Name of the Docker container including the --name switch. Example --name myapp
@@ -37,7 +37,7 @@ export CONTAINER_NAME="--name ${CONTAINER}"
 ## Port map [optional] - Mapping of external to internal ports including the -p switch. Example -p 80:8080 
 #export PORT_MAP="-p 80:8080"
 ## Volume map [optional] - Mapping of external to internal paths including the -v switch. Example $(pwd):/wd
-export VOL_MAP="-v ${HOME}/.aws:/root/.aws -v $(pwd)/wd/conf/eks.conf:/eks/eks.conf"
+export VOL_MAP="-v ${HOME}/.aws:/root/.aws -v ${HOME}/.kube:/root/.kube -v $(pwd)/wd/conf/eks.conf:/eks/eks.conf -v $(pwd)/wd/conf/eks.yaml:/eks/eks.yaml"
 ## Network [optional] - Network name including the --net switch. Example --net mynet
 #export NETWORK=
 ## RUN_OPTS [optional] - additional options to specify with the run comman. Example -e POSTGRES_DB=dbname

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Container-Root/eks/deployment/cluster-autoscaler/cluster-autoscaler.yaml
 Container-Root/eks/deployment/aws-load-balancer-controller/aws-load-balancer-controller.yaml
+Container-Root/eks/deployment/kube-ops-view/kube-ops-view

--- a/Container-Root/eks/deployment/efa-device-plugin/test-efa-nccl.yaml
+++ b/Container-Root/eks/deployment/efa-device-plugin/test-efa-nccl.yaml
@@ -1,0 +1,97 @@
+apiVersion: kubeflow.org/v1alpha2
+kind: MPIJob
+metadata:
+  name: test-efa-nccl
+spec:
+  slotsPerWorker: 1
+  cleanPodPolicy: Running
+  mpiReplicaSpecs:
+    Launcher:
+      replicas: 1
+      template:
+         spec:
+          imagePullPolicy: IfNotPresent
+          restartPolicy: OnFailure
+          containers:
+          - image: public.ecr.aws/w6p6i9i7/aws-efa-nccl-rdma:base-cudnn8-cuda11-ubuntu18.04
+            name: efa-nccl-launcher
+            env:
+             - name: LD_LIBRARY_PATH
+               value: /opt/amazon/openmpi/lib:/opt/nccl/build/lib:/opt/amazon/efa/lib:/opt/aws-ofi-nccl/install/lib:/usr/local/nvidia/lib:$LD_LIBRARY_PATH
+             - name: PATH
+               value: $PATH:/opt/amazon/efa/bin
+            command:
+            - /opt/amazon/openmpi/bin/mpirun
+            - --allow-run-as-root
+            - --tag-output
+            - -np
+            - "16"
+            - -bind-to
+            - none
+            - -map-by
+            - slot
+            - -x
+            - PATH
+            - -x
+            - LD_LIBRARY_PATH
+            - -x
+            - NCCL_DEBUG=INFO
+            - -x
+            - NCCL_ALGO=Ring
+            - -x
+            - FI_PROVIDER=efa
+            - -x
+            - FI_EFA_USE_DEVICE_RDMA=1
+            - -x
+            - RDMAV_FORK_SAFE=1
+            - -x
+            - NCCL_SHM_DISABLE=0
+            - --mca
+            - pml
+            - ^cm
+            - --oversubscribe
+            - /tmp/nccl-tests/build/all_reduce_perf
+            - -b
+            - "8"
+            - -e
+            - 1G
+            - -f
+            - "2"
+            - -t
+            - "1"
+            - -g
+            - "1"
+            - -c
+            - "1"
+            - -n
+            - "100"
+    Worker:
+      replicas: 2
+      template:
+        spec:
+          #nodeSelector:
+            #beta.kubernetes.io/instance-type: "p4d.24xlarge"
+            #beta.kubernetes.io/instance-type: "p3dn.24xlarge"
+            #beta.kubernetes.io/instance-type: "g4dn.metal"
+          imagePullPolicy: IfNotPresent
+          containers:
+          - image: public.ecr.aws/w6p6i9i7/aws-efa-nccl-rdma:base-cudnn8-cuda11-ubuntu18.04
+            name: efa-nccl-worker
+            volumeMounts:
+            - name: shmem
+              mountPath: /dev/shm
+            resources:
+              limits:
+                nvidia.com/gpu: 8
+                hugepages-2Mi: 5120Mi
+                vpc.amazonaws.com/efa: 1
+                memory: 8000Mi
+              requests:
+                nvidia.com/gpu: 8
+                hugepages-2Mi: 5120Mi
+                vpc.amazonaws.com/efa: 1
+                memory: 8000Mi
+          volumes:
+          - name: shmem
+            hostPath:
+              path: /dev/shm

--- a/Container-Root/eks/deployment/efa-device-plugin/test-efa.yaml
+++ b/Container-Root/eks/deployment/efa-device-plugin/test-efa.yaml
@@ -1,0 +1,84 @@
+apiVersion: kubeflow.org/v1alpha2
+kind: MPIJob
+metadata:
+  name: efa-info-test
+spec:
+  slotsPerWorker: 1
+  cleanPodPolicy: Running
+  mpiReplicaSpecs:
+    Launcher:
+      replicas: 1
+      template:
+         spec:
+          imagePullPolicy: IfNotPresent
+          restartPolicy: OnFailure
+          containers:
+          - image: public.ecr.aws/w6p6i9i7/aws-efa-nccl-rdma:base-cudnn8-cuda11-ubuntu18.04
+            name: efa-info-launcher
+            env:
+             - name: LD_LIBRARY_PATH
+               value: /opt/amazon/openmpi/lib:/opt/nccl/build/lib:/opt/amazon/efa/lib:/opt/aws-ofi-nccl/install/lib:/usr/local/nvidia/lib:$LD_LIBRARY_PATH
+             - name: PATH
+               value: $PATH:/opt/amazon/efa/bin
+             - name: XLA_FLAGS
+               value: "--xla_gpu_cuda_data_dir=/usr/local/cuda"
+             - name: TF_XLA_FLAGS
+               value: "--tf_xla_cpu_global_jit"
+             - name: NCCL_DEBUG
+               value: INFO
+            command:
+            - /opt/amazon/openmpi/bin/mpirun
+            - --allow-run-as-root
+            - --tag-output
+            - -np
+            - "16"
+            - -bind-to
+            - none
+            - -map-by
+            - slot
+            - -x
+            - PATH
+            - -x
+            - LD_LIBRARY_PATH
+            - -x
+            - XLA_FLAGS
+            - -x
+            - TF_XLA_FLAGS
+            - -x
+            - NCCL_DEBUG=INFO
+            - -x
+            - NCCL_ALGO=RING
+            - -x
+            - FI_EFA_USE_DEVICE_RDMA=1
+            - -x
+            - RDMAV_FORK_SAFE=1
+            - -x
+            - NCCL_DEBUG
+            - --mca
+            - pml
+            - ^cm
+            - --oversubscribe
+            - /opt/amazon/efa/bin/fi_info
+            - -p
+            - "efa"
+            - -t
+            - "FI_EP_RDM"
+    Worker:
+      replicas: 2
+      template:
+        spec:
+          imagePullPolicy: IfNotPresent
+          containers:
+          - image: public.ecr.aws/w6p6i9i7/aws-efa-nccl-rdma:base-cudnn8-cuda11-ubuntu18.04
+            name: efa-info-worker
+            resources:
+              limits:
+                nvidia.com/gpu: 8
+                hugepages-2Mi: 5120Mi
+                vpc.amazonaws.com/efa: 4
+                memory: 8000Mi
+              requests:
+                nvidia.com/gpu: 8
+                hugepages-2Mi: 5120Mi
+                vpc.amazonaws.com/efa: 4
+                memory: 8000Mi

--- a/Container-Root/eks/deployment/efa-device-plugin/test-nccl.yaml
+++ b/Container-Root/eks/deployment/efa-device-plugin/test-nccl.yaml
@@ -1,0 +1,97 @@
+apiVersion: kubeflow.org/v1alpha2
+kind: MPIJob
+metadata:
+  name: test-nccl
+spec:
+  slotsPerWorker: 1
+  cleanPodPolicy: Running
+  mpiReplicaSpecs:
+    Launcher:
+      replicas: 1
+      template:
+         spec:
+          imagePullPolicy: IfNotPresent
+          restartPolicy: OnFailure
+          containers:
+          - image: public.ecr.aws/w6p6i9i7/aws-efa-nccl-rdma:base-cudnn8-cuda11-ubuntu18.04
+            name: nccl-launcher
+            env:
+             - name: LD_LIBRARY_PATH
+               value: /opt/amazon/openmpi/lib:/opt/nccl/build/lib:/opt/amazon/efa/lib:/opt/aws-ofi-nccl/install/lib:/usr/local/nvidia/lib:$LD_LIBRARY_PATH
+             - name: PATH
+               value: $PATH:/opt/amazon/efa/bin
+            command:
+            - /opt/amazon/openmpi/bin/mpirun
+            - --allow-run-as-root
+            - --tag-output
+            - -np
+            - "16"
+            - -bind-to
+            - none
+            - -map-by
+            - slot
+            - -x
+            - PATH
+            - -x
+            - LD_LIBRARY_PATH
+            - -x
+            - NCCL_DEBUG=INFO
+            - -x
+            - NCCL_ALGO=Ring
+            - -x
+            - FI_PROVIDER=sockets
+            - -x
+            - FI_EFA_USE_DEVICE_RDMA=1
+            - -x
+            - RDMAV_FORK_SAFE=1
+            - -x
+            - NCCL_SHM_DISABLE=0
+            - --mca
+            - pml
+            - ^cm
+            - --oversubscribe
+            - /tmp/nccl-tests/build/all_reduce_perf
+            - -b
+            - "8"
+            - -e
+            - 1G
+            - -f
+            - "2"
+            - -t
+            - "1"
+            - -g
+            - "1"
+            - -c
+            - "1"
+            - -n
+            - "100"
+    Worker:
+      replicas: 2
+      template:
+        spec:
+          #nodeSelector:
+            #beta.kubernetes.io/instance-type: "p4d.24xlarge"
+            #beta.kubernetes.io/instance-type: "p3dn.24xlarge"
+            #beta.kubernetes.io/instance-type: "g4dn.metal"
+          imagePullPolicy: IfNotPresent
+          containers:
+          - image: public.ecr.aws/w6p6i9i7/aws-efa-nccl-rdma:base-cudnn8-cuda11-ubuntu18.04
+            name: nccl-worker
+            volumeMounts:
+            - name: shmem
+              mountPath: /dev/shm
+            resources:
+              limits:
+                nvidia.com/gpu: 8
+                hugepages-2Mi: 5120Mi
+                #vpc.amazonaws.com/efa: 1
+                memory: 8000Mi
+              requests:
+                nvidia.com/gpu: 8
+                hugepages-2Mi: 5120Mi
+                #vpc.amazonaws.com/efa: 1
+                memory: 8000Mi
+          volumes:
+          - name: shmem
+            hostPath:
+              path: /dev/shm

--- a/Container-Root/eks/deployment/fsx-csi/delete.sh
+++ b/Container-Root/eks/deployment/fsx-csi/delete.sh
@@ -1,10 +1,68 @@
 #!/bin/bash
 
-kubectl delete -f ./fsx-storage-class.yaml
+. fsx.conf
 
+# This script removes the integration of your EKS cluster with FSx
+# Please note that deleting any dynamically provisioned FSx volumes
+# destroys the volumes and the data stored in them
+
+# Storage class
+kubectl delete -f ./fsx-storage-class.yaml
+rm -f ./fsx-storage-class.yaml
+
+# Security group
+echo ""
+echo "Checking security group ${FSX_SECURITY_GROUP_NAME} ..."
+SECURITY_GROUP_ID=$(aws ec2 describe-security-groups --query SecurityGroups[?GroupName=="'${FSX_SECURITY_GROUP_NAME}'"].{GroupId:GroupId} --output text)
+if [ "$SECURITY_GROUP_ID" == "" ]; then
+        echo "Not found."
+else
+        echo "Found."
+        echo "SECURITY_GROUP_ID=${SECURITY_GROUP_ID}"
+        echo "Deleting ..."
+        aws ec2 delete-security-group --group-id ${SECURITY_GROUP_ID}
+fi
+
+# FSx CSI driver
 kubectl delete -k "github.com/kubernetes-sigs/aws-fsx-csi-driver/deploy/kubernetes/overlays/stable/?ref=master"
 
-aws ec2 delete-security-group --group-id ${SECURITY_GROUP_ID}
+# FSx Policy
+echo ""
+echo "Checking FSx Policy ${FSX_POLICY_NAME} ..."
+POLICY_ARN=$(aws iam list-policies --query Policies[?PolicyName=="'${FSX_POLICY_NAME}'"].{Arn:Arn} --output text)
+echo ""
+if [ "$POLICY_ARN" == "" ]; then
+        echo "Policy does not exist."
+else
+        echo "Policy ${FSX_POLICY_NAME} found"
+        echo "POLICY_ARN=$POLICY_ARN"
+        # Detach policy from EKS Instance Profiles
+        echo ""
+        echo "Checking instance profiles ..."
+        for index in ${!EKS_INSTANCE_PROFILE_NAMES[@]}; do
+                EKS_INSTANCE_PROFILE_NAME=${EKS_INSTANCE_PROFILE_NAMES[$index]}
+                echo ""
+                echo "Instance profile ${EKS_INSTANCE_PROFILE_NAME} ..."
+                INSTANCE_PROFILE=$(aws iam list-instance-profiles --query InstanceProfiles[?InstanceProfileName=="'${EKS_INSTANCE_PROFILE_NAME}'"].{InstanceProfileName:InstanceProfileName} --output text)
+                if [ "$INSTANCE_PROFILE" == "" ]; then
+                        echo "Not found."
+                        echo "Please check fsx.conf and try again."
+                        echo "The configured instance profile must exist"
+                        echo "Describe one of the EKS instances in each node group that should have access to FSx "
+                        echo "and find its attached instance profile. Update the array in fsx.conf and try again."
+                        exit 1
+                else
+                        echo "Found."
+                        echo "Getting instance profile role ..."
+                        ROLE_NAME=$(aws iam get-instance-profile --instance-profile-name ${INSTANCE_PROFILE} --query InstanceProfile.Roles[0].RoleName --output text)
+                        echo "Detaching FSx Policy from role ${ROLE_NAME} ..."
+                        aws iam detach-role-policy --role-name ${ROLE_NAME} --policy-arn ${POLICY_ARN}
+                fi
+        done
+        echo ""
+        echo "Deleting policy ${FSX_POLICY_NAME} ..."
+        aws iam delete-policy --policy-arn ${POLICY_ARN}
+fi
 
-aws iam detach-role-policy --role-name ${INSTANCE_ROLE_NAME} --policy-arn ${POLICY_ARN}
+kubectl get sc
 

--- a/Container-Root/eks/deployment/fsx-csi/deploy.sh
+++ b/Container-Root/eks/deployment/fsx-csi/deploy.sh
@@ -1,48 +1,102 @@
 #!/bin/bash
 
-# This script is not fully automated. Follow the steps from this post
+# This script intergrates your EKS cluster with Amazon FSx for Lustre.
+# It requres all values in fsx.conf to be configured.
+# To learn more about FSx and the steps involved in setting it up, please refer to the following links
 # https://aws.amazon.com/blogs/opensource/using-fsx-lustre-csi-driver-amazon-eks/
-# Also refer to: https://docs.aws.amazon.com/eks/latest/userguide/fsx-csi.html
-# and https://github.com/kubernetes-sigs/aws-fsx-csi-driver
-# If dynamic provisioning does not work, use static provisioning instructions from here
+# https://docs.aws.amazon.com/eks/latest/userguide/fsx-csi.html
+# https://github.com/kubernetes-sigs/aws-fsx-csi-driver
+# If dynamic provisioning of FSx volumes through the storage class does not work,
+# you can also use static provisioning using the manifests in this folder or following instructions from here:
 # https://github.com/kubernetes-sigs/aws-fsx-csi-driver/blob/master/examples/kubernetes/static_provisioning/README.md
 
+. fsx.conf
 
+# FSx Policy
 echo ""
-
-echo "Creating FSX Policy ..."
-POLICY_ARN=$(aws iam create-policy --policy-name fsx-csi --policy-document file://./fsx-policy.json --query "Policy.Arn" --output text)
+echo "Checking if FSx Policy ${FSX_POLICY_NAME} exists ..."
+POLICY_ARN=$(aws iam list-policies --query Policies[?PolicyName=="'${FSX_POLICY_NAME}'"].{Arn:Arn} --output text)
+echo ""
+if [ "$POLICY_ARN" == "" ]; then
+        echo "Policy does not exist."
+        echo "Creating FSX Policy ${FSX_POLICY_NAME} ..."
+        POLICY_ARN=$(aws iam create-policy --policy-name ${FSX_POLICY_NAME} --policy-document $FSX_POLICY_DOC --query "Policy.Arn" --output text)
+else
+        echo "Policy ${FSX_POLICY_NAME} found"
+fi
 echo "POLICY_ARN=$POLICY_ARN"
 
-echo "Attaching FSX Policy to Instance Role ..."
-INSTANCE_ROLE_NAME=$(aws cloudformation describe-stacks --stack-name eksctl--driver-nodegroup-ng-1 --output text --query "Stacks[0].Outputs[1].OutputValue" | sed -e 's/.*\///g')
+# EKS Instance Profiles
+echo ""
+echo "Checking instance profiles ..."
+for index in ${!EKS_INSTANCE_PROFILE_NAMES[@]}; do
+        EKS_INSTANCE_PROFILE_NAME=${EKS_INSTANCE_PROFILE_NAMES[$index]}
+        echo ""
+        echo "Instance profile ${EKS_INSTANCE_PROFILE_NAME} ..."
+        INSTANCE_PROFILE=$(aws iam list-instance-profiles --query InstanceProfiles[?InstanceProfileName=="'${EKS_INSTANCE_PROFILE_NAME}'"].{InstanceProfileName:InstanceProfileName} --output text)
+        if [ "$INSTANCE_PROFILE" == "" ]; then
+                echo "Not found."
+                echo "Please check fsx.conf and try again."
+                echo "The configured instance profile must exist"
+                echo "Describe one of the EKS instances in each node group that should have access to FSx "
+                echo "and find its attached instance profile. Update the array in fsx.conf and try again."
+                exit 1
+        else
+                echo "Found."
+                echo "Getting instance profile role ..."
+                ROLE_NAME=$(aws iam get-instance-profile --instance-profile-name ${INSTANCE_PROFILE} --query InstanceProfile.Roles[0].RoleName --output text)
+                echo "Attaching FSx Policy to role ${ROLE_NAME} ..."
+                aws iam attach-role-policy --policy-arn ${POLICY_ARN} --role-name ${ROLE_NAME}
+        fi
+done
 
-echo "INSTANCE_ROLE_NAME=$INSTANCE_ROLE_NAME"
-aws iam attach-role-policy --policy-arn ${POLICY_ARN} --role-name ${INSTANCE_ROLE_NAME}
-
+# FSx CSI driver
+echo ""
 echo "Installing FSx CSI driver ..."
-kubectl create -k "github.com/kubernetes-sigs/aws-fsx-csi-driver/deploy/kubernetes/overlays/stable/?ref=master"
+kubectl apply -k "github.com/kubernetes-sigs/aws-fsx-csi-driver/deploy/kubernetes/overlays/stable/?ref=master"
+echo "FSx pods in kube-system namespace ..."
+kubectl -n kube-system get pods | grep fsx
 
-echo "Showing pods in kube-system namespace ..."
-kubectl -n kube-system get pods
+# Subnet CIDR
+echo ""
+echo "Getting CIDR for subnet ${FSX_SUBNET_ID} ..."
+SUBNET_CIDR=$(aws ec2 describe-subnets --query Subnets[?SubnetId=="'${FSX_SUBNET_ID}'"].{CIDR:CidrBlock} --output text)
+if [ "$SUBNET_CIDR" == "" ]; then
+        echo "Subnet not found."
+        echo "Please check the subnet id provided in fsx.conf and try again"
+        exit 1
+else
+        echo "Subnet found"
+        echo "CIDR=$SUBNET_CIDR"
+        VPC_ID=$(aws ec2 describe-subnets --query Subnets[?SubnetId=="'${FSX_SUBNET_ID}'"].{VpcId:VpcId} --output text)
+fi
 
-VPC_ID=$(aws ec2 describe-vpcs --filters "Name=tag:Name,Values=eksctl-fsx-csi-driver/VPC" --query "Vpcs[0].VpcId" --output text)
+# Security Group
+echo ""
+echo "Checking security group ${FSX_SECURITY_GROUP_NAME} ..."
+SECURITY_GROUP_ID=$(aws ec2 describe-security-groups --query SecurityGroups[?GroupName=="'${FSX_SECURITY_GROUP_NAME}'"].{GroupId:GroupId} --output text)
+if [ "$SECURITY_GROUP_ID" == "" ]; then
+        echo "Not found. Creating ..."
+        SECURITY_GROUP_ID=$(aws ec2 create-security-group --vpc-id ${VPC_ID} --group-name ${FSX_SECURITY_GROUP_NAME} --description "FSx for Lustre Security Group" --query "GroupId" --output text)
+        echo "Authorizing FSx ..."
+        aws ec2 authorize-security-group-ingress --group-id ${SECURITY_GROUP_ID} --protocol tcp --port 988 --cidr ${SUBNET_CIDR}
+else
+        echo "Found."
+fi
+echo "SECURITY_GROUP_ID=${SECURITY_GROUP_ID}"
 
-SUBNET_ID=$(aws ec2 describe-subnets --filters "[{\"Name\": \"vpc-id\",\"Values\": [\"$VPC_ID\"]},{\"Name\": \"tag:aws:cloudformation:logical-id\",\"Values\": [\"SubnetPrivateUSWEST2A\"]}]"  --query "Subnets[0].SubnetId" --output text)
-
-SECURITY_GROUP_ID=$(aws ec2 create-security-group --group-name eks-fsx-security-group --vpc-id ${VPC_ID} --description "FSx for Lustre Security Group" --query "GroupId" --output text)
-
-aws ec2 authorize-security-group-ingress --group-id ${SECURITY_GROUP_ID} --protocol tcp --port 988 --cidr 192.168.0.0/16
-
+# Storage Class
+echo ""
+echo "Creating storage class ${FSX_STORAGE_CLASS_NAME} ..."
 cat > fsx-storage-class.yaml <<EOF
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
-  name: fsx-sc
+  name: ${FSX_STORAGE_CLASS_NAME}
 provisioner: fsx.csi.aws.com
 parameters:
-  subnetId: ${SUBNET_ID}
+  subnetId: ${FSX_SUBNET_ID}
   securityGroupIds: ${SECURITY_GROUP_ID}
 EOF
-
 kubectl apply -f fsx-storage-class.yaml
+kubectl get sc

--- a/Container-Root/eks/deployment/fsx-csi/fsx.conf
+++ b/Container-Root/eks/deployment/fsx-csi/fsx.conf
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# FSX Configuration
+# All settings are required
+
+## IAM Policy to provide access to FSx, if configured policy name does not exist, it will be created.
+export FSX_POLICY_NAME=fsx-csi
+export FSX_POLICY_DOC=file://fsx-policy.json
+
+## Instance profiles of EKS node groups that will have access to FSx. Space separated string enclosed in ().
+export EKS_INSTANCE_PROFILE_NAMES=()
+
+## Subnet to use for all EKS nodes and FSx volumes
+export FSX_SUBNET_ID=
+
+## Security group name for access to FSx volumes. Will be created if it does not exist.
+export FSX_SECURITY_GROUP_NAME=eks-fsx-sg
+
+## Name of FSX storage class to create or update
+export FSX_STORAGE_CLASS_NAME=fsx-sc

--- a/Container-Root/eks/deployment/fsx-csi/test-delete.sh
+++ b/Container-Root/eks/deployment/fsx-csi/test-delete.sh
@@ -1,8 +1,14 @@
 #!/bin/bash
 
-kubectl delete -f ./example-pod.yaml
+# This script removes the test fsx pod, pvc, and pv
+# Please be aware that for dynamically provisioned FSx volumes
+# when the PVC is removed, the FSx volume and its data is destroyed
 
-kubectl delete -f ./example-pvc-static.yaml
+kubectl delete -f ./test-fsx-pod.yaml
 
-kubectl delete -f ./example-pv-static.yaml
+kubectl delete -f ./test-fsx-pvc-dynamic.yaml
+
+#kubectl delete -f ./test-fsx-pvc-static.yaml
+
+#kubectl delete -f ./test-fsx-pv-static.yaml
 

--- a/Container-Root/eks/deployment/fsx-csi/test-deploy.sh
+++ b/Container-Root/eks/deployment/fsx-csi/test-deploy.sh
@@ -1,11 +1,21 @@
 #!/bin/bash
 
-kubectl apply -f ./example-pv-static.yaml
+# This script creates an FSx volume using the fsx storage class with a volume claim
+# Please note the volume will take a while (up to 10 min) to provision
+# A pod is started and mounts the volume claim under /data
+# You can exec into the pod and explore the volume
+# Please be aware that when the PVC is deleted, 
+# the volume and any data stored on it is deleted as well.
 
-kubectl apply -f ./example-pvc-static.yaml
+# Alternatively you can configure and apply the static manifests below
 
-kubectl get pvc fsx-claim
+#kubectl apply -f ./test-fsx-pv-static.yaml
+#kubectl apply -f ./test-fsx-pvc-static.yaml
 
-kubectl apply -f ./example-pod.yaml
+kubectl apply -f ./test-fsx-pvc-dynamic.yaml
 
-#kubectl exec -it fsx-app -- tail -f /data/out.txt
+kubectl describe pvc fsx-claim
+
+kubectl apply -f ./test-fsx-pod.yaml
+
+#kubectl exec -it test-fsx-pod -- bash

--- a/Container-Root/eks/deployment/fsx-csi/test-fsx-pod.yaml
+++ b/Container-Root/eks/deployment/fsx-csi/test-fsx-pod.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-fsx-pod
+spec:
+  containers:
+  - name: app
+    image: centos
+    command: ["/bin/sh"]
+    args: ["-c", "while true; do echo \"hello from FSx\" >> /data/out.txt; sleep 5; done"]
+    volumeMounts:
+    - name: persistent-storage
+      mountPath: /data
+  volumes:
+  - name: persistent-storage
+    persistentVolumeClaim:
+      claimName: fsx-claim

--- a/Container-Root/eks/deployment/fsx-csi/test-fsx-pv-static.yaml
+++ b/Container-Root/eks/deployment/fsx-csi/test-fsx-pv-static.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: fsx-pv
+spec:
+  capacity:
+    storage: 1200Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteMany
+  mountOptions:
+    - flock
+  persistentVolumeReclaimPolicy: Recycle
+  csi:
+    driver: fsx.csi.aws.com
+    volumeHandle: <volume_handle>
+    volumeAttributes:
+      dnsname: <volume_dns_name>
+      mountname: <mount_name>

--- a/Container-Root/eks/deployment/fsx-csi/test-fsx-pvc-dynamic.yaml
+++ b/Container-Root/eks/deployment/fsx-csi/test-fsx-pvc-dynamic.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: fsx-claim
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: fsx-sc
+  resources:
+    requests:
+      storage: 3600Gi

--- a/Container-Root/eks/deployment/fsx-csi/test-fsx-pvc-static.yaml
+++ b/Container-Root/eks/deployment/fsx-csi/test-fsx-pvc-static.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: fsx-claim
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ""
+  resources:
+    requests:
+      storage: 1200Gi
+  volumeName: fsx-pv

--- a/Container-Root/eks/deployment/gpu-efa-metrics/gpu-efa-metrics-daemonset.yaml
+++ b/Container-Root/eks/deployment/gpu-efa-metrics/gpu-efa-metrics-daemonset.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: gpu-efa-metrics
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: "gpu-efa-metrics"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: "gpu-efa-metrics"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: "gpu-efa-metrics"
+      name: "gpu-efa-metrics"
+    spec:
+      hostPID: true
+      hostNetwork: true
+      nodeSelector:
+        #beta.kubernetes.io/instance-type: "p4d.24xlarge"
+        processor: gpu
+      initContainers:
+      - name: "installer"
+        image: "ubuntu:20.04"
+        #command: ["bash", "-c", "while true; do date; sleep 10; done"]
+        command: ["nsenter", "--target", "1", "--mount", "--uts", "--ipc", "--net", "--pid", "--","bash", "-c", "echo IyEvYmluL2Jhc2gKCmVjaG8gIiIKZWNobyAidj09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PXYiCgpvc19yZWxlYXNlPSQoY2F0IC9ldGMvb3MtcmVsZWFzZSkKZWNobyAkb3NfcmVsZWFzZSB8IGdyZXAgIkFtYXpvbiBMaW51eCIgPiAvZGV2L251bGwKaWYgWyAiJD8iID09ICIwIiBdOyB0aGVuCgkjIEFtYXpvbiBMaW51eAoJZWNobyAiSW5zdGFsbGluZyBhY2NlbGVyYXRvciBtZXRyaWNzIGNsb3Vkd2F0Y2ggZXhwb3J0ZXIgc2VydmljZSBvbiBBbWF6b24gTGludXggLi4uIgoJL3Vzci9iaW4vcGlwMyBpbnN0YWxsIGJvdG8zCglta2RpciAtcCAvb3B0L2F3cwoJeXVtIGluc3RhbGwgYW1hem9uLWNsb3Vkd2F0Y2gtYWdlbnQgZ2l0IC15CiAgICAgICAgaWYgWyAtZCAvdG1wL2F3cy1lZmEtbmNjbC1iYXNlYW1pIF07IHRoZW4KICAgICAgICAJcm0gLXJmIC90bXAvYXdzLWVmYS1uY2NsLWJhc2VhbWkKCWZpCglnaXQgY2xvbmUgaHR0cHM6Ly9naXRodWIuY29tL2F3cy1zYW1wbGVzL2F3cy1lZmEtbmNjbC1iYXNlYW1pLXBpcGVsaW5lLmdpdCAvdG1wL2F3cy1lZmEtbmNjbC1iYXNlYW1pCiAgICAgICAgbWtkaXIgLXAgL29wdC9hd3MvY2xvdWR3YXRjaAoJY3AgLXJmIC90bXAvYXdzLWVmYS1uY2NsLWJhc2VhbWkvbnZpZGlhLWVmYS1hbWlfYmFzZS9jbG91ZHdhdGNoIC9vcHQvYXdzLwoJbXYgL29wdC9hd3MvY2xvdWR3YXRjaC9hd3MtaHctbW9uaXRvci5zZXJ2aWNlIC9saWIvc3lzdGVtZC9zeXN0ZW0KCWVjaG8gLWUgJyMhL2Jpbi9zaFxuJyB8IHN1ZG8gdGVlIC9vcHQvYXdzL2Nsb3Vkd2F0Y2gvYXdzLWNsb3Vkd2F0Y2gtd3JhcHBlci5zaAoJZWNobyAtZSAnL3Vzci9iaW4vcHl0aG9uMyAvb3B0L2F3cy9jbG91ZHdhdGNoL252aWRpYS9hd3MtaHdhY2NlbC1lcnJvci1wYXJzZXIucHkgJicgfCBzdWRvIHRlZSAtYSAvb3B0L2F3cy9jbG91ZHdhdGNoL2F3cy1jbG91ZHdhdGNoLXdyYXBwZXIuc2gKCWVjaG8gLWUgJy91c3IvYmluL3B5dGhvbjMgL29wdC9hd3MvY2xvdWR3YXRjaC9udmlkaWEvYWNjZWwtdG8tY3cucHkgL29wdC9hd3MvY2xvdWR3YXRjaC9udmlkaWEvbnZpZGlhLWV4cG9ydGVyID4+IC9kZXYvbnVsbCAyPiYxICZcbicgfCBzdWRvIHRlZSAtYSAvb3B0L2F3cy9jbG91ZHdhdGNoL2F3cy1jbG91ZHdhdGNoLXdyYXBwZXIuc2gKCWVjaG8gLWUgJy91c3IvYmluL3B5dGhvbjMgL29wdC9hd3MvY2xvdWR3YXRjaC9lZmEvZWZhLXRvLWN3LnB5IC9vcHQvYXdzL2Nsb3Vkd2F0Y2gvZWZhL2VmYS1leHBvcnRlciA+PiAvZGV2L251bGwgMj4mMSAmXG4nIHwgc3VkbyB0ZWUgLWEgL29wdC9hd3MvY2xvdWR3YXRjaC9hd3MtY2xvdWR3YXRjaC13cmFwcGVyLnNoCgljaG1vZCAreCAvb3B0L2F3cy9jbG91ZHdhdGNoL2F3cy1jbG91ZHdhdGNoLXdyYXBwZXIuc2gKCWNwIC9vcHQvYXdzL2Nsb3Vkd2F0Y2gvbnZpZGlhL2N3YS1jb25maWcuanNvbiAvb3B0L2F3cy9hbWF6b24tY2xvdWR3YXRjaC1hZ2VudC9iaW4vY29uZmlnLmpzb24KCS9vcHQvYXdzL2FtYXpvbi1jbG91ZHdhdGNoLWFnZW50L2Jpbi9hbWF6b24tY2xvdWR3YXRjaC1hZ2VudC1jdGwgLWEgZmV0Y2gtY29uZmlnIC1tIGVjMiAtYyBmaWxlOi9vcHQvYXdzL2FtYXpvbi1jbG91ZHdhdGNoLWFnZW50L2Jpbi9jb25maWcuanNvbiAtcwoJc3lzdGVtY3RsIGVuYWJsZSBhd3MtaHctbW9uaXRvci5zZXJ2aWNlCglzeXN0ZW1jdGwgcmVzdGFydCBhbWF6b24tY2xvdWR3YXRjaC1hZ2VudC5zZXJ2aWNlCglzeXN0ZW1jdGwgcmVzdGFydCBhd3MtaHctbW9uaXRvci5zZXJ2aWNlCglzeXN0ZW1jdGwgc3RhdHVzIGF3cy1ody1tb25pdG9yLnNlcnZpY2UKZWxzZQoJZWNobyAiQWNjZWxlcmF0b3IgbWV0cmljcyBub3Qgc3VwcG9ydGVkIG9uIHRoaXMgb3BlcmF0aW5nIHN5c3RlbToiCgllY2hvICRvc19yZWxlYXNlCmZpCgplY2hvICIiCgo= | base64 -d > /tmp/gpu-efa-metrics-setup-al2-su.sh; chmod +x /tmp/gpu-efa-metrics-setup-al2-su.sh; /tmp/gpu-efa-metrics-setup-al2-su.sh"]
+        securityContext:
+          privileged: true
+          runAsNonRoot: false
+          runAsUser: 0
+      containers:
+      - name: "heartbeat"
+        image: "ubuntu:20.04"
+        command: ["bash", "-c", "while true; do echo Hardware Accelerator Monitor pod is alive on $(date); sleep 60; done"]
+

--- a/Container-Root/eks/deployment/gpu-efa-metrics/gpu-efa-metrics-setup-al2-su.sh
+++ b/Container-Root/eks/deployment/gpu-efa-metrics/gpu-efa-metrics-setup-al2-su.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+echo ""
+echo "v====================================================================================v"
+
+os_release=$(cat /etc/os-release)
+echo $os_release | grep "Amazon Linux" > /dev/null
+if [ "$?" == "0" ]; then
+	# Amazon Linux
+	echo "Installing accelerator metrics cloudwatch exporter service on Amazon Linux ..."
+	/usr/bin/pip3 install boto3
+	mkdir -p /opt/aws
+	yum install amazon-cloudwatch-agent git -y
+        if [ -d /tmp/aws-efa-nccl-baseami ]; then
+        	rm -rf /tmp/aws-efa-nccl-baseami
+	fi
+	git clone https://github.com/aws-samples/aws-efa-nccl-baseami-pipeline.git /tmp/aws-efa-nccl-baseami
+        mkdir -p /opt/aws/cloudwatch
+	cp -rf /tmp/aws-efa-nccl-baseami/nvidia-efa-ami_base/cloudwatch /opt/aws/
+	mv /opt/aws/cloudwatch/aws-hw-monitor.service /lib/systemd/system
+	echo -e '#!/bin/sh\n' | sudo tee /opt/aws/cloudwatch/aws-cloudwatch-wrapper.sh
+	echo -e '/usr/bin/python3 /opt/aws/cloudwatch/nvidia/aws-hwaccel-error-parser.py &' | sudo tee -a /opt/aws/cloudwatch/aws-cloudwatch-wrapper.sh
+	echo -e '/usr/bin/python3 /opt/aws/cloudwatch/nvidia/accel-to-cw.py /opt/aws/cloudwatch/nvidia/nvidia-exporter >> /dev/null 2>&1 &\n' | sudo tee -a /opt/aws/cloudwatch/aws-cloudwatch-wrapper.sh
+	echo -e '/usr/bin/python3 /opt/aws/cloudwatch/efa/efa-to-cw.py /opt/aws/cloudwatch/efa/efa-exporter >> /dev/null 2>&1 &\n' | sudo tee -a /opt/aws/cloudwatch/aws-cloudwatch-wrapper.sh
+	chmod +x /opt/aws/cloudwatch/aws-cloudwatch-wrapper.sh
+	cp /opt/aws/cloudwatch/nvidia/cwa-config.json /opt/aws/amazon-cloudwatch-agent/bin/config.json
+	/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/bin/config.json -s
+	systemctl enable aws-hw-monitor.service
+	systemctl restart amazon-cloudwatch-agent.service
+	systemctl restart aws-hw-monitor.service
+	systemctl status aws-hw-monitor.service
+else
+	echo "Accelerator metrics not supported on this operating system:"
+	echo $os_release
+fi
+
+echo ""
+

--- a/Container-Root/eks/deployment/gpu-efa-metrics/labels-add.sh
+++ b/Container-Root/eks/deployment/gpu-efa-metrics/labels-add.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+kubectl label nodes --all processor=gpu

--- a/Container-Root/eks/deployment/gpu-efa-metrics/labels-show.sh
+++ b/Container-Root/eks/deployment/gpu-efa-metrics/labels-show.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+kubectl get nodes --show-labels $@
+

--- a/Container-Root/eks/deployment/gpu-efa-metrics/logs.sh
+++ b/Container-Root/eks/deployment/gpu-efa-metrics/logs.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+kubectl -n kube-system logs --selector app.kubernetes.io/name=gpu-efa-metrics --tail -1 -c installer
+

--- a/Container-Root/eks/deployment/kube-ops-view/deploy.sh
+++ b/Container-Root/eks/deployment/kube-ops-view/deploy.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Install kube-ops-view following instructions here:
+# https://codeberg.org/hjacobs/kube-ops-view
+# Please note: This deployment is provided here for convenience only.
+#              It has its own license which is different than aws-do-eks.
+#              Please comply with the terms of the kube-ops-view license
+#              when using this deployment.
+
+git clone https://codeberg.org/hjacobs/kube-ops-view.git
+
+cd kube-ops-view 
+
+kubectl apply -k deploy
+
+kubectl get pods
+
+kubectl get services
+
+echo ""
+echo "When kube-ops-view pods are Running, execute port-forward.sh to access the UI."
+echo ""
+ 

--- a/Container-Root/eks/deployment/kube-ops-view/port-forward.sh
+++ b/Container-Root/eks/deployment/kube-ops-view/port-forward.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Port forward the kube-ops-view service
+
+kubectl port-forward service/kube-ops-view 8080:80
+
+echo ""
+echo "Visit http://localhost:8080 to see the kube-ops-view UI"
+echo ""

--- a/Container-Root/eks/deployment/kube-ops-view/remove.sh
+++ b/Container-Root/eks/deployment/kube-ops-view/remove.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Remove kube-ops-view:
+# Reference: https://codeberg.org/hjacobs/kube-ops-view
+
+cd kube-ops-view 
+
+kubectl delete -k deploy
+
+kubectl get pods
+
+kubectl get services
+
+cd ..
+
+# Optionally remove cloned kube-ops-view repo
+#rm -rf kube-ops-view

--- a/Container-Root/eks/deployment/kubeflow/mpi-operator/mpijob-test.yaml
+++ b/Container-Root/eks/deployment/kubeflow/mpi-operator/mpijob-test.yaml
@@ -1,0 +1,53 @@
+apiVersion: ubeflow.org/v1alpha2
+kind: MPIJob
+metadata:
+  name: tensorflow-mnist
+spec:
+  slotsPerWorker: 1
+  runPolicy:
+    cleanPodPolicy: Running
+  mpiReplicaSpecs:
+    Launcher:
+      replicas: 1
+      template:
+        spec:
+          containers:
+          - image: docker.io/kubeflow/mpi-horovod-mnist
+            name: mpi-launcher
+            command:
+            - mpirun
+            args:
+            - -np
+            - "2"
+            - --allow-run-as-root
+            - -bind-to
+            - none
+            - -map-by
+            - slot
+            - -x
+            - LD_LIBRARY_PATH
+            - -x
+            - PATH
+            - -mca
+            - pml
+            - ob1
+            - -mca
+            - btl
+            - ^openib
+            - python
+            - /examples/tensorflow_mnist.py
+            resources:
+              limits:
+                cpu: 1
+                memory: 2Gi
+    Worker:
+      replicas: 2
+      template:
+        spec:
+          containers:
+          - image: docker.io/kubeflow/mpi-horovod-mnist
+            name: mpi-worker
+            resources:
+              limits:
+                cpu: 2
+                memory: 4Gi

--- a/Container-Root/eks/deployment/nvidia-drivers/cuda-drivers-fabricmanager-470-update-al2-su.sh
+++ b/Container-Root/eks/deployment/nvidia-drivers/cuda-drivers-fabricmanager-470-update-al2-su.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+echo ""
+echo "v==================================================v""
+echo "Checking for failed nvidia fabricmanager service ..."
+systemctl status nvidia-fabricmanager | grep "nvidia-fabricmanager.service failed"
+if [ "$?" == "1" ]; then
+	echo "Found failed nvidia-fabricmanager.service. Updating ..."
+	yum remove -y nvidia-fabricmanager-470 nvidia-driver-470
+	yum install -y cuda-drivers-fabricmanager-470
+	systemctl daemon-reload
+	systemctl restart nvidia-fabricmanager
+	systemctl status nvidia-fabricmanager 
+else
+	echo "nvidia-fabricmanager.service is helthy. Skipping update."
+fi
+echo ""
+

--- a/Container-Root/eks/deployment/nvidia-drivers/cuda-drivers-fabricmanager-daemonset.yaml
+++ b/Container-Root/eks/deployment/nvidia-drivers/cuda-drivers-fabricmanager-daemonset.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cuda-drivers-fabricmanager
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: "cuda-drivers-fabricmanager"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: "cuda-drivers-fabricmanager"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: "cuda-drivers-fabricmanager"
+      name: "gpu-efa-metrics"
+    spec:
+      hostPID: true
+      hostNetwork: true
+      nodeSelector:
+        beta.kubernetes.io/instance-type: "p4d.24xlarge"
+        #processor: gpu
+      initContainers:
+      - name: "installer"
+        image: "ubuntu:20.04"
+        #command: ["bash", "-c", "while true; do date; sleep 10; done"]
+        command: ["nsenter", "--target", "1", "--mount", "--uts", "--ipc", "--net", "--pid", "--","bash", "-c", "echo IyEvYmluL2Jhc2gKCmVjaG8gIiIKZWNobyAidj09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09diIiCmVjaG8gIkNoZWNraW5nIGZvciBmYWlsZWQgbnZpZGlhIGZhYnJpY21hbmFnZXIgc2VydmljZSAuLi4iCnN5c3RlbWN0bCBzdGF0dXMgbnZpZGlhLWZhYnJpY21hbmFnZXIgfCBncmVwICJudmlkaWEtZmFicmljbWFuYWdlci5zZXJ2aWNlIGZhaWxlZCIKaWYgWyAiJD8iID09ICIxIiBdOyB0aGVuCgllY2hvICJGb3VuZCBmYWlsZWQgbnZpZGlhLWZhYnJpY21hbmFnZXIuc2VydmljZS4gVXBkYXRpbmcgLi4uIgoJeXVtIHJlbW92ZSAteSBudmlkaWEtZmFicmljbWFuYWdlci00NzAgbnZpZGlhLWRyaXZlci00NzAKCXl1bSBpbnN0YWxsIC15IGN1ZGEtZHJpdmVycy1mYWJyaWNtYW5hZ2VyLTQ3MAoJc3lzdGVtY3RsIGRhZW1vbi1yZWxvYWQKCXN5c3RlbWN0bCByZXN0YXJ0IG52aWRpYS1mYWJyaWNtYW5hZ2VyCglzeXN0ZW1jdGwgc3RhdHVzIG52aWRpYS1mYWJyaWNtYW5hZ2VyIAplbHNlCgllY2hvICJudmlkaWEtZmFicmljbWFuYWdlci5zZXJ2aWNlIGlzIGhlbHRoeS4gU2tpcHBpbmcgdXBkYXRlLiIKZmkKZWNobyAiIgoK | base64 -d > /tmp/cuda-drivers-fabricmanager-470-setup.sh; chmod +x /tmp/cuda-drivers-fabricmanager-470-setup.sh; /tmp/cuda-drivers-fabricmanager-470-setup.sh"]
+        securityContext:
+          privileged: true
+          runAsNonRoot: false
+          runAsUser: 0
+      containers:
+      - name: "heartbeat"
+        image: "ubuntu:20.04"
+        command: ["bash", "-c", "while true; do echo Hardware Accelerator Monitor pod is alive on $(date); sleep 60; done"]
+

--- a/Container-Root/eks/deployment/torch-elastic/config/samples/REAME.md
+++ b/Container-Root/eks/deployment/torch-elastic/config/samples/REAME.md
@@ -1,0 +1,19 @@
+# Torch-elastic samples
+
+The torch-elastic example here uses the a Kubernetes elasticjob manifest to demonstrate distributed training of resnet18 on a small imagenet dataset. 
+
+The public container torchelastic/examples:0.2.0 includes a fixed version of pytorch, cuda drivers, and nccl libraries. These must be compatible with the version of CUDA and NCCL running on the Kubernetes nodes where the job workers are spawned. The version of these drivers on your nodes depends on the AMI that was used to provision them.
+
+If your imagenet example does not work out of the box, it is possible that your nodes do not have the correct drivers. There are two options to consider:
+
+1. Recommended for production: Build a custom AMI and use it to create a new cluster, or a new node group in your existing cluster.
+The following sampl open source repository contains packer scripts for building a cusom EKS AMI:
+[https://github.com/aws-samples/aws-efa-nccl-baseami-pipeline](https://github.com/aws-samples/aws-efa-nccl-baseami-pipeline)
+This repo also contains a Dockerfile which shows how to build a corresponding container image with matching drivers.
+In addition the AMI and Docker image contain drivers to enable AWS Elastic Fabric Adapter on supported instance types (p3dn.24xlarge and p4d.24xlarge) and a setup to enable GPU metrics.
+Your custom Docker image will need to be pushed to a registry such as ECR where the Kubernetes cluster will be able to pull it from.
+
+2. Acceptable for development: Apply a privileged daemonset to install proper drivers on your existing EKS nodes.
+An example daemonset which installs NVIDIA CUDA drivers and FabricManager 470 on Amazon Linux 2 (AL2) nodes is provided in the [deployments/nvidia-drivers](/Container-Root/eks/deployment/nvidia-drivers) folder of this repo. This is approach may be acceptable for use in a development environment, however it should never be used in production due to the fact that it requires privileged pods, which circumvent the security constraints of your Kubernetes cluster.
+
+

--- a/Container-Root/eks/deployment/torch-elastic/config/samples/imagenet-efa.yaml
+++ b/Container-Root/eks/deployment/torch-elastic/config/samples/imagenet-efa.yaml
@@ -1,0 +1,61 @@
+apiVersion: elastic.pytorch.org/v1alpha1
+kind: ElasticJob
+metadata:
+  name: imagenet
+  #namespace: elastic-job
+spec:
+  # Use "etcd-service:2379" if you already applied etcd.yaml
+  rdzvEndpoint: etcd-service:2379
+  minReplicas: 1
+  maxReplicas: 128
+  replicaSpecs:
+    Worker:
+      replicas: 2
+      restartPolicy: ExitCode
+      template:
+        apiVersion: v1
+        kind: Pod
+        spec:
+          nodeSelector:
+            #beta.kubernetes.io/instance-type: p3dn.24xlarge
+            beta.kubernetes.io/instance-type: p4d.24xlarge
+            #beta.kubernetes.io/instance-type: g4dn.metal
+          containers:
+            - name: elasticjob-worker
+              image: xxxxxxxxxxxxx.dkr.ecr.us-west-2.amazonaws.com/imagenet-efa:master-20211001
+              imagePullPolicy: Always
+              env:
+                - name: NCCL_DEBUG
+                  value: INFO
+                - name: NCCL_ALGO
+                  value: Ring
+                - name: FI_PROVIDER
+                  value: efa
+                - name: FI_EFA_USE_DEVICE_RDMA
+                  value: "1"
+                - name: RDMAV_FORK_SAFE
+                  value: "1"
+              command: ["python3", "-m", "torch.distributed.run"] 
+              args:
+                - "--nproc_per_node=8"
+                - "/workspace/elastic/examples/imagenet/main.py"
+                - "--arch=resnet18"
+                - "--epochs=20"
+                - "--batch-size=32"
+                # number of data loader workers (NOT trainers)
+                # zero means load the data on the same process as the trainer
+                # this is set so that the container does not OOM since
+                # pytorch data loaders use shm
+                - "--workers=0"
+                - "/workspace/data/tiny-imagenet-200"
+              resources:
+                limits:
+                  nvidia.com/gpu: 8
+                  hugepages-2Mi: 5120Mi
+                  vpc.amazonaws.com/efa: 4
+                  memory: 80000Mi
+                requests:
+                  nvidia.com/gpu: 8
+                  hugepages-2Mi: 5120Mi
+                  vpc.amazonaws.com/efa: 4
+                  memory: 80000Mi

--- a/Container-Root/eks/eks-create.sh
+++ b/Container-Root/eks/eks-create.sh
@@ -2,71 +2,90 @@
 
 source ./eks.conf
 
-# Create EKS Cluster with initial nodegroup to run kube-system pods
-echo ""
-date
-echo "Creating cluster ${CLUSTER_NAME} ..."
-CMD="eksctl create cluster --name ${CLUSTER_NAME} --region ${CLUSTER_REGION} --version ${CLUSTER_K8S_VERSION} \
---zones "${CLUSTER_ZONES}" --vpc-cidr ${CLUSTER_VPC_CIDR} ${CLUSTER_OPTIONS}"
-echo "${CMD}"
-if [ "${DRY_RUN}" == "" ]; then
-	${CMD}
+if [ "$CONFIG" == "conf" ]; then
+
+	# Create EKS Cluster with initial nodegroup to run kube-system pods
+	echo ""
+	date
+	echo "Creating cluster ${CLUSTER_NAME} ..."
+	CMD="eksctl create cluster --name ${CLUSTER_NAME} --region ${CLUSTER_REGION} --version ${CLUSTER_K8S_VERSION} \
+	--zones "${CLUSTER_ZONES}" --vpc-cidr ${CLUSTER_VPC_CIDR} ${CLUSTER_OPTIONS}"
+	echo "${CMD}"
+	if [ "${DRY_RUN}" == "" ]; then
+		${CMD}
+	fi
+
+	# Create CPU nodegroups
+	echo ""
+	echo "Creating CPU nodegroups in cluster ${CLUSTER_NAME} ..."
+	export nodegroup_opts="${CPU_NODEGROUP_OPTIONS}"
+	for index in ${!CPU_NODEGROUP_INSTANCE_TYPES[@]}
+	do
+		export instance_type=${CPU_NODEGROUP_INSTANCE_TYPES[$index]}
+		export nodegroup_name=$(echo $instance_type | sed -e 's/\./-/g')
+		nodegroup/eks-nodegroup-create.sh
+	done
+
+	# Create GPU nodegroups
+	echo ""
+	echo "Creating GPU nodegroups in cluster ${CLUSTER_NAME} ..."
+	export nodegroup_opts="${GPU_NODEGROUP_OPTIONS}"
+	for index in ${!GPU_NODEGROUP_INSTANCE_TYPES[@]}
+	do
+		export instance_type=${GPU_NODEGROUP_INSTANCE_TYPES[$index]}
+		export nodegroup_name=$(echo $instance_type | sed -e 's/\./-/g')
+		nodegroup/eks-nodegroup-create.sh
+	done
+
+	# Create ASIC nodegroups
+	echo ""
+	echo "Creating ASIC nodegroups in cluster ${CLUSTER_NAME} ..."
+	export nodegroup_opts="${ASIC_NODEGROUP_OPTIONS}"
+	for index in ${!ASIC_NODEGROUP_INSTANCE_TYPES[@]}
+	do
+		export instance_type=${ASIC_NODEGROUP_INSTANCE_TYPES[$index]}
+		export nodegroup_name=$(echo $instance_type | sed -e 's/\./-/g')
+		nodegroup/eks-nodegroup-create.sh
+	done
+
+	# Create Fargate Profiles
+	echo ""
+	echo "Creating Fargate Profiles in cluster ${CLUSTER_NAME} ..."
+	for index in ${!SERVERLESS_FARGET_PROFILE_NAMES}
+	do
+		export fargateprofile_name=${SERVERLESS_TARGET_PROFILE_NAME[$index]}
+		fargateprofile/eks-fargateprofile-create.sh
+	done
+
+	# Scale cluster as specified
+	./eks-scale.sh
+
+	# Optionally deploy cluster autoscaler
+	if [ "$CLUSTER_AUTOSCALER_DEPLOY" == "true" ]; then
+		pushd deployment/cluster-autoscaler
+		./deploy-cluster-autoscaler.sh
+		popd
+	fi
+
+	# Done creating EKS Cluster
+	echo ""
+	date
+	echo "Done creating cluster ${CLUSTER_NAME}"
+	echo ""
+
+elif [ "$CONFIG" == "yaml" ]; then
+	echo ""
+	echo "Creating cluster using eks.yaml ..."
+	CMD="eksctl create cluster -f ${EKS_YAML}"
+        echo "${CMD}"
+        if [ "${DRY_RUN}" == "" ]; then
+                ${CMD}
+        fi
+	echo ""
+	echo "Done creating cluster using ${EKS_YAML}"
+	echo ""
+else
+	echo ""
+	echo "Unrecognized CONFIG type $CONFIG. Please specify CONFIG=conf or CONFIG=yaml in eks.conf"
+	echo ""
 fi
-
-# Create CPU nodegroups
-echo ""
-echo "Creating CPU nodegroups in cluster ${CLUSTER_NAME} ..."
-export nodegroup_opts="${CPU_NODEGROUP_OPTIONS}"
-for index in ${!CPU_NODEGROUP_INSTANCE_TYPES[@]}
-do
-	export instance_type=${CPU_NODEGROUP_INSTANCE_TYPES[$index]}
-	export nodegroup_name=$(echo $instance_type | sed -e 's/\./-/g')
-	nodegroup/eks-nodegroup-create.sh
-done
-
-# Create GPU nodegroups
-echo ""
-echo "Creating GPU nodegroups in cluster ${CLUSTER_NAME} ..."
-export nodegroup_opts="${GPU_NODEGROUP_OPTIONS}"
-for index in ${!GPU_NODEGROUP_INSTANCE_TYPES[@]}
-do
-	export instance_type=${GPU_NODEGROUP_INSTANCE_TYPES[$index]}
-	export nodegroup_name=$(echo $instance_type | sed -e 's/\./-/g')
-	nodegroup/eks-nodegroup-create.sh
-done
-
-# Create ASIC nodegroups
-echo ""
-echo "Creating ASIC nodegroups in cluster ${CLUSTER_NAME} ..."
-export nodegroup_opts="${ASIC_NODEGROUP_OPTIONS}"
-for index in ${!ASIC_NODEGROUP_INSTANCE_TYPES[@]}
-do
-	export instance_type=${ASIC_NODEGROUP_INSTANCE_TYPES[$index]}
-	export nodegroup_name=$(echo $instance_type | sed -e 's/\./-/g')
-	nodegroup/eks-nodegroup-create.sh
-done
-
-# Create Fargate Profiles
-echo ""
-echo "Creating Fargate Profiles in cluster ${CLUSTER_NAME} ..."
-for index in ${!SERVERLESS_FARGET_PROFILE_NAMES}
-do
-	export fargateprofile_name=${SERVERLESS_TARGET_PROFILE_NAME[$index]}
-	fargateprofile/eks-fargateprofile-create.sh
-done
-
-# Scale cluster as specified
-./eks-scale.sh
-
-# Optionally deploy cluster autoscaler
-if [ "$CLUSTER_AUTOSCALER_DEPLOY" == "true" ]; then
-	pushd deployment/cluster-autoscaler
-	./deploy-cluster-autoscaler.sh
-	popd
-fi
-
-# Done creating EKS Cluster
-echo ""
-date
-echo "Done creating cluster ${CLUSTER_NAME}"
-echo ""

--- a/Container-Root/eks/eks-delete.sh
+++ b/Container-Root/eks/eks-delete.sh
@@ -2,10 +2,24 @@
 
 source ./eks.conf
 
-echo ""
-echo "Deleting cluster ${CLUSTER_NAME} ..."
+if [ "$CONFIG" == "conf" ]; then
 
-CMD="eksctl delete cluster --name ${CLUSTER_NAME}"
+	echo ""
+	echo "Deleting cluster ${CLUSTER_NAME} ..."
+
+	CMD="eksctl delete cluster --name ${CLUSTER_NAME}"
+elif [ "$CONFIG" == "yaml" ]; then
+	echo ""
+	echo "Deleting cluster using ${EKS_YAML} ..."
+	
+	CMD="eksctl delete cluster -f ${EKS_YAML}"
+else
+	echo ""
+	echo "Unrecognized CONFIG type $CONFIG"
+	echo "Please specify CONFIG=conf or CONFIG=yaml in eks.conf"
+	echo ""
+	exit 1
+fi
 
 echo ${CMD}
 if [ "${DRY_RUN}" == "" ]; then

--- a/Container-Root/eks/eks-list.sh
+++ b/Container-Root/eks/eks-list.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+source ./eks.conf
+
+echo ""
+echo "List of EKS clusters ..."
+
+echo ""
+CMD="eksctl get cluster"
+echo "${CMD}"
+if [ "${DRY_RUN}" == "" ]; then
+    ${CMD}
+fi
+

--- a/Container-Root/eks/eks.conf
+++ b/Container-Root/eks/eks.conf
@@ -8,45 +8,57 @@ else
     unset DRY_RUN
 fi
 
+# CONFIG - configuration type for EKS, CONFIG=conf(default)|yaml
+# Set CONFIG=yaml and edit eks.yaml to use advanced cluster configuration options
+# like efaEnabled.
+# Refer to yaml file schema here: https://eksctl.io/usage/schema/
+# or examples here: https://github.com/weaveworks/eksctl/tree/main/examples
+export CONFIG=conf
+
+# EKS_YAML - path to cluster yaml manifest to use in case CONFIG=yaml
+export EKS_YAML=./eks.yaml
+
 # EKS Cluster
 export CLUSTER_NAME=do-eks
 export CLUSTER_REGION=us-east-1
 export CLUSTER_ZONES=us-east-1a,us-east-1b,us-east-1c,us-east-1d
-export CLUSTER_K8S_VERSION=1.20
+export CLUSTER_K8S_VERSION=1.21
 export CLUSTER_VPC_CIDR=172.33.0.0/16
 export CLUSTER_SYSTEM_NODEGROUP_NAME=system
 export CLUSTER_SYSTEM_NODEGROUP_INSTANCE_TYPE=c5.xlarge
 export CLUSTER_SYSTEM_NODEGROUP_OPTIONS="--node-type ${CLUSTER_SYSTEM_NODEGROUP_INSTANCE_TYPE} \
---nodes-min 1 --nodes-max 10 --nodes 1 --enable-ssm --node-private-networking \
+--nodes-min 1 --nodes-max 10 --nodes 1 --node-private-networking \
 --asg-access --external-dns-access --full-ecr-access --appmesh-access --alb-ingress-access --managed"
 # --ssh-public-key <path to keyfile>
 export CLUSTER_OPTIONS="--nodegroup-name ${CLUSTER_SYSTEM_NODEGROUP_NAME} ${CLUSTER_SYSTEM_NODEGROUP_OPTIONS}"
 export CLUSTER_AUTOSCALER_DEPLOY="false"
-export CLUSTER_AUTOSCALER_IMAGE_TAG="v1.20.0"
+export CLUSTER_AUTOSCALER_IMAGE_TAG="v1.21.0"
 
 # CPU Nodegroups
 export CPU_NODEGROUP_INSTANCE_TYPES=(c5.2xlarge c5.12xlarge)
 export CPU_NODEGROUP_SIZES=(2 0)
-export CPU_NODEGROUP_OPTIONS="--nodes-min 1 --nodes-max 10 --nodes 1 --node-volume-size 60 --node-volume-type gp3 --node-ami-family AmazonLinux2 \
+export CPU_NODEGROUP_OPTIONS="--region ${CLUSTER_REGION} --nodes-min 1 --nodes-max 10 --nodes 1 --node-volume-size 60 --node-volume-type gp3 --node-ami-family AmazonLinux2 \
 --node-private-networking --node-labels processor=cpu --asg-access --external-dns-access --full-ecr-access --alb-ingress-access \
---appmesh-access --enable-ssm --managed"
+--appmesh-access --managed"
 # --ssh-public-key <path to keyfile>
 # --spot
 
 # GPU Nodegroups
 export GPU_NODEGROUP_INSTANCE_TYPES=(g4dn.12xlarge p3dn.24xlarge p4d.24xlarge)
 export GPU_NODEGROUP_SIZES=(0 0 0)
-export GPU_NODEGROUP_OPTIONS="--nodes-min 1 --nodes-max 10 --nodes 1 --node-volume-size 60 --node-volume-type gp3 --node-ami-family AmazonLinux2 \
+export GPU_NODEGROUP_OPTIONS="--region ${CLUSTER_REGION} --nodes-min 1 --nodes-max 10 --nodes 1 --node-volume-size 60 --node-volume-type gp3 --node-ami-family AmazonLinux2 \
 --node-private-networking --node-labels processor=gpu --asg-access --external-dns-access --full-ecr-access --alb-ingress-access \
---appmesh-access --enable-ssm --managed --install-nvidia-plugin"
+--appmesh-access --managed --install-nvidia-plugin"
 # --spot
+# --node-zones us-east-1a
+# --node-ami ami-0bb0f156481e1c7f9
 
 # ASIC Nodegroups
 export ASIC_NODEGROUP_INSTANCE_TYPES=(inf1.xlarge inf1.6xlarge)
 export ASIC_NODEGROUP_SIZES=(0 0)
-export ASIC_NODEGROUP_OPTIONS="--nodes-min 1 --nodes-max 10 --nodes 1 --node-volume-size 60 --node-volume-type gp3 --node-ami-family AmazonLinux2 \
+export ASIC_NODEGROUP_OPTIONS="--region ${CLUSTER_REGION} --nodes-min 1 --nodes-max 10 --nodes 1 --node-volume-size 60 --node-volume-type gp3 --node-ami-family AmazonLinux2 \
 --node-private-networking --node-labels processor=asic --asg-access --external-dns-access --full-ecr-access --alb-ingress-access \
---appmesh-access --enable-ssm --install-neuron-plugin"
+--appmesh-access --install-neuron-plugin"
 
 # Fargate Profiles
 export SERVERLESS_FARGATE_PROFILE_NAMES=(fp1)

--- a/Container-Root/eks/eks.yaml
+++ b/Container-Root/eks/eks.yaml
@@ -1,0 +1,66 @@
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+
+metadata:
+  name: do-eks
+  version: "1.21"
+  region: us-east-1
+
+availabilityZones:
+  - us-east-1a
+  - us-east-1b
+  - us-east-1c
+  - us-east-1d
+
+iam:
+  withOIDC: true
+
+addons:
+  - name: vpc-cni
+    version: v1.9.1-eksbuild.1
+
+managedNodeGroups:
+  - name: p4d-24xlarge-efa
+    instanceType: p4d.24xlarge
+    instancePrefix: p4d-efa
+    privateNetworking: true
+    availabilityZones: ["us-east-1b"]
+    efaEnabled: true
+    minSize: 0
+    desiredCapacity: 0
+    maxSize: 10
+    volumeSize: 900
+    iam:
+      withAddonPolicies:
+        imageBuilder: true
+        autoScaler: true
+        ebs: true
+        fsx: true
+        cloudWatch: true
+  - name: p3dn-24xlarge-efa
+    instanceType: p3dn.24xlarge
+    instancePrefix: p3dn-efa
+    privateNetworking: true
+    availabilityZones: ["us-east-1b"]
+    efaEnabled: true
+    minSize: 0
+    desiredCapacity: 0
+    maxSize: 10
+    volumeSize: 900
+    iam:
+      withAddonPolicies:
+        imageBuilder: true
+        autoScaler: true
+        ebs: true
+        fsx: true
+        cloudWatch: true
+  - name: g4dn-metal-efa
+    instanceType: g4dn.metal
+    instancePrefix: g4dn-efa
+    privateNetworking: true
+    availabilityZones: ["us-east-1b"]
+    efaEnabled: true
+    minSize: 0
+    desiredCapacity: 2
+    maxSize: 10
+    volumeSize: 900

--- a/Container-Root/eks/nodegroup/eks-nodegroup-create.sh
+++ b/Container-Root/eks/nodegroup/eks-nodegroup-create.sh
@@ -1,35 +1,59 @@
 #!/bin/bash 
 
+source ../eks.conf
+
 echo ""
 
-unset err
-if [ "${CLUSTER_NAME}" == "" ]; then
-	echo "Environment variable CLUSTER_NAME must be set"
-	err="true"
-fi
 
-if [ "${nodegroup_name}" == "" ]; then
-	echo "Environment variable nodegroup_name must be set"
-	err="true"
-fi
+if [ "$CONFIG" == "conf" ]; then
 
-if [ "${instance_type}" == "" ]; then
-	echo "Environment variable instance_type must be set"
-	err="true"
-fi
+	unset err
+	if [ "${CLUSTER_NAME}" == "" ]; then
+		echo "Environment variable CLUSTER_NAME must be set"
+		err="true"
+	fi
 
-if [ "${nodegroup_opts}" == "" ]; then
-	nodegroup_opts="--nodes-min 1 --nodes-max 10 --nodes 1 --node-volume-size 60 --node-volume-type gp3 --node-ami-family AmazonLinux2 --node-private-networking --asg-access --external-dns-access --full-ecr-access --alb-ingress-access --appmesh-access --enable-ssm --managed"
-fi
+	if [ "${nodegroup_name}" == "" ]; then
+		echo "Environment variable nodegroup_name must be set"
+		err="true"
+	fi
 
-if [ "${err}" == "" ]; then
+	if [ "${instance_type}" == "" ]; then
+		echo "Environment variable instance_type must be set"
+		err="true"
+	fi
+
+	if [ "${nodegroup_opts}" == "" ]; then
+		nodegroup_opts="--nodes-min 1 --nodes-max 10 --nodes 1 --node-volume-size 60 --node-volume-type gp3 --node-ami-family AmazonLinux2 --node-private-networking --asg-access --external-dns-access --full-ecr-access --alb-ingress-access --appmesh-access --enable-ssm --managed"
+	fi
+
+	if [ "${err}" == "" ]; then
+		echo ""
+		echo "Creating nodegroup ${nodegroup_name} ..."
+		CMD="eksctl create nodegroup --cluster ${CLUSTER_NAME} --name ${nodegroup_name} --node-type $instance_type $nodegroup_opts"
+		echo "${CMD}"
+		if [ "${DRY_RUN}" == "" ]; then
+			${CMD}
+		fi
+	else
+		echo "Please correct errors and try again"
+	fi
+
+elif [ "$CONFIG" == "yaml" ]; then
+
 	echo ""
-	echo "Creating nodegroup ${nodegroup_name} ..."
-	CMD="eksctl create nodegroup --cluster ${CLUSTER_NAME} --name ${nodegroup_name} --node-type $instance_type $nodegroup_opts"
+	echo "Creating nodegroup using ${EKS_YAML} ..."
+	pushd ..
+	CMD="eksctl create nodegroup -f ${EKS_YAML}"
 	echo "${CMD}"
 	if [ "${DRY_RUN}" == "" ]; then
 		${CMD}
 	fi
+	popd
+
 else
-	echo "Please correct errors and try again"
+	echo ""
+	echo "Unrecognized CONFIG type $CONFIG"
+	echo "Please specify CONFIG=conf or CONFIG=yaml in eks.conf"
+	echo ""
 fi

--- a/Container-Root/eks/nodegroup/eks-nodegroup-list.sh
+++ b/Container-Root/eks/nodegroup/eks-nodegroup-list.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+echo ""
+
+function usage() {
+	echo ""
+	echo "Usage: "
+	echo "   $0 [CLUSTER_NAME]"
+	echo ""
+}
+
+if [ "$1" != "" ]; then
+	CLUSTER_NAME="$1"
+fi
+
+unset err
+if [ "${CLUSTER_NAME}" == "" ]; then
+	echo "Environment variable CLUSTER_NAME must be set"
+	echo "or CLUSTER_NAME must be passed as argument"
+	err="true"
+fi
+
+if [ "${err}" == "" ]; then
+	echo ""
+	echo "Listing nodegroups for cluster ${CLUSTER_NAME} ..."
+	CMD="eksctl get nodegroup --cluster ${CLUSTER_NAME}"
+	echo "${CMD}"
+	if [ "${DRY_RUN}" == "" ]; then
+		${CMD}
+	fi
+else
+	echo "Please correct errors and try again"
+	usage
+fi
+

--- a/Container-Root/eks/ops/README.md
+++ b/Container-Root/eks/ops/README.md
@@ -1,0 +1,36 @@
+# Kubernetes Ops
+
+This folder contains frequently used Kubernetes commands scripted for convenience and productivity.
+Many of the scripts accept arguments. 
+The script name is indicative of the arguments and the order in which they are expected.
+
+Example:
+```
+./pod-exec-ns-cmd.sh <pod_unique_prefix> <namespace> <command>
+```
+
+When specifying a pod name it is not necessary to specify the entire name, it is sufficient to provide the beginning of the name as long as that makes the pod unique. 
+
+Example:
+```
+./pods-list.sh
+
+NAME                        READY   STATUS    RESTARTS   AGE
+fsx-app                     1/1     Running   0          107m
+simnet-mpi-launcher-22zkt   1/1     Running   0          6m59s
+simnet-mpi-worker-0         1/1     Running   0          6m59s
+simnet-mpi-worker-1         1/1     Running   0          6m59s
+
+./pod-exec.sh fs
+[root@fsx-app /]#
+```
+Another common naming pattern is the command variation indicated by the suffix. 
+A -watch sufix indicates that the command will be executed periodically and monitored until interrupted with Ctl-C.
+A -list suffix indicates that the command will be executed only one time.
+
+Example:
+```
+./pods-list.sh
+vs
+./pods-watch.sh
+```

--- a/Container-Root/eks/ops/deployments-list.sh
+++ b/Container-Root/eks/ops/deployments-list.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+kubectl get deployments "$@"

--- a/Container-Root/eks/ops/deployments-watch.sh
+++ b/Container-Root/eks/ops/deployments-watch.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+watch kubectl get deployment "$@"

--- a/Container-Root/eks/ops/hpa-list.sh
+++ b/Container-Root/eks/ops/hpa-list.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Horizontal Pod Autoscalers
+kubectl get hpa "$@"
+

--- a/Container-Root/eks/ops/hpa-watch.sh
+++ b/Container-Root/eks/ops/hpa-watch.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Horizontal Pod Autoscalers
+watch kubectl get hpa "$@"
+

--- a/Container-Root/eks/ops/ingress-list.sh
+++ b/Container-Root/eks/ops/ingress-list.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+kubectl get ingress "$@"
+

--- a/Container-Root/eks/ops/ingress-watch.sh
+++ b/Container-Root/eks/ops/ingress-watch.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+watch kubectl get ingress "$@"
+

--- a/Container-Root/eks/ops/nodes-list.sh
+++ b/Container-Root/eks/ops/nodes-list.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+kubectl get nodes "$@"

--- a/Container-Root/eks/ops/nodes-types-list.sh
+++ b/Container-Root/eks/ops/nodes-types-list.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+kubectl get nodes -o yaml "$@" | grep instance-type | grep node | grep -v f:
+

--- a/Container-Root/eks/ops/nodes-types-watch.sh
+++ b/Container-Root/eks/ops/nodes-types-watch.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+watch kubectl get nodes -o yaml "$@" | grep instance-type | grep node | grep -v f:
+

--- a/Container-Root/eks/ops/nodes-watch.sh
+++ b/Container-Root/eks/ops/nodes-watch.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+watch kubectl get nodes "$@"

--- a/Container-Root/eks/ops/pod-delete-ns.sh
+++ b/Container-Root/eks/ops/pod-delete-ns.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+kubectl -n $2 delete pod $(kubectl -n $2 get pods | grep $1 | cut -d ' ' -f 1) 
+

--- a/Container-Root/eks/ops/pod-delete.sh
+++ b/Container-Root/eks/ops/pod-delete.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+kubectl delete pod $(kubectl get pods | grep $1 | cut -d ' ' -f 1) 
+

--- a/Container-Root/eks/ops/pod-exec-ns-cmd.sh
+++ b/Container-Root/eks/ops/pod-exec-ns-cmd.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+kubectl -n $2 exec -it $(kubectl -n $2 get pods | grep $1 | cut -d ' ' -f 1) -- "${@:3}"
+

--- a/Container-Root/eks/ops/pod-exec-ns.sh
+++ b/Container-Root/eks/ops/pod-exec-ns.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+kubectl -n $2 exec -it $(kubectl -n $2 get pods | grep $1 | cut -d ' ' -f 1) -- bash
+

--- a/Container-Root/eks/ops/pod-exec.sh
+++ b/Container-Root/eks/ops/pod-exec.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+kubectl exec -it $(kubectl get pods | grep $1 | cut -d ' ' -f 1) -- bash
+

--- a/Container-Root/eks/ops/pod-logs-ns.sh
+++ b/Container-Root/eks/ops/pod-logs-ns.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+kubectl -n $1 logs -f $(kubectl -n $1 get pods | grep $2 | cut -d ' ' -f 1)
+

--- a/Container-Root/eks/ops/pod-logs.sh
+++ b/Container-Root/eks/ops/pod-logs.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+kubectl logs -f $(kubectl get pods | grep $1 | cut -d ' ' -f 1)
+

--- a/Container-Root/eks/ops/pods-list.sh
+++ b/Container-Root/eks/ops/pods-list.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+kubectl get pods "$@"

--- a/Container-Root/eks/ops/pods-logs.sh
+++ b/Container-Root/eks/ops/pods-logs.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+kubetail "$@"
+

--- a/Container-Root/eks/ops/pods-watch.sh
+++ b/Container-Root/eks/ops/pods-watch.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+watch kubectl get pods -o wide "$@"
+

--- a/Container-Root/eks/ops/services-list.sh
+++ b/Container-Root/eks/ops/services-list.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+kubectl get services "$@"

--- a/Container-Root/eks/ops/services-watch.sh
+++ b/Container-Root/eks/ops/services-watch.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+watch kubectl get services "$@"
+

--- a/Container-Root/eks/ops/setup/install-eksctl.sh
+++ b/Container-Root/eks/ops/setup/install-eksctl.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-curl --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
+curl --location "https://github.com/weaveworks/eksctl/releases/download/v0.66.0/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
+#curl --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
 mv /tmp/eksctl /usr/local/bin
 eksctl version
 

--- a/Container-Root/eks/ops/setup/install-kubeps1.sh
+++ b/Container-Root/eks/ops/setup/install-kubeps1.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 
-curl -o ~/kube-ps1.sh https://github.com/jonmosco/kube-ps1/raw/master/kube-ps1.sh
+curl -L -o ~/kube-ps1.sh https://github.com/jonmosco/kube-ps1/raw/master/kube-ps1.sh
 
 cat << EOF >> ~/.bashrc
 alias ll='ls -alh --color=auto'
@@ -12,10 +12,11 @@ alias kctl='kubectl'
 alias kc='kubectx'
 alias kn='kubens'
 alias kt='kubetail'
+alias ks='kubectl node-shell'
 
 if [ -f ~/.kubeon ]; then
         source ~/kube-ps1.sh
-        PS1='[\u@\h \W $(kube_ps1)]\$ '
+        PS1='[\u@\h \W \$(kube_ps1)]\$ '
 fi
 EOF
 

--- a/Container-Root/eks/ops/setup/install-kubeshell.sh
+++ b/Container-Root/eks/ops/setup/install-kubeshell.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+curl -LO https://github.com/kvaps/kubectl-node-shell/raw/master/kubectl-node_shell
+chmod +x ./kubectl-node_shell
+mv ./kubectl-node_shell /usr/local/bin/kubectl-node_shell
+

--- a/Container-Root/setup.sh
+++ b/Container-Root/setup.sh
@@ -12,7 +12,7 @@ if [ -d /etc/apt ]; then
 fi
 
 # Install basic tools
-apt update && apt install -y curl jq vim less unzip git
+apt update && apt install -y curl jq vim nano less unzip git
 
 # Install aws cli
 ./eks/ops/setup/install-aws-cli.sh
@@ -31,3 +31,7 @@ apt update && apt install -y curl jq vim less unzip git
 
 # Install kubetail
 ./eks/ops/setup/install-kubetail.sh
+
+# Install kubeshell
+./eks/ops/setup/install-kubeshell.sh
+

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The Do framework strives to simplify DevOps and MLOps tasks by automating comple
 
 ## Configure
 All necessary configuration items are centralized in two configuration files. The [`.env`](.env) file in the project's root contains all project-specific items and is used when building and running the project container. The [`wd/conf/eks.conf`](wd/conf/eks.conf) file contains all EKS specific configuration items and is used when running the action scripts to create, scale, or delete your EKS cluster. Heterogeneous clusters are supported. In `eks.conf` you can specify the list of nodegroups to be added to the cluster and at what scale. AWS Credentials can be configured at the instance level through an instance role or injected into the container that runs aws-do-eks using volume or secrets mounting. To configure credentials, run aws configure. Credentials you configure on the host will be mounted into the aws-do-eks container according to the VOL_MAP setting in `.env`.
+Alternatively to [`eks.conf`](wd/conf/eks.conf) you may use a cluster manifest file [`wd/conf/eks.yaml`](wd/conf/eks.yaml). To use the manifest file instead of `eks.conf`, set the [`CONFIG` variable in eks.conf](/wd/conf/eks.conf#L16) to `yaml` instead of `conf`. The advantage of using a manifest file for defining the cluster is that it supports advanced options, which are not available through `eksctl`. For example, enabling of EFA networking is only supported via the manifest file. All supported options in the manifest are documented in the [`eks.yaml` schema](https://eksctl.io/usage/schema/).
 
 ## Build
 This project follows the [Depend on Docker](https://github.com/iankoulski/depend-on-docker) template to build a container including all needed tools and utilities for creation and management of your EKS clusters. Please execute the [`./build.sh`](./build.sh) script to create the `aws-do-eks` container image. If desired, the image name or registry address can be modified in the project configuration file [`.env`](.env).
@@ -30,6 +31,28 @@ To set the sizes of your cluster node groups, update the [`eks.conf`](wd/conf/ek
 
 ## EKS Delete
 To decomission your cluster and remove all AWS resources associated with it, execute the [`./eks-delete.sh`](Container-Root/eks/eks-delete.sh) script. This is a destructive operation. If there is anything in your cluster that you need saved, please persist it outside of the cluster VPC before executing this script.
+
+## Shell customiazations
+When you open a shell into a running `aws-do-eks` container via `./exec.sh`, you will be able to execute `kubectl`, `aws`, and `eksctl` commands. There are other tools and shell customizations that are installed in the container for convenience.
+
+### Tools and customizations
+* [kubectx](https://github.com/ahmetb/kubectx) - show or set current Kubernetes context
+* [kubens](https://github.com/ahmetb/kubectx) - show or set current namespace
+* [kubetail](https://github.com/johanhaleby/kubetail/master/kubetail) - tail the logs of pods that have a name matching a specified pattern
+* [kubectl-node-shell](https://github.com/kvaps/kubectl-node-shell) - open an interactive shell into a kubernetes node using a privileged mode (Do not use in production)
+* [kubeps1](https://github.com/jonmosco/kube-ps1) - customize shell prompt with cluster info 
+
+### Aliases
+```
+ll='ls -alh --color=auto'
+k=kubectl
+kc=kubectx
+kn=kubens
+kt=kubetail
+ks=kube-shell
+kon=kubeon
+koff=kubeoff
+```
 
 ## Other scripts
 
@@ -99,4 +122,5 @@ This library is licensed under the MIT-0 License. See the [LICENSE](LICENSE) fil
 * [Amazon Elastic Kubernetes Service (EKS)](https://aws.amazon.com/eks)
 * [AWS Fargate](https://aws.amazon.com/fargate)
 * [eksctl](https://docs.aws.amazon.com/eks/latest/userguide/eksctl.html)
+* [eksctl yaml schema](https://eksctl.io/usage/schema/)
 * [Depend on Docker Project](https://github.com/iankoulski/depend-on-docker)

--- a/wd/conf/eks-ami-example.yaml
+++ b/wd/conf/eks-ami-example.yaml
@@ -1,0 +1,102 @@
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+
+metadata:
+  name: do-eks
+  version: "1.21"
+  region: us-east-1
+
+availabilityZones:
+  - us-east-1a
+  - us-east-1b
+  - us-east-1c
+  - us-east-1d
+
+iam:
+  withOIDC: true
+
+addons:
+  - name: vpc-cni
+    version: v1.9.1-eksbuild.1
+
+managedNodeGroups:
+  - name: p4d-24xlarge-efa
+    instanceType: p4d.24xlarge
+    instancePrefix: p4d-efa
+    privateNetworking: true
+    availabilityZones: ["us-east-1b"]
+    efaEnabled: true
+    minSize: 0
+    desiredCapacity: 2
+    maxSize: 10
+    volumeSize: 900
+    labels: { processor: gpu }
+    iam:
+      withAddonPolicies:
+        imageBuilder: true
+        autoScaler: true
+        ebs: true
+        fsx: true
+        cloudWatch: true
+  - name: p4d-24xlarge-efa-ami
+    instanceType: p4d.24xlarge
+    ami: ami-09fa73a7999845e86
+    overrideBootstrapCommand: |
+            #!/bin/bash
+            set -ex
+            B64_CLUSTER_CA=xxxxxxxxxxxxxxxxxxxx==
+            API_SERVER_URL=https://xxxxxxxxxxxxxx.gr7.us-east-1.eks.amazonaws.com
+            K8S_CLUSTER_DNS_IP=xx.xx.xx.xx
+            /etc/eks/bootstrap.sh do-eks --kubelet-extra-args '--node-labels=eks.amazonaws.com/sourceLaunchTemplateVersion=1,alpha.eksctl.io/cluster-name=do-eks,alpha.eksctl.io/nodegroup-name=p4d-24xlarge-efa,eks.amazonaws.com/nodegroup-image=ami-010133250fdb58a8a,eks.amazonaws.com/capacityType=ON_DEMAND,eks.amazonaws.com/nodegroup=p4d-24xlarge-efa,eks.amazonaws.com/sourceLaunchTemplateId=lt-0d4abd1293bb69933 --max-pods=250' --b64-cluster-ca $B64_CLUSTER_CA --apiserver-endpoint $API_SERVER_URL --dns-cluster-ip $K8S_CLUSTER_DNS_IP --use-max-pods false
+    instancePrefix: p4d-efa
+    privateNetworking: true
+    availabilityZones: ["us-east-1b"]
+    efaEnabled: true
+    minSize: 0
+    desiredCapacity: 0
+    maxSize: 10
+    volumeSize: 900
+    labels: { processor: gpu, ami: custom, amiId: ami-0d06c725c487449e4 }
+    iam:
+      withAddonPolicies:
+        imageBuilder: true
+        autoScaler: true
+        ebs: true
+        fsx: true
+        cloudWatch: true
+  - name: p3dn-24xlarge-efa
+    instanceType: p3dn.24xlarge
+    instancePrefix: p3dn-efa
+    privateNetworking: true
+    availabilityZones: ["us-east-1b"]
+    efaEnabled: true
+    minSize: 0
+    desiredCapacity: 2
+    maxSize: 10
+    volumeSize: 900
+    labels: { processor: gpu }
+    iam:
+      withAddonPolicies:
+        imageBuilder: true
+        autoScaler: true
+        ebs: true
+        fsx: true
+        cloudWatch: true
+  - name: g4dn-metal-efa
+    instanceType: g4dn.metal
+    instancePrefix: g4dn-efa
+    privateNetworking: true
+    availabilityZones: ["us-east-1b"]
+    efaEnabled: true
+    minSize: 0
+    desiredCapacity: 2
+    maxSize: 10
+    volumeSize: 900
+    labels: { processor: gpu }
+    iam:
+      withAddonPolicies:
+        imageBuilder: true
+        autoScaler: true
+        ebs: true
+        fsx: true
+        cloudWatch: true

--- a/wd/conf/eks.conf
+++ b/wd/conf/eks.conf
@@ -8,45 +8,57 @@ else
     unset DRY_RUN
 fi
 
+# CONFIG - configuration type for EKS, CONFIG=conf(default)|yaml
+# Set CONFIG=yaml and edit eks.yaml to use advanced cluster configuration options
+# like efaEnabled.
+# Refer to yaml file schema here: https://eksctl.io/usage/schema/
+# or examples here: https://github.com/weaveworks/eksctl/tree/main/examples
+export CONFIG=conf
+
+# EKS_YAML - path to cluster yaml manifest to use in case CONFIG=yaml
+export EKS_YAML=./eks.yaml
+
 # EKS Cluster
 export CLUSTER_NAME=do-eks
 export CLUSTER_REGION=us-east-1
 export CLUSTER_ZONES=us-east-1a,us-east-1b,us-east-1c,us-east-1d
-export CLUSTER_K8S_VERSION=1.20
+export CLUSTER_K8S_VERSION=1.21
 export CLUSTER_VPC_CIDR=172.33.0.0/16
 export CLUSTER_SYSTEM_NODEGROUP_NAME=system
 export CLUSTER_SYSTEM_NODEGROUP_INSTANCE_TYPE=c5.xlarge
 export CLUSTER_SYSTEM_NODEGROUP_OPTIONS="--node-type ${CLUSTER_SYSTEM_NODEGROUP_INSTANCE_TYPE} \
---nodes-min 1 --nodes-max 10 --nodes 1 --enable-ssm --node-private-networking \
+--nodes-min 1 --nodes-max 10 --nodes 1 --node-private-networking \
 --asg-access --external-dns-access --full-ecr-access --appmesh-access --alb-ingress-access --managed"
 # --ssh-public-key <path to keyfile>
 export CLUSTER_OPTIONS="--nodegroup-name ${CLUSTER_SYSTEM_NODEGROUP_NAME} ${CLUSTER_SYSTEM_NODEGROUP_OPTIONS}"
 export CLUSTER_AUTOSCALER_DEPLOY="false"
-export CLUSTER_AUTOSCALER_IMAGE_TAG="v1.20.0"
+export CLUSTER_AUTOSCALER_IMAGE_TAG="v1.21.0"
 
 # CPU Nodegroups
 export CPU_NODEGROUP_INSTANCE_TYPES=(c5.2xlarge c5.12xlarge)
 export CPU_NODEGROUP_SIZES=(2 0)
-export CPU_NODEGROUP_OPTIONS="--nodes-min 1 --nodes-max 10 --nodes 1 --node-volume-size 60 --node-volume-type gp3 --node-ami-family AmazonLinux2 \
+export CPU_NODEGROUP_OPTIONS="--region ${CLUSTER_REGION} --nodes-min 1 --nodes-max 10 --nodes 1 --node-volume-size 60 --node-volume-type gp3 --node-ami-family AmazonLinux2 \
 --node-private-networking --node-labels processor=cpu --asg-access --external-dns-access --full-ecr-access --alb-ingress-access \
---appmesh-access --enable-ssm --managed"
+--appmesh-access --managed"
 # --ssh-public-key <path to keyfile>
 # --spot
 
 # GPU Nodegroups
 export GPU_NODEGROUP_INSTANCE_TYPES=(g4dn.12xlarge p3dn.24xlarge p4d.24xlarge)
 export GPU_NODEGROUP_SIZES=(0 0 0)
-export GPU_NODEGROUP_OPTIONS="--nodes-min 1 --nodes-max 10 --nodes 1 --node-volume-size 60 --node-volume-type gp3 --node-ami-family AmazonLinux2 \
+export GPU_NODEGROUP_OPTIONS="--region ${CLUSTER_REGION} --nodes-min 1 --nodes-max 10 --nodes 1 --node-volume-size 60 --node-volume-type gp3 --node-ami-family AmazonLinux2 \
 --node-private-networking --node-labels processor=gpu --asg-access --external-dns-access --full-ecr-access --alb-ingress-access \
---appmesh-access --enable-ssm --managed --install-nvidia-plugin"
+--appmesh-access --managed --install-nvidia-plugin"
 # --spot
+# --node-zones us-east-1a
+# --node-ami ami-0bb0f156481e1c7f9
 
 # ASIC Nodegroups
 export ASIC_NODEGROUP_INSTANCE_TYPES=(inf1.xlarge inf1.6xlarge)
 export ASIC_NODEGROUP_SIZES=(0 0)
-export ASIC_NODEGROUP_OPTIONS="--nodes-min 1 --nodes-max 10 --nodes 1 --node-volume-size 60 --node-volume-type gp3 --node-ami-family AmazonLinux2 \
+export ASIC_NODEGROUP_OPTIONS="--region ${CLUSTER_REGION} --nodes-min 1 --nodes-max 10 --nodes 1 --node-volume-size 60 --node-volume-type gp3 --node-ami-family AmazonLinux2 \
 --node-private-networking --node-labels processor=asic --asg-access --external-dns-access --full-ecr-access --alb-ingress-access \
---appmesh-access --enable-ssm --install-neuron-plugin"
+--appmesh-access --install-neuron-plugin"
 
 # Fargate Profiles
 export SERVERLESS_FARGATE_PROFILE_NAMES=(fp1)

--- a/wd/conf/eks.yaml
+++ b/wd/conf/eks.yaml
@@ -1,0 +1,66 @@
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+
+metadata:
+  name: do-eks
+  version: "1.21"
+  region: us-east-1
+
+availabilityZones:
+  - us-east-1a
+  - us-east-1b
+  - us-east-1c
+  - us-east-1d
+
+iam:
+  withOIDC: true
+
+addons:
+  - name: vpc-cni
+    version: v1.9.1-eksbuild.1
+
+managedNodeGroups:
+  - name: p4d-24xlarge-efa
+    instanceType: p4d.24xlarge
+    instancePrefix: p4d-efa
+    privateNetworking: true
+    availabilityZones: ["us-east-1b"]
+    efaEnabled: true
+    minSize: 0
+    desiredCapacity: 0
+    maxSize: 10
+    volumeSize: 900
+    iam:
+      withAddonPolicies:
+        imageBuilder: true
+        autoScaler: true
+        ebs: true
+        fsx: true
+        cloudWatch: true
+  - name: p3dn-24xlarge-efa
+    instanceType: p3dn.24xlarge
+    instancePrefix: p3dn-efa
+    privateNetworking: true
+    availabilityZones: ["us-east-1b"]
+    efaEnabled: true
+    minSize: 0
+    desiredCapacity: 0
+    maxSize: 10
+    volumeSize: 900
+    iam:
+      withAddonPolicies:
+        imageBuilder: true
+        autoScaler: true
+        ebs: true
+        fsx: true
+        cloudWatch: true
+  - name: g4dn-metal-efa
+    instanceType: g4dn.metal
+    instancePrefix: g4dn-efa
+    privateNetworking: true
+    availabilityZones: ["us-east-1b"]
+    efaEnabled: true
+    minSize: 0
+    desiredCapacity: 2
+    maxSize: 10
+    volumeSize: 900


### PR DESCRIPTION
* Upgrade to Kubernetes 1.21, add support for single AZ nodegroups
* Add example for use of --node-ami option
* Add support for advanced cluster configuration through eks.yaml
* Add shell customization using kubeps1
* Add efa support via eks.yaml
* Mount .kube folder from host
* Add efa tests to efa-device-plugin
* Add mpijob-test
* Add gpu-efa-metrics
* Add kubectl node-shell
* Reorganize and document ops scripts
* Add nvidia-drivers daemonset
* Add kube-ops-view
* Add imagenet efa example
* Streamline FSx deployment
* Update documentation