### PR TITLE
Update eks-kubeflow.yaml

### DIFF
--- a/Container-Root/eks/eks-kubeflow.yaml
+++ b/Container-Root/eks/eks-kubeflow.yaml
@@ -4,7 +4,7 @@ kind: ClusterConfig
 metadata:
   name: eks-kubeflow
   region: us-west-2
-  version: "1.21"
+  version: "1.22"
 iam:
   withOIDC: true
 managedNodeGroups:


### PR DESCRIPTION
EKS version 1.21 update

*Issue #, if available:* EKS version 1.21 is not supported anymore, leading to error being generated when this current yaml is used. See supported eks versions here: https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html

*Description of changes:* Changing version from 1.21 to 1.22


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
