### PR TITLE
Add check to see if kubetail is already installed

### DIFF
--- a/Container-Root/eks/ops/setup/install-kubetail.sh
+++ b/Container-Root/eks/ops/setup/install-kubetail.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
+set -e
 
+# check to see if kubetail is installed
+if command -v kubetail >/dev/null 2>&1; then
+  echo "kubetail is already installed at $(command -v kubetail)"
+  exit 0
+fi
 
+# install kubetail if not already installed
 curl -o /tmp/kubetail https://raw.githubusercontent.com/johanhaleby/kubetail/master/kubetail
 chmod +x /tmp/kubetail
 mv /tmp/kubetail /usr/local/bin/kubetail
-


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
There is an install script in the workshop to install kubetail. However, kubetail is already installed in another script. This PR adds a check to verify kubetail installation. If already installed, it shows a message that it's already installed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
