### PR TITLE
Add error handling for node name lookup in nvtop script

### DIFF
--- a/Container-Root/eks/ops/nvtop.sh
+++ b/Container-Root/eks/ops/nvtop.sh
@@ -17,6 +17,11 @@ if [ "$1" == "" ]; then
 else
         node_name=$1
         full_node_name=$(kubectl get nodes | grep $node_name | head -n 1 | cut -d ' ' -f 1)
+        # check if node exists
+        if [ -z "$full_node_name" ]; then
+                echo "ERROR: no node matches '$node_name'" >&2
+	        exit 1
+	fi
         short_node_name=$(echo $full_node_name | cut -d '.' -f 1)
         pod_name=nvtop-${short_node_name:-4}	
 	# check if pod exists


### PR DESCRIPTION
*Issue #, if available:*
N/A

-------------
*Description of changes:*
Added input validation to `Container-Root/hyperpod/ops/eks/nvtop.sh` to handle the case where the provided node name does not match any node in the cluster.

Previously, if kubectl get nodes | grep <node_name> returned no results, the script would proceed with an empty full_node_name, producing an invalid pod name (nvtop-) and empty nodeSelector, resulting in Kubernetes validation errors (RFC 1123 violations). This fix adds an early-exit check after the node lookup. 

If no matching node is found, the script now prints a clear error message to stderr and exits with status 1 instead of attempting to create a malformed pod.
```
	full_node_name=$(kubectl get nodes | grep $node_name | head -n 1 | cut -d ' ' -f 1)
        # new
	if [ -z "$full_node_name" ]; then
		echo "ERROR: no node matches '$node_name'" >&2
		exit 1
	fi
```
-------------
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.