### PR TITLE
Add disaggregation calculator (agg vs disagg decision tool) under inference/agentic-ai

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/disagg-calculator/.gitignore
+++ b/Container-Root/eks/deployment/inference/agentic-ai/disagg-calculator/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/Container-Root/eks/deployment/inference/agentic-ai/disagg-calculator/README.md
+++ b/Container-Root/eks/deployment/inference/agentic-ai/disagg-calculator/README.md
@@ -1,0 +1,91 @@
+# Disaggregation Calculator — agg vs. disagg decision tool for LLM serving
+
+Author: Anton Alexander
+
+An architecture-first calculator that answers a single question for any model on any GPU:
+**should I serve it aggregated (prefill + decode on one worker) or disaggregated (prefill and decode
+split across workers, KV cache moved over the network)?** It derives the answer from the model's real
+architecture (`config.json`), the GPU's HBM and bandwidth, and your workload (input/output token lengths,
+SLO), then reports the memory fit, the predicted TTFT/ITL/throughput, the $/Mtok, and the verdict.
+
+It is the planning companion to the [NVIDIA Nemotron 3 Ultra 550B](../nemotron/ultra) deployment in this
+project: use the calculator to pick a topology, then deploy it with the `agg` / `disagg` manifests there.
+
+To stay aligned with the principles of the [do-framework](https://bit.ly/do-framework), this tool is pure
+Python standard library (no install) plus two static HTML pages (no server) — clone and run.
+
+## What's here
+
+```
+disagg-calculator/
+  analyze/
+    calc.py          # the engine — architecture-aware agg/disagg math + verdict (CLI + importable)
+    calibration.py   # PREDICT → MEASURE → DELTA loop; corrects the math toward live-measured numbers
+  results/
+    calibration/
+      ledger.jsonl   # append-only measured datapoints the calculator calibrates against (seeded on p5en)
+  web/
+    index.html       # interactive calculator (pick a model + GPU + workload → verdict), runs in-browser
+    calculator.html  # the same engine as a single-purpose page (shareable link)
+  docs/
+    PRODUCTION-GUIDE.md  # when to disaggregate vs. scale aggregated replicas — rules of thumb + worked cases
+    METHODOLOGY.md       # the math, the physics assumptions, and how the calibration loop refines them
+```
+
+> **Engine = two files.** `calc.py` lazily imports `calibration.py`; without it the calculator silently
+> falls back to the uncalibrated HBM-roofline numbers (e.g. decode ITL ~4 ms instead of the live-measured
+> ~80 ms). Always ship/run them together. `ledger.jsonl` is the measured data they calibrate against.
+
+## Prerequisites
+
+- Python 3.9+ (standard library only — nothing to `pip install`).
+- For the web pages: any modern browser. No server, no build step.
+
+## Run (CLI)
+
+From the `aws-do-eks` shell (or any shell with Python 3):
+
+```bash
+cd /eks/deployment/inference/agentic-ai/disagg-calculator/analyze
+
+# Self-test (proves the engine + calibration are wired correctly):
+python3 calc.py --selftest
+
+# Score a model from its HuggingFace config.json on a given GPU + workload:
+python3 calc.py --config /path/to/config.json --gpu p5en --isl 8192 --osl 1024 --tp 8 --pp 1
+```
+
+The output JSON includes the memory fit (weights + KV vs. HBM), the predicted timings
+(`prefill_compute`, `kv_transfer`, `decode_step_ITL`), the $/Mtok for agg vs. disagg, and the verdict
+(`aggregate` / `disaggregate` / `no-op`) with the reasoning.
+
+## Run (web)
+
+Open `web/index.html` in a browser (or serve the `web/` folder statically). Pick a model preset (or paste a
+`config.json`), choose the GPU and workload, and read the verdict. `web/calculator.html` is the same engine
+as a single shareable page. The browser pages mirror `analyze/calc.py` exactly — a parity harness in the
+source project asserts they agree on a model × workload grid, so the link you share computes what the CLI does.
+
+## How it stays honest (calibration)
+
+First-order math over-predicts throughput and under-predicts latency for hybrid (Mamba + attention) models —
+a naive HBM roofline says "fast" while the live system is decode-latency-bound. `calibration.py` records what
+we **predicted**, ingests what we **measured** on real GPUs (the seed datapoint is Nemotron-3 Ultra 550B on
+p5en/H200), computes the **delta**, and derives a per-(family, metric) **correction factor**. As more live
+runs land in `results/calibration/ledger.jsonl`, the corrections converge and the calculator gets more
+accurate **without changing the physics**. See [docs/METHODOLOGY.md](docs/METHODOLOGY.md).
+
+## When to use which verdict
+
+See [docs/PRODUCTION-GUIDE.md](docs/PRODUCTION-GUIDE.md) for the rules of thumb. In short:
+
+- **Aggregated replicas** when: short-context chat, prefill cheap relative to decode, cost/throughput-bound,
+  loose-to-moderate ITL SLO. At the 1P:1D floor, disaggregation buys little but costs ≥2× the GPUs.
+- **Disaggregate** when: long input contexts (RAG / agents / code), prefill-heavy, tight TPOT/ITL SLO, and you
+  can right-size the prefill : decode pool ratio (asymmetric scaling via independent replica counts).
+
+## References
+
+- [do-framework](https://bit.ly/do-framework) · [aws-do-eks](https://bit.ly/do-eks)
+- Companion deployment: [Nemotron 3 Ultra 550B](../nemotron/ultra) (agg + disagg manifests)
+- [NVIDIA Dynamo](https://github.com/ai-dynamo/dynamo) · [NIXL](https://github.com/ai-dynamo/nixl)

--- a/Container-Root/eks/deployment/inference/agentic-ai/disagg-calculator/README.md
+++ b/Container-Root/eks/deployment/inference/agentic-ai/disagg-calculator/README.md
@@ -2,6 +2,14 @@
 
 Author: Anton Alexander
 
+> **Disclaimer.** This calculator is provided **free of charge, as a utility** to help quickly
+> **estimate** and plan model-serving topologies. It produces **first-order estimates and guidance only**.
+> AWS and the authors make **no representation, warranty, or guarantee** — express or implied — about model
+> performance, throughput, latency, cost, or fitness for any purpose, and **accept no liability** for any
+> outcome arising from its use. Actual measured results will differ from the calculated numbers. Always
+> validate on your own hardware with your own workload before making deployment or purchasing decisions.
+> The calculator is provided **"AS IS"** without support obligation.
+
 An architecture-first calculator that answers a single question for any model on any GPU:
 **should I serve it aggregated (prefill + decode on one worker) or disaggregated (prefill and decode
 split across workers, KV cache moved over the network)?** It derives the answer from the model's real
@@ -28,7 +36,7 @@ disagg-calculator/
     index.html       # interactive calculator (pick a model + GPU + workload → verdict), runs in-browser
     calculator.html  # the same engine as a single-purpose page (shareable link)
   docs/
-    PRODUCTION-GUIDE.md  # when to disaggregate vs. scale aggregated replicas — rules of thumb + worked cases
+    DEPLOYMENT-GUIDE.md  # when to disaggregate vs. scale aggregated replicas — rules of thumb + worked cases
     METHODOLOGY.md       # the math, the physics assumptions, and how the calibration loop refines them
 ```
 
@@ -77,7 +85,7 @@ accurate **without changing the physics**. See [docs/METHODOLOGY.md](docs/METHOD
 
 ## When to use which verdict
 
-See [docs/PRODUCTION-GUIDE.md](docs/PRODUCTION-GUIDE.md) for the rules of thumb. In short:
+See [docs/DEPLOYMENT-GUIDE.md](docs/DEPLOYMENT-GUIDE.md) for the rules of thumb. In short:
 
 - **Aggregated replicas** when: short-context chat, prefill cheap relative to decode, cost/throughput-bound,
   loose-to-moderate ITL SLO. At the 1P:1D floor, disaggregation buys little but costs ≥2× the GPUs.

--- a/Container-Root/eks/deployment/inference/agentic-ai/disagg-calculator/analyze/calc.py
+++ b/Container-Root/eks/deployment/inference/agentic-ai/disagg-calculator/analyze/calc.py
@@ -3,6 +3,10 @@
 Author: Anton Alexander
 Source: github.com/dmvevents/dynamo-disagg-optimizer · live: dmvevents.github.io/dynamo-disagg-optimizer/calculator.html
 
+DISCLAIMER: Provided free, as a utility, for estimation and planning ONLY. AWS and the authors make no
+warranty or guarantee of model performance and accept no liability for results obtained from its use.
+Actual measured numbers will differ; validate on your own hardware before deployment decisions. AS IS.
+
 calc.py — analytical "should I disaggregate?" model for ANY (instance, model, workload).
 
 Given an AWS instance type + model characteristics + workload SLO, estimate — WITHOUT running GPUs —
@@ -12,7 +16,7 @@ time, roofline regime). Outputs a JSON the HTML page + chart renderer + visual-L
 
 Grounded in first-order rooflines and CALIBRATED to this org's measured Nemotron-3 Ultra 550B / p5en
 numbers (see CAL/calibration below). It is an ESTIMATOR (order-of-magnitude + direction), not a simulator —
-it tells you where to spend GPU hours, then the live sweep (driver/sweep.py) confirms.
+it tells you where to spend GPU hours, then the live sweep (a live GPU sweep) confirms.
 
 Pure-Python stdlib only, so it runs headless and the HTML pages reimplement the SAME formulas in JS
 (kept honest by tests/parity.py, which asserts calc.py == calculator.html == index.html on a grid).
@@ -496,12 +500,12 @@ def _caveats(model: dict, itl_cal: dict | None = None) -> list[str]:
     if itl_cal is not None:
         if itl_cal.get("calibration_n", 0) >= 1:
             out.append("decode ITL is calibrated to a MEASURED anchor (n=%d, %s); raw roofline shown alongside. "
-                       "Single-point calibration — re-confirm off the bf16/H200/TP8 anchor with driver/sweep.py."
+                       "Single-point calibration — re-confirm off the bf16/H200/TP8 anchor with a live GPU sweep."
                        % (itl_cal["calibration_n"], itl_cal.get("calibration_confidence", "")))
         else:
             out.append("decode ITL is the RAW HBM roofline (no measured anchor for this family) — likely OPTIMISTIC "
                        "for eager-mode / low-concurrency; treat as a lower bound on latency.")
-    out.append("Estimator only: directionally accurate, calibrated to 550B/p5en (n=1). Confirm the verdict with driver/sweep.py on real GPUs.")
+    out.append("Estimator only: directionally accurate, calibrated to 550B/p5en (n=1). Confirm the verdict with a live GPU sweep on real GPUs.")
     return out
 
 

--- a/Container-Root/eks/deployment/inference/agentic-ai/disagg-calculator/analyze/calc.py
+++ b/Container-Root/eks/deployment/inference/agentic-ai/disagg-calculator/analyze/calc.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """
 Author: Anton Alexander
-Source: github.com/dmvevents/dynamo-disagg-optimizer · live: dmvevents.github.io/dynamo-disagg-optimizer/calculator.html
 
 DISCLAIMER: Provided free, as a utility, for estimation and planning ONLY. AWS and the authors make no
 warranty or guarantee of model performance and accept no liability for results obtained from its use.

--- a/Container-Root/eks/deployment/inference/agentic-ai/disagg-calculator/analyze/calc.py
+++ b/Container-Root/eks/deployment/inference/agentic-ai/disagg-calculator/analyze/calc.py
@@ -1,0 +1,658 @@
+#!/usr/bin/env python3
+"""
+Author: Anton Alexander
+Source: github.com/dmvevents/dynamo-disagg-optimizer · live: dmvevents.github.io/dynamo-disagg-optimizer/calculator.html
+
+calc.py — analytical "should I disaggregate?" model for ANY (instance, model, workload).
+
+Given an AWS instance type + model characteristics + workload SLO, estimate — WITHOUT running GPUs —
+whether PD disaggregation, aggregation, or hybrid is favored, plus the underlying quantities that drive
+the decision (KV size per request, KV-transfer time over the fabric, prefill compute time, decode-step
+time, roofline regime). Outputs a JSON the HTML page + chart renderer + visual-LLM verdict all consume.
+
+Grounded in first-order rooflines and CALIBRATED to this org's measured Nemotron-3 Ultra 550B / p5en
+numbers (see CAL/calibration below). It is an ESTIMATOR (order-of-magnitude + direction), not a simulator —
+it tells you where to spend GPU hours, then the live sweep (driver/sweep.py) confirms.
+
+Pure-Python stdlib only, so it runs headless and the HTML pages reimplement the SAME formulas in JS
+(kept honest by tests/parity.py, which asserts calc.py == calculator.html == index.html on a grid).
+
+=========================================================================================================
+PHYSICS NOTES (what this models, and the four things a naive roofline gets wrong — fixed here 2026-06-15
+after a deep audit; see docs/AUDIT-2026-06-15-deep-review.md):
+
+  1. HYBRID-MAMBA KV. Attention KV scales with the number of ATTENTION layers, not all layers. A Mamba-2
+     hybrid (nemotron_h: 12 attention of 108 layers) also carries a CONSTANT recurrent SSM state per
+     request (mamba_num_heads*mamba_head_dim*d_state, float32) that does NOT grow with ISL. Both are
+     modeled. Using full-GQA-over-all-layers (the old bug) overstates attention KV ~39x AND misses the
+     ~415 MB Mamba state entirely; the two errors coincidentally cancelled near ISL=512.
+
+  2. QUANTIZED PREFILL. Peak FLOP/s doubles for fp8 and quadruples for fp4 vs fp16 on Hopper/Blackwell
+     tensor cores. Using fp16 peak for an fp8 model overstates prefill time ~2x -> overstates interference
+     -> biases the verdict toward 'disaggregate'. We scale peak by a dtype multiplier.
+
+  3. ATTENTION O(ISL^2). Prefill compute is 2*P*ISL (linear, GEMM-dominated) PLUS the quadratic attention
+     term 4*ISL^2*hidden per attention layer, which dominates at long context. Both are modeled.
+
+  4. DECODE KV READ. Per-token decode reads the weights AND the whole KV cache accumulated so far, so ITL
+     grows with context. We add the KV-read term (context-dependent), on top of the calibration correction.
+
+  Plus: chunked-prefill recovery (modern vLLM/Dynamo chunk prefill, removing most interference), an SLO
+  gate (the verdict now respects TTFT/TPOT budgets), named (not magic) decision constants, and the
+  calibration ledger is WIRED IN (measured ITL used when an anchor exists, with the raw roofline + the
+  correction factor shown transparently).
+=========================================================================================================
+"""
+from __future__ import annotations
+import argparse, json, math, os, sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+try:
+    import calibration as _calib            # wired in: measured-first ITL + transparent correction factors
+except Exception:
+    _calib = None
+
+# ---- hardware catalog (AWS GPU instances) : per-GPU HBM BW + CAPACITY, FP16 dense TFLOP/s, GPUs, EFA ----
+# hbm_GBs   = HBM BANDWIDTH per GPU (GB/s) — drives the decode roofline (memory-bound per-token read).
+# hbm_cap_GB= HBM CAPACITY per GPU (GB)    — drives the memory-FIT math (does the model+KV fit? how much KV budget?).
+# fp16_TFLOPs = DENSE fp16/bf16 tensor-core peak. fp8 ~2x, fp4 ~4x (see DTYPE_PEAK_MULT).
+INSTANCES = {
+    # name:           gpus, hbm_GBs(bw), hbm_cap_GB, fp16_TFLOPs, efa_nics, efa_Gbps, nvlink_GBs
+    "p5.48xlarge":    {"gpu": "H100", "gpus": 8, "hbm_GBs": 3350, "hbm_cap_GB": 80,  "fp16_TFLOPs": 989,  "efa_nics": 32, "efa_Gbps": 100, "nvlink_GBs": 900},
+    "p5en.48xlarge":  {"gpu": "H200", "gpus": 8, "hbm_GBs": 4800, "hbm_cap_GB": 141, "fp16_TFLOPs": 989,  "efa_nics": 16, "efa_Gbps": 200, "nvlink_GBs": 900},
+    "p6-b200.48xlarge":{"gpu": "B200","gpus": 8, "hbm_GBs": 8000, "hbm_cap_GB": 180, "fp16_TFLOPs": 2250, "efa_nics": 8,  "efa_Gbps": 400, "nvlink_GBs": 1800},
+    "p4d.24xlarge":   {"gpu": "A100", "gpus": 8, "hbm_GBs": 2039, "hbm_cap_GB": 40,  "fp16_TFLOPs": 312,  "efa_nics": 4,  "efa_Gbps": 100, "nvlink_GBs": 600},
+}
+
+# ---- calibration constants (measured anchors so the estimator tracks reality, not just theory) ----
+# Nemotron-3 Ultra 550B on p5en, TP8/PP1, NIXL LIBFABRIC: per-transfer KV ~5.3 GB/s uncontended,
+# decode ITL ~82 ms @ low concurrency. The fabric-efficiency factor folds in SRD ramp + descriptor
+# granularity (a strided pull achieves ~5.3 GB/s, not the 16*25=400 GB/s line rate).
+CAL = {"kv_transfer_efficiency": 0.0095,  # end-to-end KV-hop efficiency vs aggregate line rate. Calibrated to the
+       # MEASURED disagg TTFT penalty: 486MB shipped in ~127.5ms = 3.81 GB/s = 0.0095×400GB/s (p5en). This is the
+       # END-TO-END penalty (fabric + NIXL handshake + serialization), NOT raw fabric streaming BW — matches
+       # optimizer.py disagg_ttft_penalty_ms=127 (disagg c1 TTFT 238 vs agg 110). Was 0.013 (predicted only 93ms,
+       # under the measured 127ms); corrected 2026-06-17 per the research-skeptic audit.
+       "mfu_prefill": 0.45,              # prefill compute MFU (compute-bound, batched)
+       "mbu_decode": 0.65}               # decode HBM-bandwidth utilization roofline ceiling (memory-bound, per-token)
+
+# ---- DECISION CONSTANTS (named, not magic — audit finding N5). These are HEURISTIC weights tuned so the
+# one MEASURED anchor (550B/p5en, agg wins ~2.1x => verdict 'hybrid'/'aggregate') lands correctly. They are
+# NOT derived from a paper and are calibrated to n=1; outputs are flagged accordingly until the ledger grows. ----
+DECISION = {
+    "interference_scale": 4.0,   # interference = 1 - exp(-imbalance/scale); larger scale => softer rise
+    "toll_scale": 4.0,           # toll = 1/(1 + transfer_frac*scale); larger scale => transfer punished harder
+    "threshold_disagg": 0.55,    # fav >= this => disaggregate
+    "threshold_hybrid": 0.30,    # fav >= this (and < disagg) => hybrid
+    # chunked-prefill removes most prefill->decode interference on modern vLLM/Dynamo. 0 = naive (prefill
+    # stalls ALL co-batched decodes, the old model); 1 = perfectly chunked. 0.7 matches pd_pool_scaling.py.
+    "chunked_prefill_recovery": 0.7,
+}
+
+# ---- quantization peak-FLOP multipliers (audit finding N3). Tensor-core dense peak relative to fp16/bf16. ----
+DTYPE_PEAK_MULT = {"fp16": 1.0, "bf16": 1.0, "fp8": 2.0, "int8": 2.0, "fp4": 4.0}
+DTYPE_BYTES = {"fp16": 2, "bf16": 2, "fp8": 1, "fp4": 0.5, "int8": 1}
+
+# ---- NetKV (arXiv:2606.03910) network-tier placement: where prefill<->decode sit in the DC topology
+# sets the EFFECTIVE KV-transfer bandwidth. The KV cache must cross this link before decode starts, so it
+# enters the TTFT budget. tier downgrades (NVLink -> ToR -> spine -> cross-pod core) shrink B_eff, and
+# NetKV Prop.1 shows network-oblivious placement is arbitrarily suboptimal as context (ISL) grows.
+# NOTE: default 'fabric_aggregate' uses the calibrated per-transfer reality (our measured ~5.3 GB/s, which
+# is itself a same-rack/tier1 regime). Pass an explicit net_tier for cross-rack/cross-pod placement studies. ----
+TIERS = {
+    "tier0_nvlink":    {"GBs": 450.0, "desc": "same node / NVLink (no fabric hop — effectively aggregation)"},
+    "tier1_tor":       {"GBs": 12.5,  "desc": "same rack / ToR (1 EFA hop) — our measured ~5.3 GB/s/transfer regime"},
+    "tier2_spine":     {"GBs": 6.25,  "desc": "cross-rack / spine (2 hops)"},
+    "tier3_core":      {"GBs": 3.125, "desc": "cross-pod / core (3 hops) — NetKV's worst tier"},
+    "fabric_aggregate":{"GBs": None,  "desc": "instance EFA line-rate * calibrated efficiency (default; ~tier1 same-rack)"},
+}
+
+
+def _n_attn_layers(model: dict) -> int:
+    """Number of ATTENTION layers (the only ones with a growing KV cache). For a hybrid-Mamba model this is
+    far fewer than n_layers (nemotron_h: 12 of 108). Resolution order:
+      1. explicit n_attn_layers
+      2. count 'attention' in layers_block_type (the HF config.json field)
+      3. dense/MoE default = all layers have attention
+    A hybrid-mamba family with NO attention-layer info falls back to n_layers and emits a caveat (handled
+    in _caveats) — better to over-count visibly than to silently guess a split."""
+    if model.get("n_attn_layers") is not None:
+        return int(model["n_attn_layers"])
+    lbt = model.get("layers_block_type")
+    if isinstance(lbt, (list, tuple)) and lbt:
+        return sum(1 for t in lbt if str(t).lower() == "attention")
+    return int(model["n_layers"])
+
+
+def mamba_state_bytes(model: dict) -> float:
+    """Constant Mamba-2 recurrent (SSM) + conv state per REQUEST — does NOT grow with ISL. Disagg must ship
+    this alongside the attention KV. nemotron_h: mamba_num_heads*mamba_head_dim*d_state float32 per mamba
+    layer (~8.4 MB) * 48 layers ~= 415 MB. Zero for non-Mamba families."""
+    if model.get("family") != "hybrid-mamba":
+        return 0.0
+    n_mamba = model.get("n_mamba_layers")
+    if n_mamba is None:
+        lbt = model.get("layers_block_type")
+        if isinstance(lbt, (list, tuple)) and lbt:
+            n_mamba = sum(1 for t in lbt if str(t).lower() in ("mamba", "mamba2"))
+        else:
+            n_mamba = 0
+    mh = model.get("mamba_num_heads", 0)
+    mhd = model.get("mamba_head_dim", 0)
+    d_state = model.get("mamba_d_state", 128)
+    d_conv = model.get("mamba_d_conv", 4)
+    cache_db = DTYPE_BYTES.get(model.get("mamba_cache_dtype", "fp32"), 4)
+    if mh and mhd and n_mamba:
+        ssm = mh * mhd * d_state * cache_db
+        conv = mh * mhd * max(d_conv - 1, 1) * cache_db   # causal depthwise conv caches kernel-1 timesteps
+        return (ssm + conv) * n_mamba
+    return 0.0
+
+
+def kv_bytes_per_token(hidden, n_kv_heads, n_heads, n_layers, head_dim, kv_dtype, model=None) -> float:
+    """ATTENTION KV cache bytes per token (the part that GROWS with context). GQA-aware:
+    2 (K,V) * n_kv_heads * head_dim * n_ATTENTION_layers * dtype_bytes.
+
+    Branches:
+      - MLA (DeepSeek-V3): cache is the COMPRESSED latent, (kv_lora_rank + qk_rope_head_dim) per token per
+        layer — NOT full K/V heads. Naive GQA on MLA overstates KV ~10x.
+      - hybrid-Mamba: only the ATTENTION layers hold a growing KV cache (the Mamba layers carry a constant
+        recurrent state handled by mamba_state_bytes()). Using n_layers here was the old bug (overstated ~39x).
+    """
+    model = model or {}
+    if model.get("kv_compression") == "mla":
+        lora = model.get("kv_lora_rank", 512)
+        rope = model.get("qk_rope_head_dim", 64)
+        return (lora + rope) * n_layers * DTYPE_BYTES.get(kv_dtype, 2)
+    if head_dim is None:
+        head_dim = hidden / max(n_heads, 1)
+    attn_layers = _n_attn_layers(model) if model else n_layers
+    return 2 * n_kv_heads * head_dim * attn_layers * DTYPE_BYTES.get(kv_dtype, 2)
+
+
+def _params(model: dict) -> tuple[float, float]:
+    """Return (params_compute_B, params_mem_B). For MoE these DIFFER: compute rooflines (prefill FLOPs,
+    decode HBM-read) scale with ACTIVE params/token; memory FIT scales with TOTAL resident params.
+    Backward-compat: a plain params_B (or dense model) sets both equal."""
+    total = model.get("params_total_B", model.get("params_B"))
+    active = model.get("params_active_B", model.get("params_B", total))
+    if total is None:
+        total = active
+    if active is None:
+        active = total
+    return float(active), float(total)
+
+
+def _itl_calibrated(decode_step_ms_roofline: float, model: dict) -> dict:
+    """Wire in the calibration ledger (audit finding N1). Returns the roofline floor, the measured-anchor
+    correction factor for this family, and the corrected ITL actually used downstream. Fully transparent:
+    the caller surfaces all three so nobody can claim the displayed ITL is a raw roofline OR a pasted anchor."""
+    fam = model.get("family", "dense")
+    factor, n, conf = 1.0, 0, "none (raw roofline — no measured anchor for this family)"
+    if _calib is not None:
+        try:
+            cf = _calib.correction_factor(fam, "itl_ms")
+            factor, n, conf = cf.get("factor", 1.0), cf.get("n", 0), cf.get("confidence", "")
+        except Exception:
+            pass
+    corrected = decode_step_ms_roofline * factor
+    return {"roofline_ms": round(decode_step_ms_roofline, 3), "correction_factor": factor,
+            "calibration_n": n, "calibration_confidence": conf, "used_ms": round(corrected, 3)}
+
+
+def analyze(inst: dict, model: dict, wl: dict) -> dict:
+    g = inst
+    tp = model.get("tp", g["gpus"])
+    pp = model.get("pp", 1)                  # pipeline-parallel stages: PP shards LAYERS → full weights spread over tp*pp GPUs
+    gpus_in_group = tp * pp                   # GPUs in one serving group (one replica). PP1 => == tp (back-compat).
+    params_active_B, params_total_B = _params(model)
+    params_B = params_active_B              # compute rooflines use ACTIVE params (MoE-correct; ==total for dense)
+    w_dtype = model.get("weight_dtype", "bf16")
+    kv_dtype = model.get("kv_dtype", w_dtype)
+
+    isl, osl = wl["isl"], wl["osl"]
+    n_attn = _n_attn_layers(model)
+
+    # --- KV size per request: ATTENTION KV (grows with ISL) + constant Mamba SSM state (if hybrid-mamba) ---
+    kv_bpt = kv_bytes_per_token(model["hidden"], model["n_kv_heads"], model["n_heads"],
+                                model["n_layers"], model.get("head_dim"), kv_dtype, model)
+    attn_kv_bytes = kv_bpt * isl
+    mamba_bytes = mamba_state_bytes(model)
+    kv_bytes_req = attn_kv_bytes + mamba_bytes       # total bytes disagg must ship prefill->decode
+    kv_MB = kv_bytes_req / 1e6
+
+    # --- KV transfer time over the fabric (disagg cost) ---
+    # NetKV: the prefill<->decode network TIER sets B_eff. Default = instance EFA line-rate * calibrated
+    # efficiency (our measured per-transfer reality); if a tier is named, use its bandwidth instead.
+    line_GBs = g["efa_nics"] * g["efa_Gbps"] / 8.0      # aggregate fabric GB/s
+    tier = wl.get("net_tier", "fabric_aggregate")
+    tier_GBs = TIERS.get(tier, {}).get("GBs")
+    if tier_GBs:
+        achieved_GBs = tier_GBs                          # NetKV tier-pinned effective bandwidth
+    else:
+        achieved_GBs = max(line_GBs * CAL["kv_transfer_efficiency"], 1.0)  # calibrated per-transfer reality
+    kv_transfer_ms = (kv_bytes_req / 1e9) / achieved_GBs * 1000.0
+
+    # --- prefill compute time (compute-bound): linear GEMM term + quadratic attention term ---
+    # linear: 2 * P_active * ISL FLOPs (the dense matmuls). quadratic: 4 * ISL^2 * hidden per ATTENTION layer
+    # (QK^T + attn*V), which dominates at long context. Mamba layers have NO quadratic term (linear in seq).
+    flops_prefill_linear = 2 * params_B * 1e9 * isl
+    flops_prefill_attn = 4.0 * (isl ** 2) * model["hidden"] * n_attn
+    flops_prefill = flops_prefill_linear + flops_prefill_attn
+    # peak FLOP/s is set by the MATMUL (compute) dtype, not the storage dtype. Default compute_dtype = weight
+    # dtype (true for native W8A8 fp8 like DeepSeek-V3), but a weight-only-quant model (W8A16/AWQ) computes in
+    # bf16 — set compute_dtype explicitly there so we don't over-credit the tensor-core peak.
+    # ARCH GATE (LIVE-CORRECTED 2026-06-19): the dtype peak multiplier only applies if the GPU has the NATIVE
+    # tensor-core instruction. fp4's 4x is BLACKWELL-only (native FP4 GEMM). On Hopper/Ampere an NVFP4 ckpt
+    # runs via Marlin W4A16 (4-bit weights, in-kernel DEQUANT to bf16, compute ≈ bf16) → effective peak ~1x,
+    # NOT 4x. (Live-proven: 550B-NVFP4 serves on H200 via Marlin at ~bf16 compute — results/nvfp4-probe/.)
+    # fp8 is native sm89+ (Hopper/Blackwell) so keeps 2x there; on A100 (sm80) it also degrades to ~1x.
+    compute_dtype = model.get("compute_dtype", w_dtype)
+    gpu = g.get("gpu", "")
+    _is_blackwell = gpu in ("B200", "B100", "GB200")
+    _is_hopper_plus = _is_blackwell or gpu in ("H100", "H200")          # sm89+ has native fp8
+    raw_mult = DTYPE_PEAK_MULT.get(compute_dtype, 1.0)
+    if compute_dtype == "fp4" and not _is_blackwell:
+        dtype_peak_mult = 1.0      # Marlin W4A16 dequant path on non-Blackwell: compute ≈ bf16
+    elif compute_dtype in ("fp8", "int8") and not _is_hopper_plus:
+        dtype_peak_mult = 1.0      # no native fp8 tensor cores pre-Hopper
+    else:
+        dtype_peak_mult = raw_mult                                     # native path: fp8 2x (Hopper+), fp4 4x (Blackwell)
+    compute_GFLOPs = g["fp16_TFLOPs"] * dtype_peak_mult * 1e3 * tp * CAL["mfu_prefill"]
+    prefill_ms = flops_prefill / (compute_GFLOPs * 1e9) * 1000.0
+
+    # --- decode per-token time (memory-bound): read ACTIVE weights + KV-cache-so-far from HBM each step ---
+    # roofline floor reads weights only; the real per-token read also includes the KV accumulated so far
+    # (grows with context). Average over the decode phase => KV at ~ isl + osl/2 tokens.
+    param_bytes = params_B * 1e9 * DTYPE_BYTES.get(w_dtype, 2)
+    avg_ctx_tokens = isl + osl / 2.0
+    kv_read_bytes = kv_bpt * avg_ctx_tokens                       # attention KV re-read each decode step (avg)
+    hbm_GBs = g["hbm_GBs"] * tp * CAL["mbu_decode"]
+    decode_step_ms_roofline = ((param_bytes + kv_read_bytes) / 1e9) / hbm_GBs * 1000.0
+    # wire in calibration: measured-anchor correction (e.g. hybrid-mamba ~18.6x for eager+conc-1) applied,
+    # with the raw roofline + factor kept visible.
+    itl_cal = _itl_calibrated(decode_step_ms_roofline, model)
+    decode_step_ms = itl_cal["used_ms"]
+
+    # --- MEMORY FIT: TOTAL resident weights vs aggregate HBM CAPACITY across the tp*pp GPUs of the serving
+    # group. Leftover after weights = KV budget = concurrency ceiling. Three states (no-fit / tight / fits).
+    # Also reports whether CUDA graphs are feasible (audit N10): a 'tight' fit needs enforce-eager; graphs
+    # need util <= 0.92. PP spans the model's LAYERS across pp nodes, so a role that doesn't fit one node
+    # (550B BF16 on 1 p5en = weights eat 97.5% of HBM) gets real KV headroom + CUDA graphs at pp>=2. ---
+    UTIL_CEILING = 0.98                                            # absolute safe gpu-memory-utilization ceiling
+    GRAPH_UTIL_CEILING = 0.92                                      # above this, CUDA-graph capture OOMs (matches feasibility.py)
+    w_bytes_per_param = DTYPE_BYTES.get(w_dtype, 2)
+    weights_GB = params_total_B * w_bytes_per_param                # e.g. 550B bf16 = 1100 GB (TOTAL; PP spreads, doesn't shrink)
+    hbm_cap_GB = g.get("hbm_cap_GB", 80)
+    total_hbm_GB = gpus_in_group * hbm_cap_GB                      # aggregate capacity across the tp*pp GPUs in the group
+    min_util_for_weights = weights_GB / max(total_hbm_GB, 1e-9)    # gpu-util just to hold the weights
+    kv_budget_GB = total_hbm_GB * UTIL_CEILING - weights_GB        # KV headroom at the max safe util
+    fits = kv_budget_GB > 0.5
+    tight = fits and min_util_for_weights > 0.90
+    fit_status = "no-fit" if not fits else ("tight" if tight else "fits")
+    graph_feasible = fits and (min_util_for_weights <= GRAPH_UTIL_CEILING)
+    min_gpus_to_fit = int(math.ceil(weights_GB / max(hbm_cap_GB * 0.85, 1e-9)))
+    # per-request KV footprint (attention KV grows to full context + the constant Mamba state)
+    kv_bytes_full_ctx = kv_bpt * (isl + osl) + mamba_bytes
+    max_kv_tokens = (kv_budget_GB * 1e9 / kv_bpt) if (fits and kv_bpt > 0) else 0.0
+    # concurrency = how many of THIS workload's requests fit in the KV budget. KV grows during decode, so
+    # average footprint ~ isl + osl/2 (audit N11). Mamba state is per-request constant overhead.
+    per_req_avg_bytes = kv_bpt * (isl + osl / 2.0) + mamba_bytes
+    concurrency_at_isl = (kv_budget_GB * 1e9 / per_req_avg_bytes) if (fits and per_req_avg_bytes > 0) else 0.0
+    per_req_maxctx_bytes = kv_bpt * model.get("max_ctx", isl + osl) + mamba_bytes
+    concurrency_at_maxctx = (kv_budget_GB * 1e9 / per_req_maxctx_bytes) if (fits and per_req_maxctx_bytes > 0) else 0.0
+
+    # --- the decision (TaiChi premise): aggregation makes one prefill burst STALL the decode stream of every
+    # co-batched request (TPOT interference); disaggregation removes that interference but pays a KV-transfer
+    # toll. Disagg wins when interference-removed >> transfer-toll-added. Chunked prefill (modern engines)
+    # reclaims most of the interference, so we discount it by chunked_prefill_recovery. ---
+    decode_phase_ms = decode_step_ms * osl
+    # (a) transfer toll: KV-transfer time as a fraction of the decode phase it unblocks. cheap => good for disagg.
+    transfer_overhead_frac = kv_transfer_ms / max(decode_phase_ms, 1e-6)
+    # (b) interference removed: a prefill burst (prefill_ms) blocks ~prefill_ms/decode_step decode steps of
+    #     other requests. Normalize against one decode step => "how many ITLs a prefill stalls". Chunked
+    #     prefill interleaves prefill chunks with decode, recovering `chunked_prefill_recovery` of it.
+    prefill_decode_imbalance = prefill_ms / max(decode_step_ms, 1e-6)
+    cpr = wl.get("chunked_prefill_recovery", DECISION["chunked_prefill_recovery"])
+    interference_raw = 1.0 - math.exp(-prefill_decode_imbalance / DECISION["interference_scale"])
+    interference = interference_raw * (1.0 - cpr)
+    toll = 1.0 / (1.0 + transfer_overhead_frac * DECISION["toll_scale"])
+    fav = toll * interference
+
+    # chunked-prefill caps interference at (1-cpr), so favorability lives on a [0, 1-cpr] axis. Rescale the
+    # thresholds onto that same axis so the verdict SHAPE is preserved (disagg stays reachable for genuinely
+    # prefill-heavy, cheap-transfer workloads) instead of becoming structurally impossible at cpr>0.45.
+    thr_disagg = DECISION["threshold_disagg"] * (1.0 - cpr)
+    thr_hybrid = DECISION["threshold_hybrid"] * (1.0 - cpr)
+    if fav >= thr_disagg:
+        verdict, why = "disaggregate", "cheap KV transfer; prefill bursts would stall many decode steps under aggregation (high TPOT-interference, even after chunked-prefill)"
+    elif fav >= thr_hybrid:
+        verdict, why = "hybrid", "non-trivial interference but transfer/imbalance moderate — TaiChi hybrid (differentiated P/D instances) likely best"
+    else:
+        verdict, why = "aggregate", "prefill is cheap relative to decode (low interference, incl. chunked-prefill) and/or KV transfer toll high — colocate"
+
+    # --- SLO gate (audit finding N2): the verdict above is latency-physics-only. Now respect the user's SLO.
+    # If shipping the KV would blow the TTFT budget, disagg is not viable regardless of favorability. If even
+    # the predicted single-stream ITL exceeds the TPOT budget, flag it (no topology fixes a too-slow model). ---
+    slo_ttft_ms = wl.get("slo_ttft_ms")
+    slo_tpot_ms = wl.get("slo_tpot_ms")
+    slo_notes = []
+    slo_viable_disagg = True
+    if slo_ttft_ms is not None:
+        # disagg's TTFT critical path = prefill + the KV hop. It's viable only if that sum fits the budget.
+        # (Was a 0.5*TTFT heuristic — refuted 2026-06-17: the physically-correct gate is the additive one,
+        # which spuriously-rejected disagg whenever transfer was 50-100% of budget even if prefill was tiny.)
+        if prefill_ms + kv_transfer_ms > slo_ttft_ms:
+            slo_viable_disagg = False
+            slo_notes.append(f"prefill+transfer {prefill_ms + kv_transfer_ms:.0f}ms exceeds TTFT budget {slo_ttft_ms:.0f}ms — disagg can't meet the TTFT SLO")
+    if slo_tpot_ms is not None and decode_step_ms > slo_tpot_ms:
+        slo_notes.append(f"predicted ITL {decode_step_ms:.0f}ms exceeds TPOT budget {slo_tpot_ms:.0f}ms (model/hardware too slow at this op-point)")
+    verdict_pre_slo = verdict
+    if verdict == "disaggregate" and not slo_viable_disagg:
+        verdict, why = "aggregate", "favorability prefers disagg, but KV transfer would breach the TTFT SLO — colocate (no transfer hop)"
+
+    # --- HELP / NO-OP / REGRESS vs aggregation (the operational question) ----------------------------------
+    # The agg/hybrid/disagg verdict above says WHICH topology; this says, per axis, whether moving from plain
+    # aggregation to disaggregation HELPS, does nothing, or REGRESSES — and by how much. Each axis is a
+    # speedup ratio = (aggregation value) / (disaggregation value), oriented so >1 = disagg is BETTER, <1 =
+    # disagg is WORSE (a regression). A ±DISAGG_BAND dead-band around 1.0 = NO-OP (within modeling noise).
+    # Grounded in the same quantities the verdict uses; the COST axis reproduces the MEASURED 550B regression
+    # (decode-dominated short chat → tiny interference → disagg pays ~2x GPUs for ~nothing → ~0.5x = regress
+    # ~2x, matching the measured agg-wins-2.1x anchor) and flips to >1 for prefill-heavy agent/RAG workloads.
+    DISAGG_BAND = 0.10                                          # ±10% around parity = NO-OP (within n=1 noise)
+
+    def _band(sp):
+        if sp >= 1.0 + DISAGG_BAND: return "helps"
+        if sp <= 1.0 - DISAGG_BAND: return "regresses"
+        return "no-op"
+
+    # (1) ITL / per-token decode latency: aggregation inflates the decode stream by the prefill interference
+    #     it couldn't hide; disagg removes it. agg_ITL = ITL*(1+interference), disagg_ITL = ITL. >1 => disagg better.
+    itl_speedup = 1.0 + interference
+    # (2) TTFT: disagg ADDS the KV hop to the first-token critical path (prefill+transfer) vs agg's prefill
+    #     alone. <1 here = disagg is WORSE on TTFT (the long-KV-ship regression the SLO gate also guards).
+    ttft_speedup = prefill_ms / max(prefill_ms + kv_transfer_ms, 1e-9)
+    # (3) COST $/Mtok at the 1P:1D floor: disagg lifts decode goodput by the interference 'uplift' (cost.py)
+    #     but spends 2x the GPUs. ratio = uplift/2 (price-independent — the $/hr cancels). uplift matches
+    #     cost.py: 1/(1-0.5*interference). <1 => disagg costs MORE per token (the 2x-GPU regression).
+    cost_uplift = 1.0 / max(1.0 - 0.5 * interference, 0.3)
+    cost_speedup = cost_uplift / 2.0
+    axes = {
+        "cost_per_token": {"speedup_disagg_over_agg": round(cost_speedup, 3), "band": _band(cost_speedup),
+                           "basis": "1P:1D floor: decode goodput uplift 1/(1-0.5*interf) vs 2x GPUs (price-independent ratio = uplift/2)"},
+        "ttft":           {"speedup_disagg_over_agg": round(ttft_speedup, 3), "band": _band(ttft_speedup),
+                           "basis": "agg prefill-only vs disagg prefill+KV-hop on the first-token critical path"},
+        "itl":            {"speedup_disagg_over_agg": round(itl_speedup, 3), "band": _band(itl_speedup),
+                           "basis": "agg decode inflated by (1+interference) co-batch stall; disagg removes it"},
+    }
+    # overall: REGRESSES if any axis regresses and none helps enough to offset; HELPS if >=1 axis helps and
+    # none regresses; else MIXED/NO-OP. Cost is the tie-breaker (the decision most teams act on).
+    bands = [a["band"] for a in axes.values()]
+    if "regresses" in bands and "helps" not in bands:
+        disagg_overall = "regresses"
+        disagg_summary = "disaggregation REGRESSES here vs aggregation — " + ", ".join(
+            f"{k} {v['speedup_disagg_over_agg']}x" for k, v in axes.items())
+    elif "helps" in bands and "regresses" not in bands:
+        disagg_overall = "helps"
+        disagg_summary = "disaggregation HELPS here vs aggregation — " + ", ".join(
+            f"{k} {v['speedup_disagg_over_agg']}x" for k, v in axes.items())
+    elif "helps" in bands and "regresses" in bands:
+        disagg_overall = "mixed"
+        disagg_summary = ("MIXED: disagg helps on " + "/".join(k for k, v in axes.items() if v["band"] == "helps")
+                          + " but regresses on " + "/".join(k for k, v in axes.items() if v["band"] == "regresses")
+                          + " — pick on your priority axis (cost vs latency)")
+    else:
+        disagg_overall = "no-op"
+        disagg_summary = "disaggregation is roughly a NO-OP here (within ±%d%% of aggregation on every axis) — the split's cost ≈ its benefit; stay aggregated for simplicity" % int(DISAGG_BAND * 100)
+
+    out = {
+        "instance": {"name": wl.get("instance_name"), **g, "line_rate_GBs": round(line_GBs, 1)},
+        "model": {**{k: model[k] for k in ("name", "n_layers", "n_heads", "n_kv_heads", "hidden", "family") if k in model},
+                  "n_attn_layers": n_attn, "params_active_B": params_active_B, "params_total_B": params_total_B},
+        "workload": {"isl": isl, "osl": osl, "tp": tp, "pp": pp, "gpus_in_group": gpus_in_group,
+                     "weight_dtype": w_dtype, "kv_dtype": kv_dtype, "chunked_prefill_recovery": cpr},
+        "kv": {"attn_bytes_per_token": round(kv_bpt, 1), "attn_MB_per_request": round(attn_kv_bytes / 1e6, 2),
+               "mamba_state_MB": round(mamba_bytes / 1e6, 1), "MB_per_request": round(kv_MB, 1)},
+        "memory_fit": {
+            "weights_GB": round(weights_GB, 1), "total_hbm_GB": round(total_hbm_GB, 1),
+            "kv_budget_GB": round(kv_budget_GB, 1), "fits_at_tp": fits, "fit_status": fit_status,
+            "graph_feasible": graph_feasible, "graph_util_ceiling": GRAPH_UTIL_CEILING,
+            "min_util_for_weights": round(min_util_for_weights, 3),
+            "min_gpus_to_fit": min_gpus_to_fit, "gpus_in_play": gpus_in_group,
+            "max_kv_tokens": int(max_kv_tokens),
+            "concurrency_at_workload": round(concurrency_at_isl, 1),
+            "concurrency_at_maxctx": round(concurrency_at_maxctx, 1),
+            "note": ("does NOT fit on %d GPUs (weights %.0fGB > %.0fGB safe HBM) — need >=%d GPUs: span nodes (pp>=2) / quantize (fp8)"
+                     % (gpus_in_group, weights_GB, total_hbm_GB * UTIL_CEILING, min_gpus_to_fit) if not fits else
+                     ("TIGHT: weights eat %.0f%% of HBM on %d GPUs — needs gpu-util>=%.2f + enforce-eager (NO CUDA graphs); "
+                      "span nodes (pp>=2, e.g. tp%d/pp2=%d GPUs) or fp8 to unlock KV headroom + graphs; "
+                      "~%d KV tokens => ~%.0f concurrent reqs at ctx=%d"
+                      % (min_util_for_weights * 100, gpus_in_group, max(min_util_for_weights + 0.01, 0.95),
+                         tp, tp * 2, int(max_kv_tokens), concurrency_at_isl, isl + osl)) if tight else
+                     "fits (CUDA graphs OK); ~%d KV tokens => ~%.0f concurrent reqs at ISL+OSL=%d"
+                     % (int(max_kv_tokens), concurrency_at_isl, isl + osl)),
+        },
+        "timings_ms": {
+            "kv_transfer": round(kv_transfer_ms, 2),
+            "prefill_compute": round(prefill_ms, 1),
+            "prefill_attn_quadratic_frac": round(flops_prefill_attn / max(flops_prefill, 1e-9), 3),
+            "decode_step_ITL": round(decode_step_ms, 2),
+            "decode_step_ITL_roofline": itl_cal["roofline_ms"],
+            "decode_phase_total": round(decode_phase_ms, 1),
+        },
+        "calibration": {
+            "itl_correction_factor": itl_cal["correction_factor"], "n": itl_cal["calibration_n"],
+            "confidence": itl_cal["calibration_confidence"],
+            "note": ("decode ITL = roofline %.2fms x measured correction %.2fx = %.1fms (family '%s')"
+                     % (itl_cal["roofline_ms"], itl_cal["correction_factor"], decode_step_ms, model.get("family", "dense"))
+                     if itl_cal["calibration_n"] else
+                     "decode ITL = raw roofline %.2fms (no measured anchor for family '%s' — directional only)"
+                     % (itl_cal["roofline_ms"], model.get("family", "dense"))),
+        },
+        "fabric": {"achieved_GBs_per_transfer": round(achieved_GBs, 2), "efficiency": CAL["kv_transfer_efficiency"],
+                   "net_tier": tier, "net_tier_desc": TIERS.get(tier, {}).get("desc", "")},
+        "decision": {
+            "verdict": verdict, "favorability": round(fav, 3), "why": why,
+            "verdict_pre_slo": verdict_pre_slo,
+            "transfer_overhead_frac": round(transfer_overhead_frac, 4),
+            "prefill_decode_imbalance": round(prefill_decode_imbalance, 1),
+            "interference": round(interference, 3), "interference_raw": round(interference_raw, 3),
+            "chunked_prefill_recovery": cpr,
+            "transfer_toll": round(toll, 3),
+            "thresholds": {"disagg": round(thr_disagg, 3), "hybrid": round(thr_hybrid, 3),
+                           "base_disagg": DECISION["threshold_disagg"], "base_hybrid": DECISION["threshold_hybrid"],
+                           "rescaled_by": round(1.0 - cpr, 3),
+                           "note": "thresholds rescaled by (1-chunked_prefill_recovery) to match the capped interference axis"},
+            "slo": {"ttft_ms": slo_ttft_ms, "tpot_ms": slo_tpot_ms, "disagg_slo_viable": slo_viable_disagg,
+                    "notes": slo_notes},
+        },
+        "disagg_vs_agg": {
+            "overall": disagg_overall, "summary": disagg_summary, "band_pct": int(DISAGG_BAND * 100),
+            "axes": axes,
+            "note": "speedup = aggregation/disaggregation per axis; >1 = disagg better, <1 = disagg REGRESSES, "
+                    "within ±%d%% = no-op. Cost axis is the price-independent 1P:1D-floor ratio." % int(DISAGG_BAND * 100),
+        },
+        "caveats": _caveats(model, itl_cal),
+    }
+    return out
+
+
+def _caveats(model: dict, itl_cal: dict | None = None) -> list[str]:
+    out = []
+    fam = model.get("family", "dense")
+    if fam == "hybrid-mamba":
+        # if we couldn't resolve an attention/mamba split, say so loudly (we fell back to all-layers)
+        if model.get("n_attn_layers") is None and not model.get("layers_block_type"):
+            out.append("hybrid-Mamba but NO attention/mamba layer split provided (n_attn_layers/layers_block_type) "
+                       "— KV computed over ALL layers (OVER-counts attention KV; add the split for accuracy).")
+        out.append("hybrid-Mamba: attention KV scales with the few attention layers; a CONSTANT Mamba SSM state "
+                   "(~hundreds of MB, ISL-independent) is shipped too. PP1 only on EFA (PP2 = open vLLM bug); "
+                   "KV pull descriptor-bound (~5.3 GB/s/transfer measured).")
+    if fam == "moe":
+        out.append("MoE: KV is standard attention (per-active-params), but expert-parallel comms add a separate axis not modeled here.")
+    if fam == "moe-mla":
+        out.append("MoE+MLA: KV is the compressed latent (kv_lora_rank+rope), far smaller than naive GQA; EP comms not modeled.")
+    if itl_cal is not None:
+        if itl_cal.get("calibration_n", 0) >= 1:
+            out.append("decode ITL is calibrated to a MEASURED anchor (n=%d, %s); raw roofline shown alongside. "
+                       "Single-point calibration — re-confirm off the bf16/H200/TP8 anchor with driver/sweep.py."
+                       % (itl_cal["calibration_n"], itl_cal.get("calibration_confidence", "")))
+        else:
+            out.append("decode ITL is the RAW HBM roofline (no measured anchor for this family) — likely OPTIMISTIC "
+                       "for eager-mode / low-concurrency; treat as a lower bound on latency.")
+    out.append("Estimator only: directionally accurate, calibrated to 550B/p5en (n=1). Confirm the verdict with driver/sweep.py on real GPUs.")
+    return out
+
+
+def _selftest() -> int:
+    # ---- Nemotron-3 Ultra 550B on p5en — REAL nemotron_h arch (from config.json) ----
+    inst = INSTANCES["p5en.48xlarge"]
+    model = {"name": "nemotron-ultra-550b", "family": "hybrid-mamba", "params_total_B": 550, "params_active_B": 55,
+             "n_layers": 108, "n_attn_layers": 12, "n_mamba_layers": 48, "n_heads": 64, "n_kv_heads": 2,
+             "hidden": 8192, "head_dim": 128, "weight_dtype": "bf16", "tp": 8, "max_ctx": 262144,
+             "mamba_num_heads": 256, "mamba_head_dim": 64, "mamba_d_state": 128, "mamba_d_conv": 4,
+             "mamba_cache_dtype": "fp32"}
+    wl = {"isl": 512, "osl": 128, "instance_name": "p5en.48xlarge"}
+    r = analyze(inst, model, wl)
+    assert r["decision"]["verdict"] in ("disaggregate", "hybrid", "aggregate"), r["decision"]
+    assert r["kv"]["MB_per_request"] > 0 and r["timings_ms"]["decode_step_ITL"] > 0
+    # hybrid-mamba KV: attention KV must be SMALL (12 layers, 2 kv heads) and the Mamba state must DOMINATE.
+    assert r["kv"]["mamba_state_MB"] > 300, r["kv"]            # ~415 MB constant SSM state
+    assert r["kv"]["attn_MB_per_request"] < 20, r["kv"]       # 12 attn layers * 2 kvheads @ ISL512 ~= 6 MB
+    # total KV should land in the ballpark of the MEASURED 486 MB/req anchor (not the old buggy 247)
+    assert 380 <= r["kv"]["MB_per_request"] <= 520, r["kv"]["MB_per_request"]
+    # calibration WIRED IN: decode ITL must be the measured-corrected value (~82ms), not the 4.4ms roofline
+    assert r["timings_ms"]["decode_step_ITL"] > 50, r["timings_ms"]
+    assert r["timings_ms"]["decode_step_ITL_roofline"] < 20, r["timings_ms"]
+    assert r["calibration"]["itl_correction_factor"] > 5, r["calibration"]
+    # memory-fit: 550B bf16 = 1100GB; tp8 p5en = 1128GB -> tight, graphs NOT feasible
+    mf = r["memory_fit"]
+    assert mf["weights_GB"] == 1100.0, mf
+    assert mf["fit_status"] == "tight" and mf["graph_feasible"] is False, mf
+    print(f"calc.py selftest PASS — 550B/p5en verdict={r['decision']['verdict']} fav={r['decision']['favorability']} "
+          f"KV={r['kv']['MB_per_request']}MB (attn {r['kv']['attn_MB_per_request']} + mamba {r['kv']['mamba_state_MB']}) "
+          f"ITL={r['timings_ms']['decode_step_ITL']}ms (roofline {r['timings_ms']['decode_step_ITL_roofline']} x{r['calibration']['itl_correction_factor']}) "
+          f"fit={mf['fit_status']} graphs={mf['graph_feasible']}")
+
+    # ---- PP-aware fit (Alex's multinode-per-role, 2026-06-18): TP8/PP2 = 16 GPUs across 2 nodes spreads the
+    # model's LAYERS, so the same 1100GB weights now sit in 2256GB aggregate HBM -> KV headroom + CUDA graphs. ----
+    r_pp2 = analyze(inst, dict(model, pp=2), {"isl": 8192, "osl": 512, "instance_name": "p5en.48xlarge"})
+    mf2 = r_pp2["memory_fit"]
+    assert mf2["total_hbm_GB"] == 2256.0, mf2                       # 16 * 141 (was 1128 at pp1)
+    assert mf2["weights_GB"] == 1100.0, mf2                         # TOTAL weights unchanged — PP spreads, doesn't shrink
+    assert mf2["gpus_in_play"] == 16, mf2
+    assert mf2["fit_status"] == "fits" and mf2["graph_feasible"] is True, mf2   # tight->fits, eager->graphs
+    assert mf2["concurrency_at_workload"] > 100, mf2               # ~2150 vs ~1 at pp1 — real headroom
+    # PP1 back-compat: the tight anchor must STILL hold with explicit pp=1
+    assert analyze(inst, dict(model, pp=1), wl)["memory_fit"]["fit_status"] == "tight", "pp1 back-compat broke"
+    print(f"calc.py selftest PASS — PP-aware fit: 550B tp8/pp2 (16 GPUs, 2 nodes) total_hbm "
+          f"{mf['total_hbm_GB']:.0f}->{mf2['total_hbm_GB']:.0f}GB, fit {mf['fit_status']}->{mf2['fit_status']}, "
+          f"graphs {mf['graph_feasible']}->{mf2['graph_feasible']}, conc {mf['concurrency_at_workload']:.0f}->{mf2['concurrency_at_workload']:.0f}")
+
+    # ---- fp8 peak multiplier (N3): an fp8 model must get ~2x prefill compute vs the same model labeled bf16 ----
+    m_bf16 = {"name": "x", "family": "dense", "params_total_B": 70, "params_active_B": 70, "n_layers": 80,
+              "n_heads": 64, "n_kv_heads": 8, "hidden": 8192, "head_dim": 128, "weight_dtype": "bf16", "tp": 8}
+    m_fp8 = {**m_bf16, "weight_dtype": "fp8"}
+    p_bf16 = analyze(inst, m_bf16, {"isl": 4096, "osl": 128, "instance_name": "p5en.48xlarge"})["timings_ms"]["prefill_compute"]
+    p_fp8 = analyze(inst, m_fp8, {"isl": 4096, "osl": 128, "instance_name": "p5en.48xlarge"})["timings_ms"]["prefill_compute"]
+    assert abs(p_bf16 / p_fp8 - 2.0) < 0.05, (p_bf16, p_fp8)   # fp8 peak 2x => half the prefill time
+    print(f"calc.py selftest PASS — fp8 peak: prefill bf16={p_bf16}ms vs fp8={p_fp8}ms (~2x, dtype peak applied)")
+
+    # ---- ARCH GATE for fp4 (LIVE-CORRECTED 2026-06-19): fp4's 4x peak is BLACKWELL-only. On Hopper (H200) an
+    # NVFP4 ckpt runs Marlin W4A16 (dequant→bf16 compute) so prefill ≈ bf16 (NOT 4x faster). On B200 it gets 4x. ----
+    m_fp4 = {**m_bf16, "weight_dtype": "fp4"}
+    p_fp4_h200 = analyze(INSTANCES["p5en.48xlarge"], m_fp4, {"isl": 4096, "osl": 128, "instance_name": "p5en.48xlarge"})["timings_ms"]["prefill_compute"]
+    p_bf16_h200 = analyze(INSTANCES["p5en.48xlarge"], m_bf16, {"isl": 4096, "osl": 128, "instance_name": "p5en.48xlarge"})["timings_ms"]["prefill_compute"]
+    assert abs(p_fp4_h200 / p_bf16_h200 - 1.0) < 0.05, ("fp4 on H200 must be ~bf16 (Marlin W4A16), NOT 4x", p_fp4_h200, p_bf16_h200)
+    p_fp4_b200 = analyze(INSTANCES["p6-b200.48xlarge"], m_fp4, {"isl": 4096, "osl": 128, "instance_name": "p6-b200.48xlarge"})["timings_ms"]["prefill_compute"]
+    p_bf16_b200 = analyze(INSTANCES["p6-b200.48xlarge"], m_bf16, {"isl": 4096, "osl": 128, "instance_name": "p6-b200.48xlarge"})["timings_ms"]["prefill_compute"]
+    assert abs(p_bf16_b200 / p_fp4_b200 - 4.0) < 0.1, ("fp4 on B200 must be ~4x bf16 (native FP4)", p_fp4_b200, p_bf16_b200)
+    print(f"calc.py selftest PASS — fp4 ARCH GATE: H200 fp4/bf16={p_fp4_h200/p_bf16_h200:.2f} (~1x Marlin, live-correct) | "
+          f"B200 bf16/fp4={p_bf16_b200/p_fp4_b200:.2f} (~4x native FP4)")
+
+    # ---- attention O(ISL^2) term (N7): quadratic fraction must RISE with ISL for a dense attention model ----
+    q_short = analyze(inst, m_bf16, {"isl": 512, "osl": 128, "instance_name": "p5en.48xlarge"})["timings_ms"]["prefill_attn_quadratic_frac"]
+    q_long = analyze(inst, m_bf16, {"isl": 16384, "osl": 128, "instance_name": "p5en.48xlarge"})["timings_ms"]["prefill_attn_quadratic_frac"]
+    assert q_long > q_short, (q_short, q_long)
+    print(f"calc.py selftest PASS — attn O(ISL^2): quadratic frac {q_short} @512 -> {q_long} @16384 (rises, as physics requires)")
+
+    # ---- SLO gate (N2): a disagg-favored case with a tiny TTFT budget must be overridden to aggregate ----
+    # craft a moderate-ISL, small-KV (few kv-heads), fast-decode case that favors disagg, then choke TTFT.
+    sm = {"name": "s", "family": "dense", "params_total_B": 8, "params_active_B": 8, "n_layers": 32, "n_heads": 32,
+          "n_kv_heads": 8, "hidden": 4096, "head_dim": 128, "weight_dtype": "bf16", "tp": 1}
+    base = analyze(INSTANCES["p5.48xlarge"], sm, {"isl": 4096, "osl": 128, "instance_name": "p5.48xlarge"})
+    assert base["decision"]["verdict"] == "disaggregate", ("SLO-gate base must be disagg", base["decision"])
+    choked = analyze(INSTANCES["p5.48xlarge"], sm, {"isl": 4096, "osl": 128, "instance_name": "p5.48xlarge",
+                                                    "slo_ttft_ms": 5.0})  # absurdly tight TTFT
+    assert choked["decision"]["verdict"] == "aggregate" and choked["decision"]["slo"]["disagg_slo_viable"] is False, choked["decision"]
+    print(f"calc.py selftest PASS — SLO gate: disagg→aggregate when TTFT budget breached "
+          f"(pre-SLO {choked['decision']['verdict_pre_slo']} -> {choked['decision']['verdict']}); reachability OK")
+
+    # ---- chunked-prefill (N4): recovery=0 (naive) must give >= interference than recovery=0.7 ----
+    naive = analyze(inst, model, {**wl, "chunked_prefill_recovery": 0.0})["decision"]["interference"]
+    chunked = analyze(inst, model, {**wl, "chunked_prefill_recovery": 0.7})["decision"]["interference"]
+    assert naive >= chunked, (naive, chunked)
+    print(f"calc.py selftest PASS — chunked-prefill: interference naive={naive} >= chunked(0.7)={chunked}")
+
+    # ---- HELP/NO-OP/REGRESS vs measured reality ----
+    # KEY PHYSICS (the honest headline): at the HOMOGENEOUS 1P:1D floor AS MODELED HERE, disaggregation is a
+    # LATENCY play, not a cost play. COST = uplift/2 with uplift = 1/(1-0.5*interference) capped by
+    # interference<=(1-cpr)=0.3, so cost tops out at 0.588x — disagg regresses on $/token at this floor (2x
+    # GPUs is a hard 2x; the interference uplift caps ~1.18x). TTFT regresses (KV hop on the first-token path);
+    # ITL is the axis disagg helps (removes co-batch interference). So a floor verdict is typically MIXED:
+    # trade cost+TTFT for ITL. Matches the MEASURED 550B (agg beat disagg 2.1x on cost).
+    # SCOPE (consensus-dialectic 2026-06-17, docs/CONSENSUS-2026-06-17): this is NOT a universal — it's the
+    # homogeneous-1P:1D L0 screen. Heterogeneous P:D right-sizing (DistServe) AND decode-batch-memory isolation
+    # (a dedicated decode pool frees the KV budget the prefill activations cannibalized, raising decode batch at
+    # fixed SLO) can make disagg cost-neutral-or-winning WITHOUT this floor's 2x penalty — that axis lives in
+    # pd_pool_scaling.py, not here. Read the cost verdict as "for the as-modeled floor," not "for disagg in general."
+    dva = r["disagg_vs_agg"]
+    cost_sp = dva["axes"]["cost_per_token"]["speedup_disagg_over_agg"]
+    assert dva["axes"]["cost_per_token"]["band"] == "regresses", dva["axes"]["cost_per_token"]
+    assert 0.45 <= cost_sp <= 0.61, cost_sp                    # ~0.5-0.59 => disagg costs ~2x => regress ~2x (matches measured)
+    assert dva["axes"]["ttft"]["band"] == "regresses", dva["axes"]["ttft"]        # KV hop on first-token path
+    assert dva["overall"] in ("regresses", "mixed"), dva["overall"]
+    # prefill-heavy agent workload: the ITL axis must HELP (more interference to remove than short chat).
+    agent = analyze(INSTANCES["p5.48xlarge"], sm, {"isl": 8192, "osl": 64, "instance_name": "p5.48xlarge"})["disagg_vs_agg"]
+    assert agent["axes"]["itl"]["band"] == "helps", agent["axes"]["itl"]
+    assert agent["axes"]["itl"]["speedup_disagg_over_agg"] >= dva["axes"]["itl"]["speedup_disagg_over_agg"], \
+        (agent["axes"]["itl"], dva["axes"]["itl"])             # longer-prefill agent helps ITL >= short chat
+    # every axis speedup positive + finite; bands valid
+    for k, a in dva["axes"].items():
+        assert a["speedup_disagg_over_agg"] > 0 and a["band"] in ("helps", "no-op", "regresses"), (k, a)
+    print(f"calc.py selftest PASS — help/regress: 550B cost={cost_sp}x (regresses, matches measured 2.1x agg-win), "
+          f"ttft regresses, ITL={dva['axes']['itl']['speedup_disagg_over_agg']}x ({dva['axes']['itl']['band']}) "
+          f"=> overall {dva['overall']}; agent ISL8192 ITL helps {agent['axes']['itl']['speedup_disagg_over_agg']}x "
+          f"(disagg = latency play, not cost play, at the 1P:1D floor)")
+
+    # ---- DeepSeek-V3 (MoE+MLA): active 37B compute, total 671B memory, MLA KV << naive GQA ----
+    ds = {"name": "deepseek-v3", "family": "moe-mla", "params_total_B": 671, "params_active_B": 37, "n_layers": 61,
+          "n_heads": 128, "n_kv_heads": 128, "hidden": 7168, "head_dim": 56, "kv_compression": "mla",
+          "kv_lora_rank": 512, "weight_dtype": "fp8", "tp": 8, "max_ctx": 163840}
+    rd = analyze(INSTANCES["p6-b200.48xlarge"], ds, {"isl": 4096, "osl": 512, "instance_name": "p6-b200.48xlarge"})
+    naive_kv = 2 * 128 * 56 * 61 * 1
+    assert rd["kv"]["attn_bytes_per_token"] < naive_kv, (rd["kv"]["attn_bytes_per_token"], naive_kv)
+    assert rd["memory_fit"]["weights_GB"] == 671.0, rd["memory_fit"]
+    print(f"calc.py selftest PASS — DeepSeek-V3(MLA)/b200 verdict={rd['decision']['verdict']} "
+          f"MLA-KV={rd['kv']['attn_bytes_per_token']}B/tok (naive GQA would be {naive_kv}) weights={rd['memory_fit']['weights_GB']}GB(fp8)")
+    return 0
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--selftest", action="store_true")
+    ap.add_argument("--instance", choices=list(INSTANCES))
+    ap.add_argument("--config", help="JSON {model:{...}, workload:{...}}")
+    ap.add_argument("--out")
+    a = ap.parse_args()
+    if a.selftest:
+        sys.exit(_selftest())
+    if not (a.instance and a.config):
+        ap.error("--instance and --config required (or --selftest)")
+    cfg = json.load(open(a.config))
+    wl = cfg["workload"]; wl["instance_name"] = a.instance
+    res = analyze(INSTANCES[a.instance], cfg["model"], wl)
+    js = json.dumps(res, indent=2)
+    if a.out: open(a.out, "w").write(js)
+    print(js)

--- a/Container-Root/eks/deployment/inference/agentic-ai/disagg-calculator/analyze/calibration.py
+++ b/Container-Root/eks/deployment/inference/agentic-ai/disagg-calculator/analyze/calibration.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """
 Author: Anton Alexander
-Source: github.com/dmvevents/dynamo-disagg-optimizer · live: dmvevents.github.io/dynamo-disagg-optimizer/calculator.html
 
 calibration.py — close the loop: PREDICT → MEASURE → DELTA → CORRECTION-FACTOR, refined over time.
 

--- a/Container-Root/eks/deployment/inference/agentic-ai/disagg-calculator/analyze/calibration.py
+++ b/Container-Root/eks/deployment/inference/agentic-ai/disagg-calculator/analyze/calibration.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""
+Author: Anton Alexander
+Source: github.com/dmvevents/dynamo-disagg-optimizer · live: dmvevents.github.io/dynamo-disagg-optimizer/calculator.html
+
+calibration.py — close the loop: PREDICT → MEASURE → DELTA → CORRECTION-FACTOR, refined over time.
+
+The calculators (calc.py / optimizer.py) make first-order predictions. This records what we PREDICTED, ingests
+what we MEASURED on real GPUs, computes the DELTA (ratio measured/predicted), and derives a per-(family,metric)
+**correction factor** = the median measured/predicted across every datapoint in the ledger. As more live runs
+land (the staged optimize/queue experiments), the ledger grows and the correction factors converge — the
+calculator gets more accurate over time without changing the physics.
+
+Seed datapoint (the one cell we have MEASURED, this session, on cgk p5en):
+  Nemotron-3-Ultra-550B / p5en / ISL512-OSL128:
+    decode ITL : predicted 4.4 ms (HBM roofline floor) vs MEASURED ~82 ms  → ratio ~18.6x
+      (the eager-mode + hybrid-Mamba + concurrency-1 penalty — real MBU ~0.04, not the 0.65 roofline)
+    peak tok/s : MEASURED 292 (optimized knee) ; goodput knee : MEASURED concurrency 32
+    $/Mtok     : MEASURED $95.88 (agg) vs $202.71 (disagg)
+The ITL ratio is the single most important correction — it's why a naive roofline says "hybrid/fast" while the
+live system is decode-latency-bound. correction_factor('hybrid-mamba','itl') returns it; apply_correction()
+scales a raw prediction by it.
+
+Ledger = results/calibration/ledger.jsonl (append-only, one record/line; survives across sessions). Pure stdlib.
+"""
+from __future__ import annotations
+import argparse, json, os, sys, statistics
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+LEDGER = os.path.join(HERE, "..", "results", "calibration", "ledger.jsonl")
+
+# The seed records (MEASURED this session). add_measurement() appends more as live runs complete.
+SEED = [
+    {"model": "nemotron-ultra-550b", "family": "hybrid-mamba", "instance": "p5en.48xlarge",
+     "isl": 512, "osl": 128, "metric": "itl_ms", "predicted": 4.4, "measured": 82.0,
+     "source": "study/RESULT.md + optimize/RESULT-optimization.md (live A/B + deep ramp)", "date": "2026-06-14"},
+    {"model": "nemotron-ultra-550b", "family": "hybrid-mamba", "instance": "p5en.48xlarge",
+     "isl": 512, "osl": 128, "metric": "peak_tok_s", "predicted": None, "measured": 292.0,
+     "source": "optimize/RESULT-optimization.md deep ramp (optimized knee)", "date": "2026-06-14"},
+    {"model": "nemotron-ultra-550b", "family": "hybrid-mamba", "instance": "p5en.48xlarge",
+     "isl": 512, "osl": 128, "metric": "goodput_knee_concurrency", "predicted": 32, "measured": 32,
+     "source": "optimize/RESULT-optimization.md (optimizer predicted 32, ramp measured 32)", "date": "2026-06-14"},
+    {"model": "nemotron-ultra-550b", "family": "hybrid-mamba", "instance": "p5en.48xlarge",
+     "isl": 512, "osl": 128, "metric": "usd_per_mtok_agg", "predicted": 107.6, "measured": 95.88,
+     "source": "cost.py est vs measured-goodput live A/B", "date": "2026-06-14"},
+    {"model": "nemotron-ultra-550b", "family": "hybrid-mamba", "instance": "p5en.48xlarge",
+     "isl": 512, "osl": 128, "metric": "kv_MB_per_req", "predicted": 247.5, "measured": 486.0,
+     "source": "calc.py est vs measured host-level rdma_read_bytes delta", "date": "2026-06-13"},
+]
+
+
+def _read():
+    rows = list(SEED)
+    if os.path.isfile(LEDGER):
+        for ln in open(LEDGER):
+            ln = ln.strip()
+            if ln:
+                try:
+                    rows.append(json.loads(ln))
+                except Exception:
+                    pass
+    return rows
+
+
+def add_measurement(model, family, instance, isl, osl, metric, predicted, measured, source, date):
+    """Append a measured datapoint to the ledger (the queued live runs call this with their results)."""
+    os.makedirs(os.path.dirname(LEDGER), exist_ok=True)
+    rec = {"model": model, "family": family, "instance": instance, "isl": isl, "osl": osl,
+           "metric": metric, "predicted": predicted, "measured": measured, "source": source, "date": date}
+    with open(LEDGER, "a") as f:
+        f.write(json.dumps(rec) + "\n")
+    return rec
+
+
+def delta(rows=None):
+    """Per record: ratio = measured/predicted (the correction needed). None predicted = measurement-only."""
+    rows = rows if rows is not None else _read()
+    out = []
+    for r in rows:
+        p, m = r.get("predicted"), r.get("measured")
+        ratio = (m / p) if (p not in (None, 0) and m is not None) else None
+        out.append({**r, "ratio_measured_over_predicted": round(ratio, 3) if ratio else None,
+                    "abs_delta": round(m - p, 2) if (p is not None and m is not None) else None})
+    return out
+
+
+def correction_factor(family, metric, rows=None):
+    """The correction = median(measured/predicted) over all ledger rows for (family, metric). 1.0 = perfect;
+    >1 = we UNDER-predict (e.g. ITL), <1 = we over-predict. Used by apply_correction()."""
+    rows = rows if rows is not None else _read()
+    ratios = [r["measured"] / r["predicted"] for r in rows
+              if r.get("family") == family and r.get("metric") == metric
+              and r.get("predicted") not in (None, 0) and r.get("measured") is not None]
+    if not ratios:
+        return {"factor": 1.0, "n": 0, "confidence": "none (no measured data — raw prediction unadjusted)"}
+    return {"factor": round(statistics.median(ratios), 3), "n": len(ratios),
+            "spread": [round(min(ratios), 3), round(max(ratios), 3)],
+            "confidence": "low (n=1)" if len(ratios) == 1 else f"n={len(ratios)}"}
+
+
+def apply_correction(predicted, family, metric):
+    """Scale a raw prediction by the learned correction factor. Returns (corrected, factor_info)."""
+    cf = correction_factor(family, metric)
+    return (round(predicted * cf["factor"], 3) if predicted is not None else None), cf
+
+
+def report(rows=None):
+    rows = delta(rows)
+    fams = sorted({(r["family"], r["metric"]) for r in rows if r.get("predicted") is not None})
+    factors = {f"{fam}/{met}": correction_factor(fam, met) for fam, met in fams}
+    return {"n_records": len(rows), "ledger_path": LEDGER, "records": rows, "correction_factors": factors,
+            "note": ("Correction = median(measured/predicted). It refines as live runs append. The big one: "
+                     "hybrid-mamba ITL ~18x (eager + concurrency-1) — apply it and the calculator's latency "
+                     "prediction matches the measured 550B. As the queued long-context / 2nd-model runs land, "
+                     "more families gain factors and confidence rises.")}
+
+
+def _selftest():
+    rows = _read()
+    # seed must be present + the ITL correction must reflect the ~18x measured-vs-predicted gap
+    cf = correction_factor("hybrid-mamba", "itl_ms")
+    assert cf["n"] >= 1, cf
+    assert 15 <= cf["factor"] <= 22, cf            # measured 82 / predicted 4.4 = 18.6
+    # apply_correction lifts the 4.4ms roofline toward the measured 82ms
+    corrected, info = apply_correction(4.4, "hybrid-mamba", "itl_ms")
+    assert 70 <= corrected <= 100, (corrected, info)
+    # knee correction = 1.0 (predicted 32 == measured 32 — the optimizer nailed it)
+    knee = correction_factor("hybrid-mamba", "goodput_knee_concurrency")
+    assert abs(knee["factor"] - 1.0) < 1e-6, knee
+    # a family+metric with NO data returns the identity factor (no silent fabrication). Use a sentinel that
+    # can never appear in the ledger, so this stays true as real measured points (e.g. dense itl 0.887x) are
+    # appended over time — do NOT hardcode a real family here.
+    none_cf = correction_factor("__nonexistent_family__", "itl_ms")
+    assert none_cf["factor"] == 1.0 and none_cf["n"] == 0, none_cf
+    # if a dense ITL point has been measured (live 70B A/B), it must be a sane near-1.0 correction (not absurd)
+    dense_cf = correction_factor("dense", "itl_ms")
+    if dense_cf["n"] >= 1:
+        assert 0.3 <= dense_cf["factor"] <= 3.0, dense_cf   # dense roofline ~tracks reality; measured 0.887x
+    print(f"calibration.py selftest PASS — {len(rows)} ledger records; hybrid-mamba ITL correction "
+          f"={cf['factor']}x ({cf['confidence']}) → corrects 4.4ms roofline to {corrected}ms (measured 82); "
+          f"knee correction {knee['factor']}x (optimizer nailed it); "
+          f"dense/itl n={dense_cf['n']} factor={dense_cf['factor']}; nonexistent-family → identity 1.0")
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Calibration ledger: predicted→measured→delta→correction-factor")
+    ap.add_argument("--selftest", action="store_true")
+    ap.add_argument("--report", action="store_true")
+    ap.add_argument("--add", nargs=9, metavar=("MODEL", "FAMILY", "INSTANCE", "ISL", "OSL", "METRIC", "PRED", "MEAS", "SOURCE"),
+                    help="append a measured datapoint (date stamped today by the caller via SOURCE)")
+    ap.add_argument("--out")
+    a = ap.parse_args()
+    if a.selftest:
+        sys.exit(_selftest())
+    if a.add:
+        model, fam, inst, isl, osl, met, pred, meas, src = a.add
+        rec = add_measurement(model, fam, inst, int(isl), int(osl), met,
+                              float(pred) if pred not in ("None", "-") else None, float(meas), src, "appended")
+        print("added:", json.dumps(rec)); return 0
+    rep = report()
+    js = json.dumps(rep, indent=2)
+    if a.out: open(a.out, "w").write(js)
+    print(js)
+    print("\n=== correction factors (median measured/predicted) ===", file=sys.stderr)
+    for k, v in rep["correction_factors"].items():
+        print(f"  {k:48s} {v['factor']}x  ({v['confidence']})", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Container-Root/eks/deployment/inference/agentic-ai/disagg-calculator/docs/DEPLOYMENT-GUIDE.md
+++ b/Container-Root/eks/deployment/inference/agentic-ai/disagg-calculator/docs/DEPLOYMENT-GUIDE.md
@@ -1,7 +1,6 @@
 # Deployment guide: aggregation vs disaggregation, end-to-end
 
 *Author: Anton Alexander*  
-*Source: github.com/dmvevents/dynamo-disagg-optimizer · live: dmvevents.github.io/dynamo-disagg-optimizer/calculator.html*
 
 
 A decision-then-deploy runbook. You start with a model + an SLA + a budget, and finish with a deployed,
@@ -18,7 +17,7 @@ aggregate or disaggregate prefill/decode, and what does each cost per million to
 > `calibration.py`) and the two browser pages — the cheap, run-anywhere screening tool. This runbook also
 > references the optional **live-sweep harness** (`driver/sweep.py`, `driver/goodput.py`, `cost.py`,
 > `render_charts.py`) and the L3 GPU benchmarking steps; those are the deeper research layer and live in the
-> companion project ([github.com/dmvevents/dynamo-disagg-optimizer](https://github.com/dmvevents/dynamo-disagg-optimizer)).
+> companion research harness (not required to use the calculator).
 > You do **not** need them to use the calculator — they're how the calculator gets calibrated against real
 > GPUs. Steps 0, 2 (L0), and 7 are self-contained here; steps 1, 3–6 point at the companion harness or
 > upstream tooling.

--- a/Container-Root/eks/deployment/inference/agentic-ai/disagg-calculator/docs/DEPLOYMENT-GUIDE.md
+++ b/Container-Root/eks/deployment/inference/agentic-ai/disagg-calculator/docs/DEPLOYMENT-GUIDE.md
@@ -1,4 +1,4 @@
-# Production guide: aggregation vs disaggregation, end-to-end
+# Deployment guide: aggregation vs disaggregation, end-to-end
 
 *Author: Anton Alexander*  
 *Source: github.com/dmvevents/dynamo-disagg-optimizer · live: dmvevents.github.io/dynamo-disagg-optimizer/calculator.html*
@@ -7,7 +7,7 @@
 A decision-then-deploy runbook. You start with a model + an SLA + a budget, and finish with a deployed,
 benchmarked Dynamo serving config — having spent GPU hours **only where the cheap analytical layers said to**.
 
-The question this guide answers in production terms: **for MY model, instance, SLA, and budget — do I
+The question this guide answers in deployment terms: **for MY model, instance, SLA, and budget — do I
 aggregate or disaggregate prefill/decode, and what does each cost per million tokens?**
 
 > Latency and cost can disagree. Disaggregation often wins on **TTFT / SLA-attainment** while
@@ -119,10 +119,10 @@ python3 analyze/cost.py --instance p5en.48xlarge --config m.json \
    --price-per-hr <your_rate_if_capacity_block>      # default = live AWS on-demand
 ```
 Output: $/Mtok for agg vs disagg, cheaper-at-SLA, savings %, and the latency-vs-cost note. **This is the
-production decision artifact** — pair it with the SLA-attainment from step 6.
+deployment decision artifact** — pair it with the SLA-attainment from step 6.
 
 ## 8. DEPLOY the winner
-`kubectl apply -f <chosen YAML>` (or the aiconfigurator DGD). Re-run step 6 in prod periodically; pod-freshness
+`kubectl apply -f <chosen YAML>` (or the aiconfigurator DGD). Re-run step 6 in your live environment periodically; pod-freshness
 matters (a stale pod can show 4× worse latency — restart before trusting a baseline).
 
 ---

--- a/Container-Root/eks/deployment/inference/agentic-ai/disagg-calculator/docs/METHODOLOGY.md
+++ b/Container-Root/eks/deployment/inference/agentic-ai/disagg-calculator/docs/METHODOLOGY.md
@@ -1,7 +1,6 @@
 # Methodology: deciding aggregation vs disaggregation, and finding the optimal settings — for ANY model on ANY compute
 
 *Author: Anton Alexander*  
-*Source: github.com/dmvevents/dynamo-disagg-optimizer · live: dmvevents.github.io/dynamo-disagg-optimizer/calculator.html*
 
 
 A **repeatable, model-agnostic, hardware-agnostic, engine-agnostic** process. Plug in a model (its HF

--- a/Container-Root/eks/deployment/inference/agentic-ai/disagg-calculator/docs/METHODOLOGY.md
+++ b/Container-Root/eks/deployment/inference/agentic-ai/disagg-calculator/docs/METHODOLOGY.md
@@ -1,0 +1,115 @@
+# Methodology: deciding aggregation vs disaggregation, and finding the optimal settings — for ANY model on ANY compute
+
+*Author: Anton Alexander*  
+*Source: github.com/dmvevents/dynamo-disagg-optimizer · live: dmvevents.github.io/dynamo-disagg-optimizer/calculator.html*
+
+
+A **repeatable, model-agnostic, hardware-agnostic, engine-agnostic** process. Plug in a model (its HF
+`config.json`), a compute target (GPU instance), a serving engine (any OpenAI-compatible endpoint), an SLA,
+and a budget — and the process tells you: **(1) aggregate or disaggregate, and (2) the optimal operating
+point** (topology × batch × concurrency × chunk × every knob), in $/Mtok and latency.
+
+It is a **predict → measure → re-calibrate loop**, grounded in the research (TaiChi, NetKV, Beyond-the-Buzz,
+DistServe, Splitwise, the PyTorch+vLLM blog) and proven end-to-end on Nemotron-3 Ultra 550B / p5en (this repo's
+`study/` + `optimize/`). You spend GPU hours only where the cheap analytical layers say the decision is close.
+
+```
+   ┌─ L0 PREDICT (no GPUs) ──────────────────────────────────────────────────────────┐
+   │  analyze/calc.py     → agg/hybrid/disagg verdict + memory-fit (does it even fit?) │
+   │  analyze/cost.py     → $/Mtok agg vs disagg at the SLA                            │
+   │  analyze/matrix.py   → the same across models × instances × SLA tiers (breadth)   │
+   │  analyze/optimizer.py→ OPTIMAL (topology,batch,conc,chunk,…) for SLA+cost + sens. │
+   │  web/index.html      → all of the above, interactive, no keys                     │
+   └──────────────────────────────────┬───────────────────────────────────────────────┘
+            decision close, or want ground truth?  ▼
+   ┌─ L1 RECOMMEND (no GPUs) ─────────────────────────────────────────────────────────┐
+   │  aiconfigurator → NVIDIA profiled-silicon agg-vs-disagg winner + xPyD + TP/PP     │
+   └──────────────────────────────────┬───────────────────────────────────────────────┘
+            ▼
+   ┌─ L2 CALIBRATE FABRIC (1 GPU run) ────────────────────────────────────────────────┐
+   │  kv-bench / nixlbench → measured KV-transfer GB/s → feed back into calc.py CAL    │
+   └──────────────────────────────────┬───────────────────────────────────────────────┘
+            ▼
+   ┌─ L3 MEASURE (live GPUs) ─────────────────────────────────────────────────────────┐
+   │  study/run-study.sh   → controlled agg-vs-disagg A/B (single variable = topology) │
+   │  bench/sweep.py       → batch×concurrency ramp to the goodput knee, ANY endpoint  │
+   └──────────────────────────────────┬───────────────────────────────────────────────┘
+            ▼  measured knee + $/Mtok
+   ┌─ RE-CALIBRATE ───────────────────────────────────────────────────────────────────┐
+   │  update optimizer.py CAL_OBS anchors (b_knee, itl0, tput_sat, OOM gates) → the    │
+   │  calculator now predicts THIS model+hardware; re-run L0 for the rest of the space │
+   └──────────────────────────────────────────────────────────────────────────────────┘
+```
+
+## How to repeat it for a NEW MODEL
+
+1. **Add the model** to `models/top_models.yaml` with arch params from its HF `config.json` (n_layers,
+   n_heads, n_kv_heads, hidden, head_dim, weight_dtype, max_ctx; for MoE add params_total_B + params_active_B;
+   for MLA add `kv_compression: mla` + kv_lora_rank). The two special cases that matter: **MoE** (active vs
+   total params) and **MLA** (compressed KV) — `calc.py` handles both.
+2. **L0 predict:** `python3 analyze/optimizer.py --instance <inst> --isl <I> --osl <O> --slo-ttft-ms <T>
+   --slo-tpot-ms <P> --objective cost` → the predicted optimal config + sensitivity. Also `calc.py` for the
+   agg/disagg verdict and `cost.py` for $/Mtok. If memory-fit says "no-fit", raise TP or use a bigger-HBM
+   instance before anything else.
+3. **L1 (optional):** `aiconfigurator cli default --model-path <hf-id> --total-gpus N --system <h100|h200|
+   b200>_sxm --backend <vllm|trtllm|sglang> --isl I --osl O --ttft T --tpot P` → recommended xPyD + per-phase
+   parallelism + deployable YAML.
+4. **L3 measure** (only if the decision is close or you need ground truth): deploy the agg arm + disagg arm
+   (templates in `study/deploy/` + `optimize/deploy/`), then
+   `python3 bench/sweep.py --endpoint <url> --model <name> --topology <agg|disagg> --concurrency 1,4,8,16,32,64,128`
+   → the measured goodput knee. Run both arms; `study/run-study.sh` automates the controlled single-variable A/B.
+5. **Re-calibrate:** put the measured anchors (knee concurrency, ITL floor, peak tok/s, any OOM constraint)
+   into `optimizer.py` `CAL_OBS["<model>@<instance>"]`. Now the calculator predicts this model+hardware; L0
+   covers the rest of the SLA/ISL/OSL space without more GPU runs.
+
+## How to repeat it for NEW COMPUTE (different GPU / instance)
+
+1. **Add the instance** to `analyze/calc.py` `INSTANCES{}`: `gpus`, `hbm_GBs` (bandwidth), `hbm_cap_GB`
+   (capacity — drives memory-fit), `fp16_TFLOPs`, `efa_nics`, `efa_Gbps`, `nvlink_GBs`. Add its $/hr to
+   `analyze/cost.py` `PRICE_PER_HR{}`.
+2. The memory-fit math (weights vs aggregate HBM capacity) + roofline (HBM-BW for decode, FLOPs for prefill)
+   re-derive automatically. The same calc/cost/matrix/optimizer pipeline runs unchanged.
+3. **L2 fabric calibration** matters most when the interconnect changes (EFA vs NVLink vs TCP vs InfiniBand):
+   measure achieved KV-transfer GB/s with `kv-bench`/`nixlbench` and update `calc.py` `CAL["kv_transfer_
+   efficiency"]` / `TIERS{}`. (PyTorch+vLLM blog used TCP and found single-stream is the bottleneck; we use
+   EFA multi-rail. The fabric tier is a first-class knob — NetKV.)
+4. Re-measure the knee on the new hardware (L3) and re-calibrate (different HBM/BW → different b_knee).
+
+## How to repeat it for a NEW ENGINE (vLLM / SGLang / TRT-LLM / Dynamo / hosted)
+
+`bench/sweep.py` speaks **plain OpenAI `/v1/chat/completions` (streaming)** — point it at any endpoint, pass
+`--topology agg|disagg`. The decision methodology and the goodput-knee math are identical across engines; only
+the deploy manifest + the engine-specific knob NAMES change (the `docs/KNOBS.md` table maps each knob to vLLM/
+Dynamo flags; for TRT-LLM/SGLang the concept is the same, the flag name differs). **Dynamo is one backend, not
+the core** — the analysis (`analyze/`) and measurement (`bench/`) layers are vendor-free.
+
+## The decision rule (what the process concludes)
+
+**Aggregate vs disaggregate is regime-dependent, and the process measures the regime rather than assuming it:**
+- **Aggregate** when: short context (ISL not ≫ OSL), cost-per-token is the objective, the model fits and
+  decode isn't interference-bound. (Our 550B/p5en short-ctx result: agg 2.1× cheaper — confirmed by calc +
+  live A/B + aiconfigurator, three independent methods.)
+- **Disaggregate** when: long input (prefill interference high), or the objective is **per-user latency /
+  tail-latency / TTFT-SLA attainment** with an independently-scaled prefill pool. (aiconfigurator: disagg
+  3.3× tok/s/user + 2.9× lower request-latency at ISL8192.)
+- **Hybrid** (TaiChi) in the balanced middle.
+
+**The optimal operating point within a topology** = the **goodput knee**: the highest concurrency whose joint
+(TTFT, TPOT) SLO attainment stays ≥90%. Beyond the knee, throughput is flat and latency explodes (measured:
+550B knee at concurrency 32 — 292 tok/s; at 64/128 tok/s is flat but TTFT goes 2.9 s→16 s→42 s).
+
+## Hard constraints the process surfaces (don't skip the feasibility gate)
+- **Memory-fit first.** A model that barely fits has near-zero KV budget → tiny concurrency → high $/token,
+  regardless of latency. `calc.py` 3-state fit (fits/tight/no-fit) gates everything.
+- **CUDA-graph feasibility.** Re-enabling graphs is the biggest decode-latency lever — but on a memory-tight
+  config it OOMs (MEASURED: 550B/TP8/util0.90 → engine-core init failure). The optimizer encodes this as a
+  feasibility gate; graphs need TP16 or fp8 KV on tight models. **Predicted by calc.py `min_util`, confirmed live.**
+- **Per-model footguns** (e.g. hybrid-Mamba: PP>1 hangs, `--block-size 128` crashes, `kv_role` mis-route) live
+  in `docs/KNOBS.md` — check them before sweeping.
+
+## Honest scope
+- The L0 models are first-order, calibrated to measured anchors; they give the **direction + the where-to-
+  spend-GPU**, and L3 replaces estimates with measurements. The re-calibrate loop is what makes the calculator
+  trustworthy for a given model+hardware.
+- Proven end-to-end on one model (550B) + one instance (p5en) + one engine (vLLM/Dynamo). The breadth across
+  models/instances is analytical (`docs/MATRIX.md`); each new live cell tightens the calibration.

--- a/Container-Root/eks/deployment/inference/agentic-ai/disagg-calculator/docs/PRODUCTION-GUIDE.md
+++ b/Container-Root/eks/deployment/inference/agentic-ai/disagg-calculator/docs/PRODUCTION-GUIDE.md
@@ -1,0 +1,227 @@
+# Production guide: aggregation vs disaggregation, end-to-end
+
+*Author: Anton Alexander*  
+*Source: github.com/dmvevents/dynamo-disagg-optimizer · live: dmvevents.github.io/dynamo-disagg-optimizer/calculator.html*
+
+
+A decision-then-deploy runbook. You start with a model + an SLA + a budget, and finish with a deployed,
+benchmarked Dynamo serving config — having spent GPU hours **only where the cheap analytical layers said to**.
+
+The question this guide answers in production terms: **for MY model, instance, SLA, and budget — do I
+aggregate or disaggregate prefill/decode, and what does each cost per million tokens?**
+
+> Latency and cost can disagree. Disaggregation often wins on **TTFT / SLA-attainment** while
+> **aggregation wins on $/Mtok** (disagg needs ≥2× the GPUs). This guide makes both explicit so you choose
+> on YOUR priority (tail-latency SLA vs unit cost). The `cost.py` tool quantifies the tradeoff.
+
+> **Scope of this directory.** What ships here is the **analytical layer** (`analyze/calc.py` +
+> `calibration.py`) and the two browser pages — the cheap, run-anywhere screening tool. This runbook also
+> references the optional **live-sweep harness** (`driver/sweep.py`, `driver/goodput.py`, `cost.py`,
+> `render_charts.py`) and the L3 GPU benchmarking steps; those are the deeper research layer and live in the
+> companion project ([github.com/dmvevents/dynamo-disagg-optimizer](https://github.com/dmvevents/dynamo-disagg-optimizer)).
+> You do **not** need them to use the calculator — they're how the calculator gets calibrated against real
+> GPUs. Steps 0, 2 (L0), and 7 are self-contained here; steps 1, 3–6 point at the companion harness or
+> upstream tooling.
+
+---
+
+## Rule of thumb: disaggregate, or run multiple aggregated replicas?
+
+The single most-asked question. Short version, surfaced by the calculator + our measured 550B/70B runs:
+
+| Choose… | When | Why |
+|---|---|---|
+| **Multiple aggregated replicas** | short-context chat · prefill cheap vs decode · cost/throughput-bound · loose-to-moderate ITL SLO | At the homogeneous 1P:1D floor, disagg buys ~nothing but costs **≥2× the GPUs** → unit-cost regresses (efficiency caps ≈0.5–0.59×). Just scale replicas. |
+| **Disaggregate (split prefill/decode)** | long input contexts (RAG, agents, code) · prefill heavy vs decode · **tight TPOT/ITL SLO** · you can right-size the prefill:decode pool ratio | A prefill burst stalls the decode stream of every co-batched request; splitting removes that **TPOT interference**. This is the one axis disagg wins. |
+
+**Per-axis truth (so nobody is surprised):** moving agg→disagg **regresses cost** (extra GPUs) and **regresses TTFT** (adds a KV-transfer hop); **ITL is the only axis it improves**, and only when prefill interference is high. So disaggregation is fundamentally a **latency play, not a cost play** — *unless* you also right-size the P:D ratio (e.g. 1P:3D) and isolate decode-batch memory, which is what opens disagg's cost case (DistServe, arXiv:2401.09670; Splitwise, 2.35×).
+
+**Measured anchor (not taken on faith):** Nemotron-3 Ultra 550B, p5en, short chat (ISL512/OSL128, low concurrency) → **aggregation 2.1× cheaper** ($95.88 vs $202.71/Mtok), triangulated by NVIDIA aiconfigurator (1.77×) and our analytic optimizer. At HIGH concurrency the gap narrows (interference grows) — confirm at your real load with the L3 sweep below.
+
+**TL;DR:** tight-ITL + long prompts + can right-size pools → **disaggregate**. Cost-sensitive + short context + simpler ops → **aggregated replicas**. When in doubt, the L0 screen (`calc.py` / `web/index.html`) returns the verdict + the help/no-op/regress breakdown per axis in one shot, before you spend a GPU-hour.
+
+---
+
+## 0. Prerequisites (once per cluster)
+- EKS cluster with GPU nodes (p5/p5en/p6-b200), EFA device plugin, FSx (weights), dynamo-platform (etcd+NATS).
+- `pip install aiconfigurator aiperf` (or use the Dynamo container which bakes both).
+- This repo: `analyze/` (calc, cost, charts, vision) + `driver/` (sweep, goodput) + `deploy/templates/`.
+
+## 1. Build the images (chain of custody)
+The serving image is a thin overlay chain — build once, reuse for agg AND disagg (same image, different args).
+The disaggregation-capable serving image = the public NGC vLLM-runtime + EFA + the NVIDIA Nemotron-Ultra
+disagg patch series (which removes the `External KV connector is not verified yet` assert and adds the
+SSM tail-align). The companion [Nemotron 3 Ultra](../../nemotron/ultra) deployment in this project ships the
+Dockerfile and a pre-built public image:
+```
+# from the nemotron/ultra disagg build dir — see ../../nemotron/ultra/disagg
+docker build -t <your-registry>/dynamo-vllm-efa:disagg \
+  -f ../../nemotron/ultra/disagg/dynamo-vllm-efa/Dockerfile .
+```
+A pre-built, anon-pullable image is referenced from the [Nemotron 3 Ultra README](../../nemotron/ultra):
+`public.ecr.aws/hpc-cloud/dynamo-vllm-efa:disagg-1.2.0`.
+**Agg vs disagg is NOT a different image** — it's `--disaggregation-mode {prefill|decode}` + topology in the YAML.
+
+## 2. SCREEN before you spend GPUs — L0 (instant, this repo)
+```
+cat > m.json <<'J'
+{"model":{"name":"my-model","family":"dense","params_B":70,"n_layers":80,"n_heads":64,"n_kv_heads":8,
+          "hidden":8192,"head_dim":128,"weight_dtype":"bf16","tp":8},
+ "workload":{"isl":4096,"osl":512,"ttft_s":2.0,"tpot_ms":50}}
+J
+python3 analyze/calc.py --instance p5en.48xlarge --config m.json --out a.json    # latency verdict
+python3 analyze/cost.py --instance p5en.48xlarge --config m.json                 # $/Mtok agg vs disagg
+python3 analyze/render_charts.py --instance p5en.48xlarge --config m.json --outdir charts/
+python3 analyze/visual_verdict.py --charts 'charts/*.png' --analysis a.json      # vision LLM confirms
+```
+Read the two verdicts:
+- `calc.py` → **latency** verdict (disagg if cheap KV transfer + high prefill interference).
+- `cost.py` → **cost** verdict ($/Mtok agg vs disagg + savings %). If they disagree, that's your tradeoff to own.
+Or open `web/index.html` (interactive, no keys) for the same, live.
+
+## 3. RECOMMEND parallelism — L1 aiconfigurator (offline, profiled, emits Dynamo YAML)
+```
+aiconfigurator cli default --model-path <hf-id> --total-gpus 16 --system h200_sxm --backend vllm \
+   --ttft 2000 --tpot 50 --isl 4096 --osl 512 --save-dir reco/
+# emits reco/{agg_config.yaml, prefill_config.yaml, decode_config.yaml, k8s_deploy.yaml, bench_run.sh}
+```
+aiconfigurator is upstream NVIDIA tooling ([github.com/ai-dynamo/aiconfigurator](https://github.com/ai-dynamo/aiconfigurator)).
+This gives the real TP/PP/EP and prefill:decode worker ratio (`R_PD`) — better than the L0 1:1 assumption.
+
+## 4. RENDER the deploy YAMLs
+- Disagg (proven, unprivileged, no-hostNetwork): `deploy/templates/pp1-disagg.nohostnet.yaml`
+  (TP8/PP1, NixlConnector + LIBFABRIC, EFA env, `imagePullPolicy: Always`, IPC_LOCK — Alex's publication standard).
+- Agg: same image, single deployment, no `--disaggregation-mode`.
+- Or use aiconfigurator's `k8s_deploy.yaml` from step 3 (Dynamo DGD).
+
+## 5. CALIBRATE the fabric — L2 nixlbench (one run per instance+backend)
+The biggest L0 unknown is achieved KV-transfer GB/s. Measure it, then feed it back so every estimate tracks YOUR fabric:
+```
+# nixlbench ships with NIXL (github.com/ai-dynamo/nixl); run its p2p KV bandwidth sweep over EFA:
+nixlbench --etcd-endpoints <etcd-url> --backend Libfabric --initiator_seg_type VRAM \
+  --target_seg_type VRAM --op_type WRITE
+```
+Update `analyze/calc.py` `CAL["kv_transfer_efficiency"]` / `TIERS[...]["GBs"]` with the measured number.
+
+## 6. CONFIRM on real GPUs — L3 AIPerf goodput (the ground truth)
+Deploy the top-1 agg and top-1 disagg configs, benchmark each at the FRONTEND, get goodput-under-SLA:
+```
+driver/run_cell.sh my-model "mode=disagg,R_PD=1:1,..." ~/.kube/config-cgk    # deploy+bench+capture+teardown
+# or Dynamo-native: kubectl apply -f benchmarks/incluster/benchmark_job.yaml
+# goodput = max QPS sustaining >=90% joint (TTFT,TPOT) attainment:
+python3 driver/goodput.py --runs runs.json --ttft-slo-s 2.0 --tpot-slo-ms 50
+```
+
+## 7. DECIDE on cost+SLA — feed MEASURED goodput into cost.py
+```
+python3 analyze/cost.py --instance p5en.48xlarge --config m.json \
+   --agg-goodput <measured_agg_tok_s> --disagg-goodput <measured_disagg_tok_s> \
+   --price-per-hr <your_rate_if_capacity_block>      # default = live AWS on-demand
+```
+Output: $/Mtok for agg vs disagg, cheaper-at-SLA, savings %, and the latency-vs-cost note. **This is the
+production decision artifact** — pair it with the SLA-attainment from step 6.
+
+## 8. DEPLOY the winner
+`kubectl apply -f <chosen YAML>` (or the aiconfigurator DGD). Re-run step 6 in prod periodically; pod-freshness
+matters (a stale pod can show 4× worse latency — restart before trusting a baseline).
+
+---
+
+## Worked decision (Nemotron-3 Ultra 550B, p5en, ISL512/OSL128, SLA 2s/120ms)
+- L0 latency verdict: **disaggregate** (fav 0.573 — cheap KV transfer, high prefill interference).
+- cost.py (measured low-conc goodput): agg **$98/Mtok** vs disagg **$196/Mtok** → **aggregation cheaper** here.
+- **Decision:** if your SLA is TTFT-bound (interactive chat) → disaggregate (proven: 486MB KV/req over EFA,
+  ITL flat 77ms). If your SLA is loose and you optimize $/token at low concurrency → aggregate. At HIGH
+  concurrency the disagg cost gap closes (interference grows) — confirm with an L3 sweep at your real load.
+
+## Parallelism status: independent P/D scaling ships at PP1; PP>1 is the can't-fit-one-node case
+
+**Independent prefill/decode scaling is the whole point of disaggregation — and it does NOT require PP>1.**
+It comes from **replica count**, not pipeline parallelism. Prefill and decode are separate workloads, each
+independently scalable, and the Dynamo router sprays across each pool.
+
+**Use LWS (LeaderWorkerSet) for disagg, not plain Deployments** — that's the right primitive and the answer
+is "yes, stick with LWS":
+- A **single-node role** (TP8/PP1, one node) maps to an LWS group of size 1 (leader only). Scaling the pool
+  = LWS `replicas:`. This is interchangeable with a Deployment here, but LWS keeps prefill and decode as
+  uniform, named, gang-scheduled groups — cleaner and consistent with the multi-node case.
+- A **multi-node role** (TP8/PP2, role spans 2 nodes) *requires* LWS: the group is leader + worker(s),
+  gang-scheduled, with the stable leader DNS the engine's Ray/torch-dist bootstrap needs. A Deployment can't
+  express "these N pods are one gang-scheduled replica." This is exactly the topology running live on cgk
+  today (`nemotron3-ultra-550b-disagg-{prefill,decode}-0` + `-0-1` = LWS leader+worker per role).
+
+To run 16 GPUs of prefill and 32 of decode (PP1, single-node roles):
+
+```
+prefill LWS = 2 × (TP8/PP1 group, size 1) = 16 GPUs   # prefill LWS replicas: 2
+decode  LWS = 4 × (TP8/PP1 group, size 1) = 32 GPUs   # decode  LWS replicas: 4  → asymmetric 1:2 P:D, zero PP
+```
+
+That asymmetric pool sizing is exactly the `R_PD` axis (`pd_pool_scaling.py` models it: goodput =
+`max over p of min(p·prefill_rate, (R−p)·decode_rate)`). **No PP needed** — each replica is one TP8/PP1 node.
+
+- **Tensor-parallel >1 is NOT blocked.** The shipping, proven unit is **TP8 / PP1** (one node per role):
+  verified E2E on p5en — coherent chat + **486 MB KV-over-EFA/request**, ITL flat ~77 ms. 550B fits one
+  p5en node at TP8, so a prefill (or decode) replica = one node, and you scale pools by `replicas:`.
+- **Status of independent pool scaling:** architecturally supported + proven at the 1:1 floor. The N:M-replica
+  case (e.g. 1P:2D) is the one open *validation* — but it's just more replicas of the proven TP8/PP1 unit,
+  no known blocker, and **not** the PP bug below.
+
+**When PP>1 IS required** (and currently blocked on hybrid-Mamba): only when a **single replica of a role
+can't fit one node's TP domain** — e.g. a model too large for one node even at max TP (550B on H100's
+640 GB/node, or a larger future model on p5en). It is NOT required for asymmetric P:D pool scaling. The
+blocker is an open vLLM bug ([#43368](https://github.com/vllm-project/vllm/issues/43368)): NIXL
+member-identity routing is disabled for Mamba (`_use_member_identity`→`False` when `_has_mamba`), so the
+hybrid-Mamba region groups collapse and the decode worker reads the wrong SSM region → **degenerate output**
+(not a hang; KV *does* transfer). Dense/MoE models are unaffected — PP>1 works for them.
+
+- **Unblock path (staged, not yet merged):** a minimal `_ssm_layer_names()` filter so SSM descriptors land at
+  the right offsets — static-verified, cluster-E2E pending a 4-node p5en window. Tracked in
+  [`docs/DISAGG-PR-LEDGER.md`](DISAGG-PR-LEDGER.md). The PR author deferred the upstream fix (hybrid E2E was
+  never validated upstream), so this is a high-value contribution-in-progress.
+- **For the blog / the standard:** independent prefill/decode scaling ships **today at PP1 via replicas**.
+  Reach for PP>1 only when one replica can't fit one node — for 550B at TP8 on p5en, that case doesn't arise.
+
+## The fit squeeze: 550B BF16 "barely fits" one node — and the two escapes
+
+A fair objection (Alex, 2026-06-18): 550B BF16 *technically* fits one p5en, but the settings to make it fit
+**degrade the model**, which can defeat the point of disaggregating. The calculator quantifies it
+(`analyze/calc.py`, now PP-aware), 550B on p5en at the RAG workload ISL8192/OSL512:
+
+| Topology | GPUs | weight-util | KV budget | CUDA graphs | conc. ceiling |
+|---|---|---|---|---|---|
+| **BF16 TP8 / PP1** (1 node, ships today) | 8 | **0.97** | ~5 GB | ❌ enforce-eager | **~1** |
+| **BF16 TP8 / PP2** (2 nodes per role) | 16 | 0.49 | ~1111 GB | ✅ | ~272 |
+| **FP8 TP8 / PP1** (1 node, quantized) | 8 | 0.49 | ~555 GB | ✅ | ~272 |
+
+At BF16/PP1 the weights eat **97.5%** of HBM → ~one long request fits, no CUDA graphs (`--enforce-eager`),
+`--max-model-len` and `--gpu-memory-utilization` pushed to the edge. That IS a degraded operating point.
+**Three ways out, all restore CUDA graphs + large KV headroom — and the best one is LIVE-PROVEN on H200:**
+
+0. **★ Official NVFP4 checkpoint — `nvidia/...-550B-A55B-NVFP4` (LIVE-PROVEN on p5en/H200, 2026-06-19).**
+   322 GB ModelOpt MIXED_PRECISION ckpt → fits **TP8 on ONE node, no PP, no 2nd node**. Live probe on cgk
+   (vLLM 0.20.1): loaded 41.34 GiB/GPU, **81.83 GiB free for KV → 1374× conc @2K**, coherent output. This is
+   the cleanest single-node fix — and it's an OFFICIAL NVIDIA artifact, not a self-quant. *Earlier we (and a
+   3-LLM quorum) wrongly believed NVFP4 was Blackwell-only; the live test refuted that — the MoE-expert NVFP4
+   GEMMs run on SM90 because the rest of the model is FP8/BF16.* Open: throughput vs BF16 (characterizing now).
+   `results/nvfp4-probe/`.
+1. **Span the model across nodes per role (PP≥2).** PP shards the model's *layers* over `tp·pp` GPUs, so the
+   same 1100 GB of weights sit in 2256 GB of aggregate HBM (2 p5en) — weight-util drops to 0.49, KV budget
+   jumps to ~1.1 TB, CUDA graphs come back. Cost: 2× GPUs per replica (the calculator's cost axis counts it).
+   **This is the LWS path** (a role = a LeaderWorkerSet leader+worker spanning 2 nodes). Blocked on the
+   hybrid-Mamba PP bug above for 550B specifically; dense/MoE models can do this today.
+2. **Self-quantize to FP8 (ModelOpt).** Halves weights to ~550 GB → fits one node at 0.49 util with the *same*
+   KV headroom and CUDA graphs, **no second node**. Trade: produce a validated-accuracy FP8 checkpoint (we
+   proved the ModelOpt FP8 *serving path* on p5en, but on Qwen-1.5B — `project A/B validated-FP8-vs-BF16` —
+   not yet on 550B). Now mostly redundant with option 0 since the official NVFP4 ckpt already serves.
+
+**Read:** Alex is right that 1-node BF16 is a compromised operating point. The fix is *more aggregate HBM per
+replica* — reached either by spanning nodes (PP, the LWS path, pending the Mamba fix for 550B) or by FP8
+(available today, one node). The calculator now models both so the trade is explicit, not discovered at deploy.
+
+## Honest scope
+- L0/cost are estimators (calibrated to measured 550B/p5en); steps 5-7 replace estimates with measurements.
+- p5en price is the AWS capacity-reservation rate ($63.30/hr); pass `--price-per-hr` for your actual contract.
+- Disagg needs the dynamo-platform (etcd+NATS) + the patched image; agg can run barer. Factor ops cost too.
+- **Topology:** independent P/D scaling = `replicas:` per role at TP8/PP1 (proven unit); PP>1 is only the
+  can't-fit-one-node case and is research on hybrid-Mamba (see above).

--- a/Container-Root/eks/deployment/inference/agentic-ai/disagg-calculator/results/calibration/ledger.jsonl
+++ b/Container-Root/eks/deployment/inference/agentic-ai/disagg-calculator/results/calibration/ledger.jsonl
@@ -1,0 +1,3 @@
+{"model": "llama-3.1-70b", "family": "dense", "instance": "p5en.48xlarge", "isl": 512, "osl": 128, "metric": "itl_ms", "predicted": 22.44, "measured": 19.9, "source": "optimize/at-scale/results/l70-agg-result.json (live agg sweep, CUDA graphs on, conc16)", "date": "2026-06-14"}
+{"model": "llama-3.1-70b", "family": "dense", "instance": "p5en.48xlarge", "isl": 512, "osl": 128, "metric": "agg_req_s", "predicted": null, "measured": 3.54, "source": "l70-agg-result.json conc16 knee", "date": "2026-06-14"}
+{"model": "llama-3.1-70b", "family": "dense", "instance": "p5en.48xlarge", "isl": 512, "osl": 128, "metric": "disagg_req_s", "predicted": null, "measured": 3.17, "source": "l70-disagg-result.json conc16 (1P:1D, 4 GPU)", "date": "2026-06-14"}

--- a/Container-Root/eks/deployment/inference/agentic-ai/disagg-calculator/web/calculator.html
+++ b/Container-Root/eks/deployment/inference/agentic-ai/disagg-calculator/web/calculator.html
@@ -116,6 +116,13 @@
    transfer-toll vs interference → <b>verdict</b> → $/Mtok → optimal operating point.
    <b class="honest">Disaggregation is not free — it helps for some workloads and regresses for others. This tool tells you which: when it helps, when it&rsquo;s a no-op, and when it costs you (at the 1P:1D floor it&rsquo;s a latency play, not a cost play).</b>
    Physics mirrors <code>analyze/calc.py</code> + <code>cost.py</code> + <code>optimizer.py</code>, calibrated to measured 550B/p5en.</div>
+  <div style="margin:10px 0;padding:8px 12px;border:1px solid #c89b3c;background:#2a2410;color:#e8d9a0;border-radius:6px;font-size:12px;line-height:1.45">
+    <b>Disclaimer.</b> Provided free of charge, as a utility, for quick <b>estimation and planning only</b>. AWS and the
+    authors make <b>no representation, warranty, or guarantee</b> of model performance, throughput, latency, or cost, and
+    <b>accept no liability</b> for any outcome arising from its use. Actual measured results will differ from the
+    calculated numbers — always validate on your own hardware with your own workload before deployment or purchasing
+    decisions. Provided <b>&ldquo;AS IS&rdquo;</b>.
+  </div>
 </header>
 <div class="wrap">
   <!-- ============ INPUTS (the architecture) ============ -->
@@ -205,7 +212,7 @@
         <b>How to read this:</b> a <b>directional L0 screen</b>, calibrated to a single measured anchor
         (<b>n=1</b>): Nemotron-3 Ultra 550B, <b>bf16</b>, <b>H200 / p5en</b>, <b>TP8</b>. It models per-request
         single-stream latency — <b>not</b> a validated multi-tenant simulator. Confirm any verdict with
-        <code>driver/sweep.py</code> on real GPUs before acting.
+        <code>a live GPU sweep</code> on real GPUs before acting.
         <div class="provlegend">Number provenance:
           <span class="badge meas tiny">MEASURED</span> real GPU benchmark
           <span class="badge der tiny">DERIVED</span> computed from your inputs

--- a/Container-Root/eks/deployment/inference/agentic-ai/disagg-calculator/web/calculator.html
+++ b/Container-Root/eks/deployment/inference/agentic-ai/disagg-calculator/web/calculator.html
@@ -1,0 +1,725 @@
+<!DOCTYPE html>
+<!-- Author: Anton Alexander | Source: github.com/dmvevents/dynamo-disagg-optimizer · live: dmvevents.github.io/dynamo-disagg-optimizer/calculator.html -->
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Agg-vs-Disagg Calculator — work backwards from the model architecture</title>
+<!-- Self-contained. NO API keys. Physics is a faithful JS port of analyze/calc.py + cost.py + optimizer.py
+     (calibrated to MEASURED Nemotron-3 Ultra 550B / p5en anchors). Chart.js (CDN) for the two charts only. -->
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+<style>
+ :root{--bg:#0d1117;--card:#161b22;--card2:#1c2230;--fg:#e6edf3;--mut:#8b949e;--acc:#58a6ff;--ok:#3fb950;--warn:#d29922;--bad:#f85149;--line:#30363d}
+ *{box-sizing:border-box} body{margin:0;background:var(--bg);color:var(--fg);font:14px/1.5 system-ui,Segoe UI,Roboto,sans-serif}
+ header{padding:16px 24px;border-bottom:1px solid var(--line)} h1{margin:0;font-size:19px} .sub{color:var(--mut);font-size:13px;margin-top:4px}
+ .sub .honest{color:var(--fg)}                          /* the agg-vs-disagg honesty line reads as a feature, not a footnote (mirrors index.html) */
+ .wrap{display:grid;grid-template-columns:340px 1fr;gap:18px;padding:18px 24px;align-items:start}
+ .card{background:var(--card);border:1px solid var(--line);border-radius:10px;padding:14px;margin-bottom:14px}
+ .card h3{margin:0 0 8px;font-size:13px;color:var(--acc);text-transform:uppercase;letter-spacing:.04em}
+ label{display:block;color:var(--mut);font-size:12px;margin:8px 0 2px} input,select{width:100%;background:#0d1117;color:var(--fg);border:1px solid var(--line);border-radius:6px;padding:6px}
+ .row{display:grid;grid-template-columns:1fr 1fr;gap:8px} .row3{display:grid;grid-template-columns:1fr 1fr 1fr;gap:8px}
+ button{margin-top:12px;width:100%;background:var(--acc);color:#06121f;border:0;border-radius:6px;padding:9px;font-weight:600;cursor:pointer}
+ /* derivation chain */
+ .step{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--acc);border-radius:8px;padding:12px 14px;margin-bottom:10px}
+ .step .n{display:inline-block;width:20px;height:20px;line-height:20px;text-align:center;background:var(--acc);color:#06121f;border-radius:50%;font-size:11px;font-weight:700;margin-right:8px}
+ .step .t{font-weight:600} .step .f{color:var(--mut);font-size:12px;font-family:ui-monospace,Menlo,monospace;margin:4px 0 6px}
+ .step .v{font-size:15px} .step .v b{color:var(--fg)}
+ .ad{display:grid;grid-template-columns:1fr 1fr;gap:10px;margin-top:6px}
+ .ad>div{background:var(--card2);border-radius:6px;padding:8px 10px} .ad .h{font-size:11px;text-transform:uppercase;letter-spacing:.04em;color:var(--mut)}
+ .agg .h{color:var(--acc)} .dis .h{color:var(--ok)}
+ .verdict{font-size:24px;font-weight:800;margin:2px 0} .disaggregate{color:var(--ok)} .hybrid{color:var(--warn)} .aggregate{color:var(--acc)}
+ /* verdict carries a SHAPE prefix too (CSS ::before keyed on the verdict class the JS sets) — meaning is
+    never color-only, so it passes a11y / colorblind. Pure presentation; no JS change. */
+ .verdict::before{font-family:ui-monospace,Menlo,monospace;margin-right:9px;font-size:19px;vertical-align:1px}
+ .verdict.disaggregate::before{content:"▲"} .verdict.hybrid::before{content:"◆"} .verdict.aggregate::before{content:"■"}
+ .mut{color:var(--mut)} .kpi{display:flex;justify-content:space-between;border-bottom:1px solid #21262d;padding:4px 0;font-size:13px} .kpi b{color:var(--fg)}
+ .pill{display:inline-block;padding:1px 8px;border-radius:10px;font-size:11px;font-weight:600}
+ .pill.fits{background:#13351f;color:var(--ok)} .pill.tight{background:#3a2f12;color:var(--warn)} .pill.nofit{background:#3a1718;color:var(--bad)}
+ canvas{max-height:230px} code{background:#0d1117;padding:1px 5px;border-radius:4px;font-size:12px} .warnote{color:var(--warn);font-size:12px;margin-top:6px}
+ .grid2{display:grid;grid-template-columns:1fr 1fr;gap:14px}
+ .arch{font-size:12px;color:var(--mut)} .small{font-size:11px;color:var(--mut)}
+ .ucwrap{background:var(--card2);border:1px solid var(--acc);border-radius:8px;padding:8px 10px;margin:2px 0 8px}
+ .ucwrap label{margin-top:0} .ucsel{border-color:var(--acc)!important}
+ .uchint{font-size:11px;color:var(--mut);margin-top:5px;line-height:1.45}
+ .trustchip{display:inline-flex;align-items:center;gap:7px;background:#0c1f13;border:1px solid var(--ok);border-radius:999px;padding:4px 11px;margin:10px 0 0;font-size:11.5px;color:var(--fg);line-height:1.4}
+ .trustchip .dot{width:7px;height:7px;border-radius:50%;background:var(--ok);flex:none} .trustchip b{color:#56d364}
+ /* ---- topology explainer (3 cards + inline SVG diagrams) — shared verdict vocabulary with index.html ---- */
+ .topohead{font-size:15px;margin:2px 0 3px;color:var(--fg)} .topolead{color:var(--mut);font-size:12px;margin-bottom:10px;line-height:1.5}
+ .topo3{display:grid;grid-template-columns:repeat(3,1fr);gap:12px}
+ @media(max-width:1080px){.topo3{grid-template-columns:1fr}}
+ .topo{background:var(--card2);border:1px solid var(--line);border-radius:10px;padding:12px;border-top:3px solid var(--line)}
+ .topo.agg{border-top-color:var(--acc)} .topo.hyb{border-top-color:var(--warn)} .topo.dis{border-top-color:var(--ok)}
+ .topo h4{margin:0 0 4px;font-size:14px} .topo.agg h4{color:var(--acc)} .topo.hyb h4{color:var(--warn)} .topo.dis h4{color:var(--ok)}
+ .topo svg.topodiag{display:block;width:100%;max-width:100%;height:auto;background:#0d1117;border:1px solid #21262d;border-radius:6px;margin:8px 0}
+ .topodiag .node{fill:#0d1117;stroke:#30363d;stroke-width:1.5}
+ .topodiag .gpu{fill:#161b22;stroke-width:1.4} .topodiag .lbl{fill:var(--fg);font:600 9px ui-monospace,Menlo,monospace} .topodiag .lbl-sm{fill:var(--mut);font:8px ui-monospace,Menlo,monospace}
+ .topodiag .tag{font:700 7.5px ui-monospace,Menlo,monospace} .topodiag .note{fill:var(--mut);font:italic 8px system-ui,sans-serif}
+ .topo.agg .topodiag .gpu{stroke:var(--acc)} .topo.hyb .topodiag .gpu{stroke:var(--warn)} .topo.dis .topodiag .gpu{stroke:var(--ok)}
+ .topo p{margin:6px 0;font-size:12px;color:var(--fg)} .topo .pick{color:var(--mut);font-size:11.5px;margin-top:6px} .topo .pick b{color:var(--fg)} .topo .def code{font-size:11px}
+ .collision{background:#11203a;border:1px solid var(--acc);border-radius:8px;padding:10px;margin:12px 0 0;font-size:12px;line-height:1.5}
+ /* ---- provenance badges (MEASURED / DERIVED / ASSUMED n=1) — shared vocabulary with index.html ---- */
+ .badge{font-size:10px;font-weight:700;padding:1px 6px;border-radius:4px;margin-left:6px;white-space:nowrap;letter-spacing:.02em;vertical-align:1px}
+ .badge.meas{background:#0f2a17;color:#56d364;border:1px solid var(--ok)} .badge.der{background:#10243a;color:#79c0ff;border:1px solid var(--acc)}
+ .badge.asm{background:#2a1e10;color:#e3b341;border:1px dashed var(--warn)} .badge.tiny{font-size:9px;padding:0 4px;margin-left:5px}
+ .provlegend{font-size:11px;color:var(--mut);margin:6px 0 0;display:flex;flex-wrap:wrap;gap:6px;align-items:center}
+ /* ---- provenance / honesty banner under the verdict ---- */
+ .provbar{background:#1d1505;border:1px solid var(--warn);border-left:4px solid var(--warn);border-radius:8px;padding:9px 11px;margin:10px 0 0;font-size:12px;color:var(--fg);line-height:1.5}
+ .provbar b{color:#e3b341} .provbar code{background:#0d1117;padding:1px 5px;border-radius:4px}
+ details.whatis{background:var(--card2);border:1px solid var(--acc);border-radius:8px;margin:10px 0 0;padding:0 12px}
+ details.whatis>summary{cursor:pointer;padding:10px 0;font-weight:600;font-size:13px;color:var(--acc);list-style:none}
+ details.whatis>summary::-webkit-details-marker{display:none}
+ details.whatis>summary::before{content:"▸ ";color:var(--acc)} details.whatis[open]>summary::before{content:"▾ "}
+ details.whatis .wbody{padding:0 0 12px;font-size:12px;color:var(--fg);line-height:1.55}
+ details.whatis .wcol{display:grid;grid-template-columns:1fr 1fr;gap:12px}
+ details.whatis ul{margin:4px 0;padding-left:17px} details.whatis li{margin:3px 0}
+ details.whatis .is h4{color:var(--ok);margin:0 0 3px;font-size:12px} details.whatis .isnt h4{color:var(--bad);margin:0 0 3px;font-size:12px}
+ .chartsum{font-size:11px;color:var(--mut);margin-top:6px;line-height:1.4}
+ /* ---- "Does disaggregation help here?" readout — a SEPARATE axis from the ■◆▲ topology verdict.
+    Topology says WHICH layout; this says whether the agg→disagg SPLIT helps/hurts, per axis. The whole
+    point is to show where it REGRESSES, so that state is the loudest. Meaning is never color-only — the
+    band WORD (HELPS/NO-OP/MIXED/REGRESSES) + a leading glyph + the chip text all carry it. ---- */
+ .dva{border-radius:10px;padding:13px 15px;margin:12px 0 0;border:1px solid var(--line);border-left-width:5px;background:var(--card2)}
+ .dva.helps{border-color:var(--ok);background:#0c1f13} .dva.helps .dva-word{color:var(--ok)}
+ .dva.noop{border-color:var(--mut);background:#161b22} .dva.noop .dva-word{color:var(--mut)}
+ .dva.mixed{border-color:var(--warn);background:#1d1505} .dva.mixed .dva-word{color:var(--warn)}
+ .dva.regresses{border-color:var(--bad);background:#2a1213;box-shadow:inset 0 0 0 1px var(--bad)} .dva.regresses .dva-word{color:var(--bad)}
+ .dva-q{font-size:11px;text-transform:uppercase;letter-spacing:.05em;color:var(--mut);margin-bottom:3px}
+ .dva-word{font-size:23px;font-weight:800;line-height:1.1;letter-spacing:.01em;display:flex;align-items:baseline;gap:9px;flex-wrap:wrap}
+ .dva-word .gly{font-family:ui-monospace,Menlo,monospace;font-size:19px}
+ .dva-word .pct{font-size:12px;font-weight:600;color:var(--mut);letter-spacing:0}
+ .dva-sum{font-size:12.5px;color:var(--fg);margin:7px 0 9px;line-height:1.5}
+ .dva-chips{display:flex;flex-wrap:wrap;gap:8px}
+ .dva-chip{display:flex;align-items:center;gap:7px;background:#0d1117;border:1px solid var(--line);border-radius:7px;padding:5px 10px;font-size:12px}
+ .dva-chip .ax{color:var(--mut);font-weight:600;text-transform:uppercase;font-size:10px;letter-spacing:.03em}
+ .dva-chip .x{font-family:ui-monospace,Menlo,monospace;font-weight:700;color:var(--fg)}
+ .dva-chip .bd{font-size:10px;font-weight:700;padding:1px 6px;border-radius:4px;text-transform:uppercase;letter-spacing:.02em}
+ .dva-chip.helps{border-color:var(--ok)} .dva-chip.helps .bd{background:#0f2a17;color:#56d364} .dva-chip.helps .x{color:#56d364}
+ .dva-chip.regresses{border-color:var(--bad)} .dva-chip.regresses .bd{background:#3a1718;color:#ff7b72} .dva-chip.regresses .x{color:#ff7b72}
+ .dva-chip.noop .bd{background:#21262d;color:var(--mut)}
+ .dva-foot{font-size:11px;color:var(--mut);margin-top:9px;line-height:1.5;border-top:1px solid var(--line);padding-top:8px}
+ .dva-foot b{color:var(--fg)} .dva-foot .anchor{color:#e3b341}
+ /* keyboard focus must be visible on the dark theme (WCAG 2.4.7) */
+ input:focus-visible,select:focus-visible,button:focus-visible,summary:focus-visible,a:focus-visible{outline:2px solid var(--acc);outline-offset:2px}
+ /* ---- mobile: verdict first, single column, no horizontal scroll (~375px standup glance) ---- */
+ @media(max-width:760px){
+   header{padding:14px 16px} h1{font-size:17px} .verdict{font-size:21px}
+   .wrap{grid-template-columns:1fr;gap:14px;padding:14px 16px}
+   .wrap>div:nth-child(2){order:-1}        /* OUTPUT (verdict + chain) above the INPUT controls */
+   .grid2{grid-template-columns:1fr} .ad{grid-template-columns:1fr} details.whatis .wcol{grid-template-columns:1fr}
+   canvas{max-height:300px} .step .f{overflow-wrap:anywhere}
+ }
+</style></head>
+<body>
+<header>
+  <h1>Aggregation vs Disaggregation Calculator</h1>
+  <div class="sub">Work <b>backwards from the model architecture</b> → KV/token → memory fit → prefill/decode rooflines →
+   transfer-toll vs interference → <b>verdict</b> → $/Mtok → optimal operating point.
+   <b class="honest">Disaggregation is not free — it helps for some workloads and regresses for others. This tool tells you which: when it helps, when it&rsquo;s a no-op, and when it costs you (at the 1P:1D floor it&rsquo;s a latency play, not a cost play).</b>
+   Physics mirrors <code>analyze/calc.py</code> + <code>cost.py</code> + <code>optimizer.py</code>, calibrated to measured 550B/p5en.</div>
+</header>
+<div class="wrap">
+  <!-- ============ INPUTS (the architecture) ============ -->
+  <div>
+    <div class="card">
+      <h3>1 · Model architecture</h3>
+      <label for="preset">Preset (from verified HF config.json)</label>
+      <select id="preset"></select>
+      <div class="row">
+        <div><label for="family">family</label><select id="family"><option>dense</option><option>moe</option><option>moe-mla</option><option>hybrid-mamba</option></select></div>
+        <div><label for="wdtype">weight dtype</label><select id="wdtype"><option>bf16</option><option>fp16</option><option>fp8</option><option>fp4</option></select></div>
+      </div>
+      <div class="row">
+        <div><label for="ptot">params TOTAL (B) — fit</label><input id="ptot" type="number" value="550"></div>
+        <div><label for="pact">params ACTIVE (B) — compute</label><input id="pact" type="number" value="55"></div>
+      </div>
+      <div class="row3">
+        <div><label for="layers">layers</label><input id="layers" type="number" value="118"></div>
+        <div><label for="heads">attn heads</label><input id="heads" type="number" value="96"></div>
+        <div><label for="kvheads">KV heads</label><input id="kvheads" type="number" value="8"></div>
+      </div>
+      <div class="row3">
+        <div><label for="hidden">hidden</label><input id="hidden" type="number" value="12288"></div>
+        <div><label for="headdim">head dim</label><input id="headdim" type="number" value="128"></div>
+        <div><label for="maxctx">max ctx</label><input id="maxctx" type="number" value="131072"></div>
+      </div>
+      <div id="mlaBox" style="display:none">
+        <div class="row">
+          <div><label for="lora">kv_lora_rank (MLA)</label><input id="lora" type="number" value="512"></div>
+          <div><label for="rope">qk_rope_dim (MLA)</label><input id="rope" type="number" value="64"></div>
+        </div>
+      </div>
+    </div>
+    <div class="card">
+      <h3>2 · Compute + workload + targets</h3>
+      <label for="inst">AWS instance (8-GPU)</label><select id="inst"></select>
+      <div class="row">
+        <div><label for="tp">tensor-parallel (TP)</label><input id="tp" type="number" value="8"></div>
+        <div><label for="price">$/hr (whole instance, override)</label><input id="price" type="number" placeholder="(AWS list)"></div>
+      </div>
+      <div class="ucwrap">
+        <label for="usecase">Use case <span class="mut">— the workload IS the use case; it sets ISL:OSL, which drives the verdict</span></label>
+        <select id="usecase" class="ucsel"></select>
+        <div id="ucHint" class="uchint"></div>
+      </div>
+      <div class="row">
+        <div><label for="isl">input len (ISL)</label><input id="isl" type="number" value="512" oninput="ucCustom()"></div>
+        <div><label for="osl">output len (OSL)</label><input id="osl" type="number" value="128" oninput="ucCustom()"></div>
+      </div>
+      <div class="row">
+        <div><label for="slottft">SLO TTFT (ms)</label><input id="slottft" type="number" value="2000"></div>
+        <div><label for="slotpot">SLO TPOT/ITL (ms)</label><input id="slotpot" type="number" value="120"></div>
+      </div>
+      <button onclick="run()">Derive ▸</button>
+      <div class="small" id="archline" style="margin-top:8px"></div>
+    </div>
+  </div>
+
+  <!-- ============ OUTPUT: verdict + derivation chain ============ -->
+  <div>
+    <div class="card" style="border-left:3px solid var(--ok)">
+      <div class="mut">Latency verdict for <b id="vmodel"></b> on <b id="vinst"></b> @ ISL <b id="visl"></b>/OSL <b id="vosl"></b></div>
+      <div class="verdict" id="verdict" role="status" aria-live="polite" aria-atomic="true">—</div>
+      <div class="mut" id="why" style="font-size:13px"></div>
+      <div style="margin-top:8px" class="grid2">
+        <div class="kpi"><span class="mut">memory fit <span class="badge der tiny">DERIVED</span></span><b><span id="fitpill" class="pill"></span> <span id="fitnote"></span></b></div>
+        <div class="kpi"><span class="mut">cost — cheaper at SLA <span class="badge asm tiny" title="cost uses the calibrated ITL (n=1 family correction) + 2×-GPU disagg model">ASSUMED n=1</span></span><b id="cheaper"></b></div>
+        <div class="kpi"><span class="mut">favorability (vs chunked-prefill-rescaled thresholds) <span class="badge der tiny">DERIVED</span></span><b id="fav"></b></div>
+        <div class="kpi"><span class="mut">optimal operating point <span class="badge asm tiny" title="goodput knee b=32 + ITL floor 78ms are MEASURED 550B/p5en anchors; off-anchor it is a KV-budget estimate">ASSUMED n=1</span></span><b id="optpt"></b></div>
+      </div>
+      <div class="warnote" id="costwarn"></div>
+      <!-- ===== Does disaggregation HELP here? — a SEPARATE axis from the ■◆▲ topology verdict above.
+           Topology = WHICH layout; this = does the agg→disagg SPLIT help / do nothing / hurt, per axis. ===== -->
+      <div class="dva" id="dva" role="group" aria-labelledby="dvaQ">
+        <div class="dva-q" id="dvaQ">Does disaggregation help here?</div>
+        <div class="dva-word" id="dvaWord">—</div>
+        <div class="dva-sum" id="dvaSum"></div>
+        <div class="dva-chips" id="dvaChips"></div>
+        <div class="dva-foot">
+          Each axis is a speedup = <b>aggregation ÷ disaggregation</b>: <b>&gt;1</b> = disagg is better, <b>&lt;1</b> = disagg <b>regresses</b>, within ±10% = no-op.
+          <span class="anchor">Measured proof both outcomes are real:</span> 550B short-chat <b>regresses on cost ~0.5×</b> (agg won the live A/B 2.1×); a long-context agent workload <b>helps on ITL</b>.
+          At the 1P:1D floor disagg is a <b>latency play, not a cost play</b> — cost tops out ~0.59× (2× GPUs is a hard 2×), TTFT always pays the KV hop, ITL is the win. The cost win needs P:D right-sizing (<code>pd_pool_scaling.py</code>), not this floor — so an <b>overall &ldquo;HELPS&rdquo; is an at-scale / right-sized outcome, not a 1P:1D-floor one</b> (at the floor you trade cost+TTFT for ITL → MIXED).
+        </div>
+      </div>
+      <div class="trustchip"><span class="dot" aria-hidden="true"></span><span>Honest by design — across our 240-cell catalog the verdict splits roughly evenly: <b>~52% disaggregate, ~48% aggregate-or-hybrid</b> (reproduce: <code>tests/catalog_distribution.py</code>). On cost at the 1P:1D floor, disagg almost always regresses — a no-op or a regression is a real result, not a failure.</span></div>
+      <div class="provbar">
+        <b>How to read this:</b> a <b>directional L0 screen</b>, calibrated to a single measured anchor
+        (<b>n=1</b>): Nemotron-3 Ultra 550B, <b>bf16</b>, <b>H200 / p5en</b>, <b>TP8</b>. It models per-request
+        single-stream latency — <b>not</b> a validated multi-tenant simulator. Confirm any verdict with
+        <code>driver/sweep.py</code> on real GPUs before acting.
+        <div class="provlegend">Number provenance:
+          <span class="badge meas tiny">MEASURED</span> real GPU benchmark
+          <span class="badge der tiny">DERIVED</span> computed from your inputs
+          <span class="badge asm tiny">ASSUMED n=1</span> single-anchor calibration / heuristic
+        </div>
+      </div>
+      <details class="whatis">
+        <summary>What this tool is — and what it is not</summary>
+        <div class="wbody">
+          <div class="wcol">
+            <div class="is"><h4>✓ It IS</h4>
+              <ul>
+                <li>A fast, auditable <b>first-pass screen</b> that derives agg / hybrid / disaggregate from the model architecture.</li>
+                <li>Calibrated to <b>real measured anchors</b> (550B/p5en ITL 82ms, KV-over-EFA ~127ms hop).</li>
+                <li>Every term a first-order roofline you can read in the derivation chain below and challenge.</li>
+              </ul>
+            </div>
+            <div class="isnt"><h4>✗ It is NOT</h4>
+              <ul>
+                <li>A <b>benchmark</b> / validated simulator — every "predicted" number is calibrated, not measured.</li>
+                <li>A <b>batched, load-dependent goodput</b> model (queueing, EP all-to-all are out of L0 scope).</li>
+                <li>Generalizable off the anchor without re-calibration — the <b>n=1</b> family correction is honest, not universal.</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </details>
+    </div>
+
+    <!-- ============ TOPOLOGY EXPLAINER: what aggregate / hybrid / disaggregate actually look like ============ -->
+    <div class="card">
+      <h3>What the three verdicts look like</h3>
+      <div class="topolead">Every request has two phases — <b>prefill</b> (read the whole prompt, compute-bound, bursty) and
+        <b>decode</b> (emit one token at a time, memory-bandwidth-bound, steady). The verdict is <i>where you run those two phases relative to each other</i>.</div>
+      <div class="topo3">
+        <div class="topo agg">
+          <h4><span aria-hidden="true">■</span> Aggregate</h4>
+          <svg class="topodiag" viewBox="0 0 260 150" role="img" aria-label="Aggregate topology: one node holding four GPUs. Every GPU runs both prefill and decode for a request, in place. No KV cache is moved between nodes.">
+            <title>Aggregate — prefill and decode co-located on the same GPUs, no KV move</title>
+            <rect class="node" x="14" y="24" width="232" height="92" rx="8"/>
+            <text class="lbl" x="24" y="40">NODE — 1 GPU pool</text>
+            <g>
+              <rect class="gpu" x="24" y="50" width="48" height="50" rx="5"/>
+              <rect class="gpu" x="80" y="50" width="48" height="50" rx="5"/>
+              <rect class="gpu" x="136" y="50" width="48" height="50" rx="5"/>
+              <rect class="gpu" x="192" y="50" width="48" height="50" rx="5"/>
+            </g>
+            <g class="tag" fill="var(--warn)" text-anchor="middle">
+              <text x="48" y="68">prefill</text><text x="104" y="68">prefill</text><text x="160" y="68">prefill</text><text x="216" y="68">prefill</text>
+            </g>
+            <g class="tag" fill="var(--ok)" text-anchor="middle">
+              <text x="48" y="92">decode</text><text x="104" y="92">decode</text><text x="160" y="92">decode</text><text x="216" y="92">decode</text>
+            </g>
+            <text class="note" x="130" y="134" text-anchor="middle">↻ both phases in place — no KV move</text>
+          </svg>
+          <p>Prefill + decode fully co-located on the same GPUs. <b>No KV transfer.</b> A prefill burst <i>can</i> stall the decode stream of co-batched requests.</p>
+          <p class="pick">Picked when: <b>prefill is cheap vs decode</b> (little interference), or the KV toll would cost more than it saves. Cheapest $/token at low–moderate load.</p>
+        </div>
+        <div class="topo hyb">
+          <h4><span aria-hidden="true">◆</span> Hybrid</h4>
+          <svg class="topodiag" viewBox="0 0 260 150" role="img" aria-label="Hybrid topology: one node with shared GPUs, still co-located. Prefill is chopped into small chunks that are interleaved between decode steps on the same GPUs' timeline, so a prefill burst can never monopolize a step. Interference is bounded and there is no cross-node KV hop.">
+            <title>Hybrid — chunked prefill interleaved with decode on the same GPUs, no cross-node hop</title>
+            <rect class="node" x="14" y="22" width="232" height="96" rx="8"/>
+            <text class="lbl" x="24" y="38">NODE — shared GPUs (chunked schedule)</text>
+            <text class="lbl-sm" x="24" y="58">one GPU step timeline ▸</text>
+            <g>
+              <rect class="gpu" x="24"  y="64" width="20" height="26" rx="3" fill="#0f2a17"/>
+              <rect class="gpu" x="76"  y="64" width="20" height="26" rx="3" fill="#0f2a17"/>
+              <rect class="gpu" x="128" y="64" width="20" height="26" rx="3" fill="#0f2a17"/>
+              <rect class="gpu" x="180" y="64" width="20" height="26" rx="3" fill="#0f2a17"/>
+              <rect class="gpu" x="218" y="64" width="20" height="26" rx="3" fill="#0f2a17"/>
+              <rect x="48"  y="68" width="24" height="18" rx="3" fill="#3a2f12" stroke="var(--warn)" stroke-width="1.3"/>
+              <rect x="100" y="68" width="24" height="18" rx="3" fill="#3a2f12" stroke="var(--warn)" stroke-width="1.3"/>
+              <rect x="152" y="68" width="24" height="18" rx="3" fill="#3a2f12" stroke="var(--warn)" stroke-width="1.3"/>
+              <rect x="204" y="68" width="10" height="18" rx="2" fill="#3a2f12" stroke="var(--warn)" stroke-width="1.3"/>
+            </g>
+            <g class="tag" text-anchor="middle">
+              <text x="34" y="81" fill="var(--ok)">d</text><text x="86" y="81" fill="var(--ok)">d</text><text x="138" y="81" fill="var(--ok)">d</text><text x="190" y="81" fill="var(--ok)">d</text><text x="228" y="81" fill="var(--ok)">d</text>
+              <text x="60" y="80" fill="var(--warn)">P</text><text x="112" y="80" fill="var(--warn)">P</text><text x="164" y="80" fill="var(--warn)">P</text>
+            </g>
+            <text class="lbl-sm" x="24" y="104"><tspan fill="var(--ok)">d</tspan> = decode step &#160; <tspan fill="var(--warn)">P</tspan> = prefill chunk (sliced)</text>
+            <text class="note" x="130" y="134" text-anchor="middle">chunked-prefill — bursts can't block decode · no cross-node hop</text>
+          </svg>
+          <p class="def">The <b>middle verdict</b> — hybrid when <code>0.30·(1−cpr) ≤ fav &lt; 0.55·(1−cpr)</code>, i.e. <code>0.090 ≤ fav &lt; 0.165</code> at the default <code>cpr=0.7</code>. Interference is real but a full split isn't justified (KV toll too high, or imbalance only moderate).</p>
+          <p class="def">TaiChi's <b>differentiated P/D</b> regime: prefill is <b>chunked</b> and interleaved with decode on the <b>same</b> GPUs so a burst can't monopolize a step — <b>no cross-node KV hop</b>. Exactly what <code>chunked_prefill_recovery=0.7</code> models.</p>
+          <p class="pick">Picked when: <b>in between</b> — enough interference to want separation, but not enough (or too high a KV toll) for a full split.</p>
+        </div>
+        <div class="topo dis">
+          <h4><span aria-hidden="true">▲</span> Disaggregate</h4>
+          <svg class="topodiag" viewBox="0 0 260 150" role="img" aria-label="Disaggregate topology: two separate nodes. A prefill pool on the left and a decode pool on the right, each with its own GPUs. The KV cache is shipped from the prefill pool to the decode pool over EFA / NIXL RDMA. Decode never sees a prefill burst.">
+            <title>Disaggregate — separate prefill and decode pools, KV cache shipped over EFA / NIXL RDMA</title>
+            <rect class="node" x="10" y="34" width="96" height="78" rx="8"/>
+            <text class="lbl" x="20" y="50" fill="var(--warn)">PREFILL pool</text>
+            <rect class="gpu" x="20" y="58" width="36" height="44" rx="5"/>
+            <rect class="gpu" x="62" y="58" width="36" height="44" rx="5"/>
+            <text class="tag" x="38" y="84" fill="var(--warn)" text-anchor="middle">P</text>
+            <text class="tag" x="80" y="84" fill="var(--warn)" text-anchor="middle">P</text>
+            <rect class="node" x="154" y="34" width="96" height="78" rx="8"/>
+            <text class="lbl" x="164" y="50" fill="var(--ok)">DECODE pool</text>
+            <rect class="gpu" x="164" y="58" width="36" height="44" rx="5"/>
+            <rect class="gpu" x="206" y="58" width="36" height="44" rx="5"/>
+            <text class="tag" x="182" y="84" fill="var(--ok)" text-anchor="middle">d</text>
+            <text class="tag" x="224" y="84" fill="var(--ok)" text-anchor="middle">d</text>
+            <defs><marker id="kvarrow2" markerWidth="9" markerHeight="9" refX="6" refY="3" orient="auto"><path d="M0,0 L7,3 L0,6 Z" fill="var(--ok)"/></marker></defs>
+            <line x1="106" y1="72" x2="150" y2="72" stroke="var(--ok)" stroke-width="2.4" marker-end="url(#kvarrow2)"/>
+            <text class="tag" x="130" y="66" fill="var(--ok)" text-anchor="middle" font-size="8">KV cache</text>
+            <text class="lbl-sm" x="130" y="88" text-anchor="middle">EFA / NIXL</text>
+            <text class="lbl-sm" x="130" y="98" text-anchor="middle">RDMA</text>
+            <text class="note" x="130" y="134" text-anchor="middle">separate nodes — decode never sees a prefill burst</text>
+          </svg>
+          <p>Separate prefill + decode pools; the KV cache is <b>shipped over EFA / NIXL RDMA</b>. Decode never sees a prefill burst → clean, steady latency.</p>
+          <p class="pick">Picked when: <b>prefill bursts would stall many decode steps</b> (high interference) <b>and</b> KV transfer is cheap. Wins on SLO-attainment / tail latency, and on $/token at scale.</p>
+        </div>
+      </div>
+      <div class="collision">
+        <b>⚠ One word, two meanings — don't confuse them.</b> “Hybrid” above is a <b>serving topology</b> (the middle verdict).
+        Separately, <b>“hybrid-Mamba”</b> is a <b>model architecture</b> (e.g. Nemotron-3 Ultra 550B — attention + Mamba layers),
+        selectable in the <i>family</i> dropdown. They are unrelated: a hybrid-Mamba <i>model</i> can be served with an
+        aggregate, hybrid, <i>or</i> disaggregate <i>topology</i>.
+      </div>
+    </div>
+
+    <div class="card"><h3>The derivation — backwards from architecture</h3>
+      <div id="chain"></div>
+    </div>
+
+    <div class="grid2">
+      <div class="card"><h3>Favorability vs context (ISL sweep)</h3><canvas id="cFav" role="img" aria-label="Disaggregation favorability vs input length"></canvas>
+        <div class="chartsum" id="cFav_sum" role="note"></div>
+        <div class="small">Disagg-favored where the curve crosses the (chunked-prefill-rescaled) disagg threshold. Non-monotonic: drops again at extreme prefill+short output (KV toll un-amortized).</div></div>
+      <div class="card"><h3>Cost vs concurrency — find the knee</h3><canvas id="cKnee" role="img" aria-label="Cost per Mtok vs concurrency"></canvas>
+        <div class="chartsum" id="cKnee_sum" role="note"></div>
+        <div class="small">$/Mtok falls until the goodput knee (KV-budget / batch ceiling), then flat. Past it, TTFT explodes for no throughput gain.</div></div>
+    </div>
+
+    <div class="card"><h3>Where does disaggregation flip? — help/regress vs context (ISL sweep)</h3>
+      <canvas id="cDva" role="img" aria-label="Disaggregation cost, TTFT and ITL speedup versus aggregation as input length grows. Three lines on a y-axis of speedup ratio, with a parity reference line at 1.0 and a shaded plus or minus ten percent no-op band. Where each line crosses 1.0 is where that axis flips between disaggregation helping and regressing."></canvas>
+      <div class="chartsum" id="cDva_sum" role="note"></div>
+      <div class="small">Speedup = aggregation ÷ disaggregation per axis (current model/instance/OSL, ISL swept). Above the dashed <b>1.0</b> line = disagg <b>helps</b>; inside the shaded ±10% band = <b>no-op</b>; below = disagg <b>regresses</b>. <b>ITL</b> (green) is the axis disagg buys as prefill grows; <b>cost</b> (blue) and <b>TTFT</b> (amber) sit below 1.0 — the 2×-GPU and KV-hop tolls that no ISL repays at the 1P:1D floor.</div></div>
+  </div>
+</div>
+
+<script>
+// ============================ physics constants (mirror analyze/) ============================
+const INSTANCES = {
+ "p5.48xlarge":     {gpu:"H100", gpus:8, hbm_GBs:3350, hbm_cap_GB:80,  fp16_TFLOPs:989,  efa_nics:32, efa_Gbps:100, nvlink_GBs:900},
+ "p5en.48xlarge":   {gpu:"H200", gpus:8, hbm_GBs:4800, hbm_cap_GB:141, fp16_TFLOPs:989,  efa_nics:16, efa_Gbps:200, nvlink_GBs:900},
+ "p6-b200.48xlarge":{gpu:"B200", gpus:8, hbm_GBs:8000, hbm_cap_GB:180, fp16_TFLOPs:2250, efa_nics:8,  efa_Gbps:400, nvlink_GBs:1800},
+ "p4d.24xlarge":    {gpu:"A100", gpus:8, hbm_GBs:2039, hbm_cap_GB:40,  fp16_TFLOPs:312,  efa_nics:4,  efa_Gbps:100, nvlink_GBs:600},
+};
+const PRICE = {"p5.48xlarge":55.04,"p5en.48xlarge":63.296,"p4d.24xlarge":21.9576,"p6-b200.48xlarge":113.9328}; // AWS, 2026-06-14
+const DB  = {fp16:2,bf16:2,fp8:1,fp4:0.5,int8:1};
+const CAL = {kv_transfer_efficiency:0.0095, mfu_prefill:0.45, mbu_decode:0.65, UTIL_CEILING:0.98};
+const DTYPE_PEAK_MULT={fp16:1.0,bf16:1.0,fp8:2.0,int8:2.0,fp4:4.0};
+const DECISION={interference_scale:4.0,toll_scale:4.0,threshold_disagg:0.55,threshold_hybrid:0.30,chunked_prefill_recovery:0.7};
+// measured calibration correction factors (median measured/predicted from analyze/calibration.py ledger)
+const ITL_CORRECTION={"hybrid-mamba":18.636,"dense":0.887,"moe":1.0,"moe-mla":1.0}; // measured medians from analyze/calibration.py ledger (dense from live 70B A/B; moe/mla unmeasured=1.0)
+// optimizer.py measured anchors (550B/p5en): ITL floor + goodput knee + CUDA-graph-OOM + disagg penalties
+const ANCHOR = {itl0_ms:78.0, b_knee:32.0, tput_sat_tok_s:292.0, tp8_cudagraph_oom:true,
+                disagg_ttft_penalty_ms:127.0, disagg_tput_factor:0.95};
+// arch params VERIFIED from each HF config.json (2026-06-14)
+const PRESETS = {
+ "Nemotron-3 Ultra 550B (hybrid-Mamba)":{family:"hybrid-mamba",ptot:550,pact:55,layers:108,n_attn_layers:12,n_mamba_layers:48,heads:64,kvheads:2,hidden:8192,headdim:128,wdtype:"bf16",maxctx:262144,tp:8,isl:512,osl:128,mamba_num_heads:256,mamba_head_dim:64,mamba_d_state:128,mamba_d_conv:4,mamba_cache_dtype:"fp32"},
+ "Llama-3.1-8B (dense)":   {family:"dense",ptot:8,  pact:8,  layers:32, heads:32, kvheads:8, hidden:4096, headdim:128,wdtype:"bf16",maxctx:131072,tp:1,isl:512,osl:128},
+ "Llama-3.1-70B (dense)":  {family:"dense",ptot:70, pact:70, layers:80, heads:64, kvheads:8, hidden:8192, headdim:128,wdtype:"bf16",maxctx:131072,tp:8,isl:512,osl:128},
+ "Qwen2.5-72B (dense)":    {family:"dense",ptot:72, pact:72, layers:80, heads:64, kvheads:8, hidden:8192, headdim:128,wdtype:"bf16",maxctx:131072,tp:8,isl:512,osl:128},
+ "Llama-3.1-405B (dense)": {family:"dense",ptot:405,pact:405,layers:126,heads:128,kvheads:8, hidden:16384,headdim:128,wdtype:"bf16",maxctx:131072,tp:8,isl:512,osl:128},
+ "Mixtral-8x22B (MoE)":    {family:"moe",  ptot:141,pact:39, layers:56, heads:48, kvheads:8, hidden:6144, headdim:128,wdtype:"bf16",maxctx:65536, tp:8,isl:512,osl:128},
+ "Qwen3-235B-A22B (MoE)":  {family:"moe",  ptot:235,pact:22, layers:94, heads:64, kvheads:4, hidden:4096, headdim:128,wdtype:"bf16",maxctx:32768, tp:8,isl:512,osl:128},
+ "DeepSeek-V3 (MoE+MLA)":  {family:"moe-mla",ptot:671,pact:37,layers:61,heads:128,kvheads:128,hidden:7168,headdim:56, wdtype:"fp8", maxctx:163840,tp:8,isl:512,osl:128,lora:512,rope:64},
+};
+// ---- USE CASES: the workload IS the use case. ISL:OSL ratio drives the verdict, so we make it pickable. ----
+// lean = which topology the ISL:OSL pressure points toward (the model still computes the real verdict).
+const USECASES={
+ "🤖 Agent / tool-use (long context, short actions)":{isl:8192,osl:128,lean:"dis",
+   note:"Agents accumulate a big, growing context (history+tools+RAG) but each step emits a short action/tool-call. Huge prefill, tiny decode → heavy prefill interference → disaggregation territory."},
+ "📚 RAG / Q&A (retrieved docs in, short answer)":{isl:4096,osl:256,lean:"dis",
+   note:"Several retrieved chunks go in; a concise grounded answer comes out. Big prefill, modest decode → disaggregation usually wins (especially at scale)."},
+ "📝 Summarization (long doc in, short summary)":{isl:8192,osl:256,lean:"dis",
+   note:"Long document in, short summary out. Very prefill-heavy → disaggregation-favored, but watch the TTFT budget (a huge prompt + KV transfer can blow it)."},
+ "💬 Chat / assistant (short turn, medium reply)":{isl:512,osl:256,lean:"hyb",
+   note:"Balanced conversational turn. Middle of the road — often hybrid, and aggregation is cheapest at low–moderate load."},
+ "🧠 Reasoning / chain-of-thought (short Q, long answer)":{isl:512,osl:2048,lean:"agg",
+   note:"Short question, long generated reasoning. Decode dominates, prefill is tiny → little interference to remove → aggregate."},
+ "🧑‍💻 Code generation (medium prompt, long code)":{isl:1024,osl:1024,lean:"hyb",
+   note:"Medium prompt, long code output. Roughly balanced → hybrid/aggregate; verdict shifts with model + GPU."},
+ "✍️ Custom (set ISL/OSL by hand)":{isl:null,osl:null,lean:null,
+   note:"Enter your own input/output lengths above."},
+};
+
+// ============================ the model (faithful to calc.py) ============================
+function kvBytesPerToken(m){            // ATTENTION KV/token — GQA-aware, MLA-branched — calc.py:kv_bytes_per_token
+ const db = DB[m.kv_dtype||m.wdtype]||2;
+ if(m.family==="moe-mla") return (m.lora + m.rope) * m.layers * db;     // compressed latent, NOT full heads
+ const hd = m.headdim || m.hidden/Math.max(m.heads,1);
+ // attention KV scales with the ATTENTION layers only (hybrid-Mamba: n_attn_layers << layers)
+ const attn = m.n_attn_layers!=null ? m.n_attn_layers : m.layers;
+ return 2 * m.kvheads * hd * attn * db;
+}
+function mambaStateBytes(m){            // constant Mamba-2 SSM+conv state per request — calc.py:mamba_state_bytes
+ if(m.family!=="hybrid-mamba") return 0;
+ const nm = m.n_mamba_layers||0;
+ const cdb = DB[m.mamba_cache_dtype||"fp32"]||4;
+ if(m.mamba_num_heads && m.mamba_head_dim && nm){
+   const ssm  = m.mamba_num_heads*m.mamba_head_dim*(m.mamba_d_state||128)*cdb;
+   const conv = m.mamba_num_heads*m.mamba_head_dim*(m.mamba_d_conv||4)*cdb;
+   return (ssm+conv)*nm;
+ }
+ return 0;
+}
+function derive(g, m, wl){            // faithful JS port of calc.py:analyze()
+ const tp = m.tp, pp = m.pp||1, gpus_in_group = tp*pp, isl = wl.isl, osl = wl.osl;
+ const pAct = m.pact, pTot = m.ptot, wdb = DB[m.wdtype]||2;
+ const n_attn = m.n_attn_layers!=null ? m.n_attn_layers : m.layers;
+ // (A) KV per request: ATTENTION KV (grows with ISL) + constant Mamba SSM state (if hybrid-mamba)
+ const kv_bpt = kvBytesPerToken(m);
+ const attn_kv_bytes = kv_bpt * isl;
+ const mamba_bytes = mambaStateBytes(m);
+ const kv_bytes_req = attn_kv_bytes + mamba_bytes;     // total bytes disagg must ship prefill->decode
+ const kv_MB = kv_bytes_req/1e6;
+ const attn_MB = attn_kv_bytes/1e6, mamba_MB = mamba_bytes/1e6;
+ // (B) fabric + KV-transfer time (disagg only pays this) — fabric_aggregate default; uses TOTAL kv bytes
+ const line_GBs = g.efa_nics * g.efa_Gbps / 8.0;
+ const achieved_GBs = Math.max(line_GBs * CAL.kv_transfer_efficiency, 1.0);
+ const kv_transfer_ms = (kv_bytes_req/1e9)/achieved_GBs*1000.0;
+ // (C) prefill compute (ACTIVE params): linear GEMM term + quadratic attention term, dtype-peak-scaled
+ const flops_prefill_linear = 2*pAct*1e9*isl;
+ const flops_prefill_attn   = 4.0*(isl*isl)*m.hidden*n_attn;
+ const flops_prefill = flops_prefill_linear + flops_prefill_attn;
+ // ARCH GATE (live-corrected 2026-06-19): fp4 4x is Blackwell-only (native FP4 GEMM). On Hopper/Ampere an
+ // NVFP4 ckpt runs via Marlin W4A16 (dequant→bf16 compute) => peak ~1x, NOT 4x. fp8 native sm89+ (Hopper/Blackwell).
+ const _bw = (g.gpu==="B200"||g.gpu==="B100"||g.gpu==="GB200");
+ const _hop = _bw || g.gpu==="H100" || g.gpu==="H200";
+ const _raw = DTYPE_PEAK_MULT[m.wdtype]||1.0;
+ const dtype_peak_mult = (m.wdtype==="fp4" && !_bw) ? 1.0
+                       : ((m.wdtype==="fp8"||m.wdtype==="int8") && !_hop) ? 1.0 : _raw;
+ const compute_GFLOPs = g.fp16_TFLOPs*dtype_peak_mult*1e3*tp*CAL.mfu_prefill;
+ const prefill_ms = flops_prefill/(compute_GFLOPs*1e9)*1000.0;
+ const prefill_attn_quadratic_frac = flops_prefill_attn/Math.max(flops_prefill,1e-9);
+ // (D) decode per-token (ACTIVE params + KV-read so far, HBM-bound), then CALIBRATION correction
+ const param_bytes = pAct*1e9*wdb;
+ const avg_ctx = isl + osl/2.0;
+ const kv_read = kv_bpt * avg_ctx;                               // attention KV re-read each decode step (avg)
+ const hbm_GBs = g.hbm_GBs*tp*CAL.mbu_decode;
+ const itl_roofline = (param_bytes+kv_read)/1e9/hbm_GBs*1000.0;
+ const corr = ITL_CORRECTION[m.family]||1.0;                     // measured-anchor correction (calibration.py)
+ const decode_step_ms = itl_roofline*corr;                       // CALIBRATION WIRED IN
+ // (E) MEMORY FIT (TOTAL params vs aggregate HBM capacity)
+ const weights_GB = pTot*wdb, hbm_cap = g.hbm_cap_GB, total_hbm_GB = gpus_in_group*hbm_cap;
+ const min_util = weights_GB/Math.max(total_hbm_GB,1e-9);
+ const kv_budget_GB = total_hbm_GB*CAL.UTIL_CEILING - weights_GB;
+ const fits = kv_budget_GB>0.5, tight = fits && min_util>0.90;
+ const fit_status = !fits?"no-fit":(tight?"tight":"fits");
+ const min_gpus_to_fit = Math.ceil(weights_GB/Math.max(hbm_cap*0.85,1e-9));
+ const max_kv_tokens = (fits&&kv_bpt>0)? kv_budget_GB*1e9/kv_bpt : 0;
+ const conc_at_wl = max_kv_tokens/Math.max(isl+osl,1);
+ // (F) decision: interference removed (favors disagg) vs transfer toll added; chunked-prefill discounts interference
+ const cpr = (wl.chunked_prefill_recovery!=null)?wl.chunked_prefill_recovery:DECISION.chunked_prefill_recovery;
+ const decode_phase_ms = decode_step_ms*osl;
+ const transfer_overhead_frac = kv_transfer_ms/Math.max(decode_phase_ms,1e-6);
+ const imbalance = prefill_ms/Math.max(decode_step_ms,1e-6);
+ const interference_raw = 1.0 - Math.exp(-imbalance/DECISION.interference_scale);
+ const interference = interference_raw*(1.0-cpr);
+ const toll = 1.0/(1.0+transfer_overhead_frac*DECISION.toll_scale);
+ const fav = toll*interference;
+ // thresholds rescaled onto the capped [0, 1-cpr] interference axis (preserves verdict shape)
+ const thr_disagg = DECISION.threshold_disagg*(1.0-cpr);
+ const thr_hybrid = DECISION.threshold_hybrid*(1.0-cpr);
+ let verdict,why;
+ if(fav>=thr_disagg){verdict="disaggregate";why="cheap KV transfer; prefill bursts would stall many decode steps under aggregation (high TPOT-interference, even after chunked-prefill).";}
+ else if(fav>=thr_hybrid){verdict="hybrid";why="non-trivial interference but transfer/imbalance moderate — TaiChi hybrid (differentiated P/D instances) likely best.";}
+ else{verdict="aggregate";why="prefill is cheap relative to decode (low interference, incl. chunked-prefill) and/or KV-transfer toll high — colocate.";}
+ // (F2) SLO gate (mirror calc.py): the verdict above is latency-physics-only. Respect the TTFT budget — if
+ // shipping the KV would eat >50% of it, disagg is not viable regardless of favorability. Also surface when
+ // prefill+transfer blows TTFT or predicted ITL blows TPOT (any topology).
+ const verdict_pre_slo = verdict; const slo_notes=[]; let disagg_slo_viable=true;
+ if(wl.slo_ttft_ms!=null){
+   if(prefill_ms+kv_transfer_ms > wl.slo_ttft_ms){disagg_slo_viable=false; slo_notes.push("prefill+transfer "+(prefill_ms+kv_transfer_ms).toFixed(0)+"ms exceeds TTFT budget "+wl.slo_ttft_ms.toFixed(0)+"ms — disagg can't meet the TTFT SLO");}
+ }
+ if(wl.slo_tpot_ms!=null && decode_step_ms > wl.slo_tpot_ms) slo_notes.push("predicted ITL "+decode_step_ms.toFixed(0)+"ms exceeds TPOT budget "+wl.slo_tpot_ms.toFixed(0)+"ms (model/hardware too slow at this op-point)");
+ if(verdict==="disaggregate" && !disagg_slo_viable){verdict="aggregate"; why="favorability prefers disagg, but KV transfer would breach the TTFT SLO — colocate (no transfer hop).";}
+ // (G) cost (cost.py): est tok/s/gpu uses the CALIBRATED ITL; agg uses tp GPUs, disagg 2·tp with interference uplift
+ const itl = decode_step_ms;        // calibrated ITL (measured-corrected) — used by cost/throughput panel
+ const itl_floor = decode_step_ms;  // kept for archline display (now the calibrated value)
+ const est_tok_s_gpu = (1000.0/Math.max(itl,1e-6))*0.90;
+ const gpu_hr = (wl.price||PRICE[wl.instName])/8.0;
+ const aggTps = est_tok_s_gpu*tp, aggGpu = gpus_in_group;
+ const aggCost = (gpu_hr*aggGpu)/(Math.max(aggTps,1e-9)*3600.0)*1e6;
+ const uplift = 1.0/Math.max(1.0-0.5*interference, 0.3), disGpu = gpus_in_group*2, disTps = est_tok_s_gpu*tp*uplift;
+ const disCost = (gpu_hr*disGpu)/(Math.max(disTps,1e-9)*3600.0)*1e6;
+ const cheaper = disCost<aggCost?"disaggregate":"aggregate";
+ const savings = aggCost? (aggCost-disCost)/aggCost*100 : 0;
+ // (H) optimal operating point (optimizer.py): knee = min(KV-budget conc, b_knee) ; ITL uses measured floor
+ const knee = Math.max(1, Math.min(Math.round(conc_at_wl), ANCHOR.b_knee));
+ // (I) DOES DISAGGREGATION HELP HERE? — per-axis speedup = aggregation/disaggregation (>1 disagg BETTER,
+ //     <1 disagg REGRESSES). Bit-identical to calc.py:analyze() disagg_vs_agg block. Reuses the already-
+ //     computed interference / prefill_ms / kv_transfer_ms — adds NOTHING to the physics, only reads it.
+ const DISAGG_BAND = 0.10;                                       // ±10% around parity = NO-OP (within n=1 noise)
+ const _band = sp => sp >= 1.0+DISAGG_BAND ? "helps" : (sp <= 1.0-DISAGG_BAND ? "regresses" : "no-op");
+ const dva_itl  = 1.0 + interference;                            // agg ITL inflated by co-batch stall; disagg removes it
+ const dva_ttft = prefill_ms / Math.max(prefill_ms + kv_transfer_ms, 1e-9);  // disagg adds KV hop to first-token path
+ const cost_uplift = 1.0 / Math.max(1.0 - 0.5*interference, 0.3);            // cost.py decode-goodput uplift
+ const dva_cost = cost_uplift / 2.0;                            // 1P:1D floor: uplift vs 2× GPUs (price-independent)
+ const dva_bands = {cost: _band(dva_cost), ttft: _band(dva_ttft), itl: _band(dva_itl)};
+ const _b = [dva_bands.cost, dva_bands.ttft, dva_bands.itl];
+ let dva_overall, dva_summary;
+ const _ax = {cost_per_token:{sp:dva_cost,band:dva_bands.cost}, ttft:{sp:dva_ttft,band:dva_bands.ttft}, itl:{sp:dva_itl,band:dva_bands.itl}};
+ const _list = sep => Object.entries(_ax).map(([k,v])=>`${k} ${v.sp.toFixed(3)}x`).join(sep);
+ if(_b.includes("regresses") && !_b.includes("helps")){
+   dva_overall="regresses"; dva_summary="disaggregation REGRESSES here vs aggregation — "+_list(", ");
+ } else if(_b.includes("helps") && !_b.includes("regresses")){
+   dva_overall="helps"; dva_summary="disaggregation HELPS here vs aggregation — "+_list(", ");
+ } else if(_b.includes("helps") && _b.includes("regresses")){
+   dva_overall="mixed";
+   dva_summary="MIXED: disagg helps on "+Object.entries(_ax).filter(([k,v])=>v.band==="helps").map(([k])=>k).join("/")
+     +" but regresses on "+Object.entries(_ax).filter(([k,v])=>v.band==="regresses").map(([k])=>k).join("/")
+     +" — pick on your priority axis (cost vs latency)";
+ } else {
+   dva_overall="no-op";
+   dva_summary="disaggregation is roughly a NO-OP here (within ±"+Math.round(DISAGG_BAND*100)+"% of aggregation on every axis) — the split's cost ≈ its benefit; stay aggregated for simplicity";
+ }
+ return {kv_bpt,kv_MB,attn_MB,mamba_MB,line_GBs,achieved_GBs,kv_transfer_ms,
+   dva_cost,dva_ttft,dva_itl,dva_overall,dva_summary,dva_bands,dva_band_pct:Math.round(DISAGG_BAND*100),
+   prefill_ms,prefill_attn_quadratic_frac,dtype_peak_mult,
+   itl_roofline,corr,decode_step_ms,itl,decode_phase_ms,avg_ctx,
+   weights_GB,total_hbm_GB,min_util,kv_budget_GB,fits,tight,fit_status,min_gpus_to_fit,max_kv_tokens,conc_at_wl,
+   cpr,transfer_overhead_frac,imbalance,interference,interference_raw,toll,fav,thr_disagg,thr_hybrid,verdict,why,
+   verdict_pre_slo,disagg_slo_viable,slo_notes,
+   aggTps,aggGpu,aggCost,disTps,disGpu,disCost,cheaper,savings,uplift,knee,gpu_hr,itl_floor,est_tok_s_gpu};
+}
+
+// ============================ UI ============================
+function fillSelects(){
+ const p=document.getElementById('preset'); Object.keys(PRESETS).forEach(k=>p.add(new Option(k,k)));
+ const i=document.getElementById('inst'); Object.keys(INSTANCES).forEach(k=>i.add(new Option(k,k))); i.value="p5en.48xlarge";
+ const uc=document.getElementById('usecase'); Object.keys(USECASES).forEach(k=>uc.add(new Option(k,k)));
+ uc.value="💬 Chat / assistant (short turn, medium reply)";
+ uc.onchange=()=>{const x=USECASES[uc.value];if(!x)return;if(x.isl!=null){document.getElementById('isl').value=x.isl;document.getElementById('osl').value=x.osl;}showUcHint();run();};
+ p.onchange=loadPreset; loadPreset();
+}
+// reflect the current ISL/OSL onto the use-case dropdown: match a known use case or show Custom
+function syncUseCase(){
+ const uc=document.getElementById('usecase'); if(!uc)return;
+ const isl=+document.getElementById('isl').value, osl=+document.getElementById('osl').value;
+ let match="✍️ Custom (set ISL/OSL by hand)";
+ for(const[k,v]of Object.entries(USECASES))if(v.isl===isl&&v.osl===osl){match=k;break;}
+ if(uc.value!==match)uc.value=match; showUcHint();
+}
+function ucCustom(){ const uc=document.getElementById('usecase'); if(uc)uc.value="✍️ Custom (set ISL/OSL by hand)"; showUcHint(); }
+function showUcHint(){
+ const uc=document.getElementById('usecase'); if(!uc)return;
+ const x=USECASES[uc.value], el=document.getElementById('ucHint');
+ if(!el)return; el.innerHTML = x&&x.note ? x.note : "";
+}
+// fields with no form input (attention/mamba split + Mamba SSM geometry) are carried from the active preset.
+// stored per family so a user manually flipping `family` away doesn't drag stale mamba fields onto another model.
+let _presetExtra={family:null, n_attn_layers:null, n_mamba_layers:null,
+  mamba_num_heads:null, mamba_head_dim:null, mamba_d_state:null, mamba_d_conv:null, mamba_cache_dtype:null};
+function loadPreset(){
+ const x=PRESETS[document.getElementById('preset').value]; if(!x)return;
+ for(const id of ["ptot","pact","layers","heads","kvheads","hidden","headdim","maxctx","tp","isl","osl"]) document.getElementById(id).value=x[id];
+ document.getElementById('wdtype').value=x.wdtype; document.getElementById('family').value=x.family;
+ if(x.family==="moe-mla"){document.getElementById('lora').value=x.lora; document.getElementById('rope').value=x.rope;}
+ document.getElementById('mlaBox').style.display = x.family==="moe-mla"?"block":"none";
+ _presetExtra={family:x.family, n_attn_layers:x.n_attn_layers??null, n_mamba_layers:x.n_mamba_layers??null,
+   mamba_num_heads:x.mamba_num_heads??null, mamba_head_dim:x.mamba_head_dim??null,
+   mamba_d_state:x.mamba_d_state??null, mamba_d_conv:x.mamba_d_conv??null, mamba_cache_dtype:x.mamba_cache_dtype??null};
+ run();
+}
+document.addEventListener('change',e=>{ if(e.target.id==='family') document.getElementById('mlaBox').style.display=e.target.value==="moe-mla"?"block":"none"; });
+
+function readModel(){
+ const f=document.getElementById('family').value;
+ const m={family:f, ptot:+ptot.value, pact:+pact.value, layers:+layers.value, heads:+heads.value, kvheads:+kvheads.value,
+   hidden:+hidden.value, headdim:+headdim.value, wdtype:wdtype.value, maxctx:+maxctx.value, tp:+tp.value,
+   lora:+ (document.getElementById('lora')?.value||512), rope:+ (document.getElementById('rope')?.value||64)};
+ // carry the attention/mamba split + Mamba geometry from the active preset (no form inputs for these),
+ // but only while the form family still matches the preset's family (else they don't apply to this arch).
+ if(_presetExtra && _presetExtra.family===f){
+   if(_presetExtra.n_attn_layers!=null)  m.n_attn_layers=_presetExtra.n_attn_layers;
+   if(_presetExtra.n_mamba_layers!=null) m.n_mamba_layers=_presetExtra.n_mamba_layers;
+   for(const k of ["mamba_num_heads","mamba_head_dim","mamba_d_state","mamba_d_conv","mamba_cache_dtype"])
+     if(_presetExtra[k]!=null) m[k]=_presetExtra[k];
+ }
+ return m;
+}
+const fmt=(v,d=1)=> (v>=1000?Math.round(v).toLocaleString():(+v).toFixed(d));
+function step(n,t,f,body){return `<div class="step"><div><span class="n">${n}</span><span class="t">${t}</span></div><div class="f">${f}</div><div class="v">${body}</div></div>`;}
+function ad(aH,aV,dH,dV){return `<div class="ad"><div class="agg"><div class="h">${aH}</div>${aV}</div><div class="dis"><div class="h">${dH}</div>${dV}</div></div>`;}
+
+let charts={};
+// a11y: write a one-line text summary under a chart (screen-reader / no-canvas fallback).
+// pure DOM text write; touches no physics. no-op if the element is absent.
+function _sum(id,txt){ const el=document.getElementById(id); if(el) el.textContent=txt; }
+function run(){
+ syncUseCase();   // keep the use-case dropdown + hint in sync with whatever ISL/OSL currently are
+ const g=INSTANCES[document.getElementById('inst').value]; const m=readModel();
+ const slottft=+document.getElementById('slottft').value, slotpot=+document.getElementById('slotpot').value;
+ const wl={isl:+isl.value, osl:+osl.value, instName:document.getElementById('inst').value, price:parseFloat(price.value)||null,
+           slo_ttft_ms: slottft>0?slottft:null, slo_tpot_ms: slotpot>0?slotpot:null};   // SLO gate now feeds the verdict
+ const r=derive(g,m,wl);
+ const instName=wl.instName;
+
+ // header
+ document.getElementById('vmodel').textContent=(document.getElementById('preset').value)+" ("+m.family+")";
+ document.getElementById('vinst').textContent=instName+" ("+g.gpu+", TP"+m.tp+")";
+ visl.textContent=wl.isl; vosl.textContent=wl.osl;
+ const vEl=document.getElementById('verdict'); vEl.textContent=r.verdict.toUpperCase(); vEl.className="verdict "+r.verdict;
+ document.getElementById('why').textContent=r.why;
+ const fp=document.getElementById('fitpill'); fp.textContent=r.fit_status; fp.className="pill "+(r.fit_status==="no-fit"?"nofit":r.fit_status);
+ document.getElementById('fitnote').textContent = r.fits? `KV budget ${fmt(r.kv_budget_GB)}GB · ~${fmt(r.conc_at_wl,0)} concurrent` : `need ≥${r.min_gpus_to_fit*g.gpus} GPUs / quantize`;
+ const ch=document.getElementById('cheaper'); ch.textContent=r.cheaper.toUpperCase()+" ("+(r.savings>=0?"+":"")+fmt(r.savings,0)+"%)"; ch.className=r.cheaper;
+ document.getElementById('fav').textContent=fmt(r.fav,3)+"  (toll "+fmt(r.toll,2)+" × interf "+fmt(r.interference,2)+" · disagg ≥"+fmt(r.thr_disagg,2)+" hybrid ≥"+fmt(r.thr_hybrid,2)+")";
+ document.getElementById('optpt').textContent = r.fits? ("concurrency ≈ "+r.knee+(r.knee>=ANCHOR.b_knee?" (measured knee)":" (KV-budget cap)")) : "n/a (doesn't fit)";
+ document.getElementById('costwarn').textContent = (r.cheaper!==r.verdict)
+   ? "⚠ Latency favors "+r.verdict.toUpperCase()+" but cost favors "+r.cheaper.toUpperCase()+" — disagg buys TTFT/SLA-attainment; agg buys $/token. Choose on your priority."
+   : "Latency and cost agree on "+r.cheaper.toUpperCase()+".";
+ document.getElementById('archline').innerHTML = `KV/req = <b>${fmt(r.kv_MB,1)} MB</b> <span class="badge der tiny">DERIVED</span> · weights = <b>${fmt(r.weights_GB,0)} GB</b> <span class="badge der tiny">DERIVED</span> · ITL ≈ <b>${fmt(r.decode_step_ms,1)} ms</b> <span class="small">(roofline ${fmt(r.itl_roofline,1)} × measured ${fmt(r.corr,1)}×)</span> <span class="badge asm tiny" title="roofline (DERIVED) × measured family correction (ASSUMED n=1)">ASSUMED n=1</span>`;
+
+ // ---- the derivation chain (backwards from architecture) ----
+ const mla = m.family==="moe-mla";
+ const isMamba = m.family==="hybrid-mamba";
+ const nAttn = m.n_attn_layers!=null ? m.n_attn_layers : m.layers;
+ let H="";
+ H+=step(1,"KV cache per token","memory the model must hold/ship per token (ATTENTION layers only)",
+   mla ? `MLA (compressed latent): (lora ${m.lora} + rope ${m.rope}) × layers ${m.layers} × ${DB[m.wdtype]}B = <b>${fmt(r.kv_bpt,0)} B/token</b> <span class="small">(naive GQA would be ${fmt(2*m.kvheads*m.headdim*m.layers*DB[m.wdtype],0)} B — MLA avoids that)</span>`
+       : `GQA: 2 × kv_heads ${m.kvheads} × head_dim ${m.headdim} × <b>attn-layers ${nAttn}</b>${isMamba?` <span class="small">(of ${m.layers} total — Mamba layers carry no growing KV)</span>`:` (= layers)`} × ${DB[m.wdtype]}B = <b>${fmt(r.kv_bpt,0)} B/token</b>`);
+ H+=step(2,"KV cache per request","attention KV (grows with ISL)"+(isMamba?" + constant Mamba SSM state":""),
+   isMamba
+     ? `attention KV = ${fmt(r.kv_bpt,0)} B × ${wl.isl} = <b>${fmt(r.attn_MB,1)} MB</b> + Mamba state = <b>${fmt(r.mamba_MB,1)} MB</b> <span class="small">(${m.n_mamba_layers||0} mamba layers × ${m.mamba_num_heads}×${m.mamba_head_dim}×(d_state ${m.mamba_d_state||128}+d_conv ${m.mamba_d_conv||4}) ${m.mamba_cache_dtype||"fp32"}, ISL-independent)</span> = <b>${fmt(r.kv_MB,1)} MB/request</b>`
+     : `${fmt(r.kv_bpt,0)} B × ${wl.isl} = <b>${fmt(r.kv_MB,1)} MB/request</b>`);
+ H+=step(3,"Memory fit — the gate","TOTAL weights vs aggregate HBM (= the KV budget = concurrency ceiling)",
+   `weights = ${m.ptot}B × ${DB[m.wdtype]}B = <b>${fmt(r.weights_GB,0)} GB</b> vs ${m.tp*(m.pp||1)}×${g.hbm_cap_GB} = <b>${fmt(r.total_hbm_GB,0)} GB</b>${(m.pp||1)>1?` (tp${m.tp}/pp${m.pp})`:''} → util-for-weights <b>${fmt(r.min_util*100,1)}%</b> → KV budget <b>${fmt(r.kv_budget_GB,0)} GB</b> → <span class="pill ${r.fit_status==='no-fit'?'nofit':r.fit_status}">${r.fit_status}</span>`);
+ H+=step(4,"Prefill compute time","(2 × P_active × ISL linear + 4 × ISL² × hidden × attn-layers quadratic) ÷ (TP × peak×dtype-mult × MFU 0.45) — same on agg & disagg",
+   `linear 2 × ${m.pact}B × ${wl.isl} + quadratic O(ISL²) attn (×${nAttn} layers, <b>${fmt(r.prefill_attn_quadratic_frac*100,1)}%</b> of FLOPs) ÷ (${m.tp} × ${fmt(g.fp16_TFLOPs,0)}T<b>×${fmt(r.dtype_peak_mult,0)}</b> ${m.wdtype} peak × 0.45) = <b>${fmt(r.prefill_ms,1)} ms</b>`);
+ H+=step(5,"Decode per-token (ITL = roofline × measured correction)","read P_active + KV-so-far from HBM ÷ (TP × HBM-BW × MBU 0.65), then × measured calibration factor",
+   `roofline = (${m.pact}B × ${DB[m.wdtype]}B + KV-read @ ctx ${fmt(r.avg_ctx,0)}) ÷ (${m.tp} × ${fmt(g.hbm_GBs,0)} × 0.65) = <b>${fmt(r.itl_roofline,2)} ms</b> × measured correction <b>${fmt(r.corr,2)}×</b>${r.corr>1?` <span class="small">(family '${m.family}' calibration ledger — eager/conc-1 penalty)</span>`:``} = <b>${fmt(r.decode_step_ms,2)} ms/token</b> → decode phase ${fmt(r.decode_phase_ms,0)} ms`);
+ H+=step(6,"Where agg & disagg DIVERGE","disagg ships the KV over the fabric; agg co-locates (no transfer)",
+   ad("AGGREGATION", `<div class="kpi"><span>KV transfer</span><b>none (co-located)</b></div><div class="kpi"><span>cost: interference toll</span><b>prefill stalls decode</b></div>`,
+      "DISAGGREGATION", `<div class="kpi"><span>KV transfer</span><b>${fmt(r.kv_transfer_ms,1)} ms</b></div><div class="kpi"><span>@ ${fmt(r.achieved_GBs,1)} GB/s</span><b>(0.013×line ${fmt(r.line_GBs,0)})</b></div>`));
+ H+=step(7,"Interference removed vs transfer toll added","TaiChi: disagg removes the prefill→decode interference (less chunked-prefill recovery) but pays the KV toll",
+   `imbalance = prefill ÷ ITL = ${fmt(r.imbalance,1)} → raw interference = 1−e^(−imb/4) = ${fmt(r.interference_raw,3)} × (1−chunked-prefill recovery ${fmt(r.cpr,2)}) = <b>${fmt(r.interference,3)}</b><br>`+
+   `transfer toll frac = xfer ÷ decode-phase = ${fmt(r.transfer_overhead_frac,3)} → toll = 1/(1+frac×4) = <b>${fmt(r.toll,3)}</b>`);
+ H+=step(8,"Favorability → verdict","fav = toll × interference, vs thresholds RESCALED by (1−chunked-prefill recovery) onto the capped interference axis",
+   `${fmt(r.toll,3)} × ${fmt(r.interference,3)} = <b style="font-size:18px" class="${r.verdict}">${fmt(r.fav,3)} → ${r.verdict.toUpperCase()}</b> <span class="small">(disagg ≥ ${fmt(r.thr_disagg,3)} · hybrid ≥ ${fmt(r.thr_hybrid,3)} — base 0.55/0.30 × (1−${fmt(r.cpr,2)}))</span>`);
+ H+=step(9,"Cost $/Mtok (work-back to $)","(per-GPU $/hr × GPUs) ÷ (tok/s × 3600) × 1e6 · disagg = 2×GPUs, interference uplift",
+   ad("AGGREGATION ("+r.aggGpu+" GPU)", `<div class="kpi"><span>~tok/s</span><b>${fmt(r.aggTps,0)}</b></div><div class="kpi"><span>$/Mtok</span><b>$${fmt(r.aggCost,2)}</b></div>`,
+      "DISAGGREGATION ("+r.disGpu+" GPU)", `<div class="kpi"><span>~tok/s (×${fmt(r.uplift,2)} uplift)</span><b>${fmt(r.disTps,0)}</b></div><div class="kpi"><span>$/Mtok</span><b>$${fmt(r.disCost,2)}</b></div>`));
+ document.getElementById('chain').innerHTML=H;
+
+ // ---- chart 1: favorability vs ISL (context sweep) ----
+ const isls=[256,512,1024,2048,4096,8192,16384];
+ const favs=isls.map(s=>derive(g,m,{...wl,isl:s}).fav);
+ if(charts.cFav)charts.cFav.destroy();
+ charts.cFav=new Chart(document.getElementById('cFav'),{type:'line',data:{labels:isls,datasets:[{label:'favorability',data:favs,borderColor:'#3fb950',tension:.3,pointRadius:3}]},
+   options:{plugins:{legend:{display:false},annotation:false},scales:{x:{title:{display:true,text:'ISL (OSL fixed)',color:'#8b949e'},ticks:{color:'#8b949e'}},y:{min:0,max:1,ticks:{color:'#8b949e'},grid:{color:'#21262d'}}}}});
+ _sum('cFav_sum','Favorability (0–1) as input length grows '+isls[0]+'→'+isls[isls.length-1]+' tokens (OSL fixed): '+favs.map(x=>x.toFixed(2)).join(' → ')+'. Disaggregate ≥ '+fmt(r.thr_disagg,2)+', hybrid ≥ '+fmt(r.thr_hybrid,2)+'. Non-monotonic — can dip at extreme prefill + short output.');
+
+ // ---- chart 2: cost vs concurrency knee (optimizer-style) ----
+ const concs=[1,2,4,8,16,32,64,128];
+ const kneeC=r.knee;
+ const cost_at=concs.map(c=>{const eff=Math.min(c,kneeC); const tps=r.est_tok_s_gpu*m.tp*eff/Math.max(kneeC,1)* (eff>=kneeC?kneeC: eff)/Math.max(eff,1); // simple ramp to knee then flat
+   const realTps=r.aggTps*Math.min(c,kneeC)/Math.max(kneeC,1)* (kneeC); return (r.gpu_hr*m.tp)/(Math.max(r.aggTps*Math.min(c,kneeC)/1,1e-9)*3600)*1e6;});
+ // simpler + faithful: throughput grows ∝ min(c,knee); $/Mtok = fixed cost / throughput
+ const cmtok=concs.map(c=>{const tp_eff=Math.min(c,kneeC); const tps=r.est_tok_s_gpu*m.tp*tp_eff; return (r.gpu_hr*m.tp)/(Math.max(tps,1e-9)*3600)*1e6;});
+ if(charts.cKnee)charts.cKnee.destroy();
+ charts.cKnee=new Chart(document.getElementById('cKnee'),{type:'line',data:{labels:concs,datasets:[{label:'$/Mtok (agg)',data:cmtok,borderColor:'#58a6ff',tension:.3,pointRadius:3}]},
+   options:{plugins:{legend:{display:false}},scales:{x:{type:'logarithmic',title:{display:true,text:'concurrency (knee ≈ '+kneeC+')',color:'#8b949e'},ticks:{color:'#8b949e'}},y:{title:{display:true,text:'$/Mtok',color:'#8b949e'},ticks:{color:'#8b949e'},grid:{color:'#21262d'}}}}});
+ _sum('cKnee_sum','Aggregation $/Mtok over concurrency '+concs[0]+'→'+concs[concs.length-1]+' (knee ≈ '+kneeC+'): '+cmtok.map(x=>'$'+fmt(x,0)).join(' → ')+'. Falls to the knee, then flat.');
+
+ // ---- "Does disaggregation help here?" banner (reads r.dva_* — bit-identical to calc.py disagg_vs_agg) ----
+ renderDva(r);
+ // ---- chart 3: where does disagg flip? cost/TTFT/ITL speedup vs ISL, parity line @1.0 + ±10% band ----
+ const dIsls=[256,512,1024,2048,4096,8192,16384,32768];
+ const dRows=dIsls.map(s=>derive(g,m,{...wl,isl:s}));
+ const dCost=dRows.map(x=>x.dva_cost), dTtft=dRows.map(x=>x.dva_ttft), dItl=dRows.map(x=>x.dva_itl);
+ const band=r.dva_band_pct/100, lo=1-band, hi=1+band;
+ const allv=dCost.concat(dTtft,dItl,[1]); const yMax=Math.max(hi+0.05, Math.max(...allv)*1.08), yMin=Math.min(lo-0.05, Math.min(...allv)*0.92);
+ // parity 1.0 line + shaded no-op band as filled datasets behind the 3 axis lines
+ const flat=(v)=>dIsls.map(()=>v);
+ if(charts.cDva)charts.cDva.destroy();
+ charts.cDva=new Chart(document.getElementById('cDva'),{type:'line',
+   data:{labels:dIsls,datasets:[
+     {label:'no-op band +10%',data:flat(hi),borderColor:'rgba(139,148,158,.35)',borderWidth:1,borderDash:[2,3],pointRadius:0,fill:'+1',backgroundColor:'rgba(139,148,158,.12)',order:9},
+     {label:'no-op band −10%',data:flat(lo),borderColor:'rgba(139,148,158,.35)',borderWidth:1,borderDash:[2,3],pointRadius:0,fill:false,order:9},
+     {label:'parity (1.0)',data:flat(1),borderColor:'#8b949e',borderWidth:1.5,borderDash:[6,4],pointRadius:0,order:8},
+     {label:'Cost (÷2× GPUs)',data:dCost,borderColor:'#58a6ff',backgroundColor:'#58a6ff',tension:.25,pointRadius:2,order:1},
+     {label:'TTFT (+KV hop)',data:dTtft,borderColor:'#d29922',backgroundColor:'#d29922',tension:.25,pointRadius:2,order:1},
+     {label:'ITL (−interference)',data:dItl,borderColor:'#3fb950',backgroundColor:'#3fb950',tension:.25,pointRadius:2,borderWidth:2.4,order:0}]},
+   options:{responsive:true,interaction:{mode:'index',intersect:false},
+     plugins:{legend:{labels:{color:'#8b949e',boxWidth:12,filter:i=>!i.text.startsWith('no-op band')}},
+       tooltip:{callbacks:{label:c=>c.dataset.label+': '+(+c.parsed.y).toFixed(3)+'× '+(c.parsed.y>=hi?'(helps)':c.parsed.y<=lo?'(regresses)':'(no-op)')}}},
+     scales:{x:{type:'logarithmic',title:{display:true,text:'ISL — input length (OSL fixed)',color:'#8b949e'},ticks:{color:'#8b949e'}},
+       y:{min:yMin,max:yMax,title:{display:true,text:'speedup  (agg ÷ disagg) — >1 disagg better',color:'#8b949e'},ticks:{color:'#8b949e'},grid:{color:'#21262d'}}}}});
+ // text/crossover fallback: report where each axis crosses 1.0 across the swept ISLs
+ const cross=(arr)=>{for(let i=1;i<arr.length;i++){if((arr[i-1]-1)*(arr[i]-1)<0)return 'crosses 1.0 between ISL '+dIsls[i-1]+' and '+dIsls[i];}return (arr[arr.length-1]>=1?'stays ≥1 (helps) across the sweep':'stays <1 (regresses) across the sweep');};
+ _sum('cDva_sum','Disagg-vs-agg speedup as ISL grows '+dIsls[0]+'→'+dIsls[dIsls.length-1]+' (OSL '+wl.osl+'): '+
+   'Cost '+dCost[0].toFixed(2)+'→'+dCost[dCost.length-1].toFixed(2)+'× ('+cross(dCost)+'); '+
+   'TTFT '+dTtft[0].toFixed(2)+'→'+dTtft[dTtft.length-1].toFixed(2)+'× ('+cross(dTtft)+'); '+
+   'ITL '+dItl[0].toFixed(2)+'→'+dItl[dItl.length-1].toFixed(2)+'× ('+cross(dItl)+'). '+
+   'Above 1.0 = disagg helps, below = disagg regresses, ±10% band = no-op.');
+}
+// populate the help/regress banner from a derive() result (pure DOM; physics already done in derive)
+function renderDva(r){
+ const box=document.getElementById('dva'); if(!box)return;
+ box.className='dva '+(r.dva_overall==='no-op'?'noop':r.dva_overall);
+ const word={helps:'HELPS',regresses:'REGRESSES','no-op':'NO-OP',mixed:'MIXED'}[r.dva_overall]||'—';
+ const gly={helps:'▲',regresses:'▼','no-op':'＝',mixed:'◆'}[r.dva_overall]||'';
+ document.getElementById('dvaWord').innerHTML='<span class="gly" aria-hidden="true">'+gly+'</span><span>'+word+'</span><span class="pct">disaggregation vs aggregation, here</span>';
+ document.getElementById('dvaSum').textContent=r.dva_summary;
+ const chip=(ax,sp,bd)=>'<span class="dva-chip '+(bd==='no-op'?'noop':bd)+'"><span class="ax">'+ax+'</span><span class="x">'+fmt(sp,2)+'×</span><span class="bd">'+bd+'</span></span>';
+ document.getElementById('dvaChips').innerHTML=
+   chip('Cost',r.dva_cost,r.dva_bands.cost)+chip('TTFT',r.dva_ttft,r.dva_bands.ttft)+chip('ITL',r.dva_itl,r.dva_bands.itl);
+}
+fillSelects();
+</script>
+</body></html>

--- a/Container-Root/eks/deployment/inference/agentic-ai/disagg-calculator/web/calculator.html
+++ b/Container-Root/eks/deployment/inference/agentic-ai/disagg-calculator/web/calculator.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<!-- Author: Anton Alexander | Source: github.com/dmvevents/dynamo-disagg-optimizer · live: dmvevents.github.io/dynamo-disagg-optimizer/calculator.html -->
+<!-- Author: Anton Alexander -->
 <html lang="en">
 <head>
 <meta charset="utf-8"/>

--- a/Container-Root/eks/deployment/inference/agentic-ai/disagg-calculator/web/calculator.html
+++ b/Container-Root/eks/deployment/inference/agentic-ai/disagg-calculator/web/calculator.html
@@ -5,12 +5,26 @@
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>Agg-vs-Disagg Calculator — work backwards from the model architecture</title>
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 16 16%27%3E%3Crect width=%2716%27 height=%2716%27 rx=%273%27 fill=%27%230d1117%27/%3E%3Crect x=%273%27 y=%279%27 width=%273%27 height=%274%27 fill=%27%2358a6ff%27/%3E%3Crect x=%277%27 y=%276%27 width=%273%27 height=%277%27 fill=%27%23d29922%27/%3E%3Crect x=%2711%27 y=%273%27 width=%273%27 height=%2710%27 fill=%27%233fb950%27/%3E%3C/svg%3E">
 <!-- Self-contained. NO API keys. Physics is a faithful JS port of analyze/calc.py + cost.py + optimizer.py
      (calibrated to MEASURED Nemotron-3 Ultra 550B / p5en anchors). Chart.js (CDN) for the two charts only. -->
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
 <style>
  :root{--bg:#0d1117;--card:#161b22;--card2:#1c2230;--fg:#e6edf3;--mut:#8b949e;--acc:#58a6ff;--ok:#3fb950;--warn:#d29922;--bad:#f85149;--line:#30363d}
  *{box-sizing:border-box} body{margin:0;background:var(--bg);color:var(--fg);font:14px/1.5 system-ui,Segoe UI,Roboto,sans-serif}
+ .disclaimer{margin:10px 24px 0;padding:9px 13px;border:1px solid #c89b3c;border-left:4px solid #c89b3c;background:#2a2410;color:#e8d9a0;border-radius:6px;font-size:12px;line-height:1.5}
+ .disclaimer b{color:#f0c552}
+ .glossary{margin:8px 24px 0;font-size:12px;color:var(--mut)} .glossary summary{cursor:pointer;color:var(--acc)}
+ .gloss-grid{display:grid;grid-template-columns:1fr 1fr;gap:3px 24px;margin-top:6px} .gloss-grid b{color:var(--fg)}
+ @media(max-width:760px){.gloss-grid{grid-template-columns:1fr}}
+ @media print{
+   :root{--bg:#fff;--card:#fff;--card2:#fff;--fg:#111;--mut:#444}
+   body{background:#fff;color:#111}
+   details{display:block!important} details>summary{font-weight:600}
+   .disclaimer{border:1px solid #b8860b;background:#fff8e6;color:#5a4500;-webkit-print-color-adjust:exact;print-color-adjust:exact}
+   button{display:none} .card,.step{border:1px solid #ccc;break-inside:avoid}
+ }
+ @media(prefers-reduced-motion:reduce){*{animation-duration:.001ms!important;transition-duration:.001ms!important}}  /* WCAG 2.3.3 */
  header{padding:16px 24px;border-bottom:1px solid var(--line)} h1{margin:0;font-size:19px} .sub{color:var(--mut);font-size:13px;margin-top:4px}
  .sub .honest{color:var(--fg)}                          /* the agg-vs-disagg honesty line reads as a feature, not a footnote (mirrors index.html) */
  .wrap{display:grid;grid-template-columns:340px 1fr;gap:18px;padding:18px 24px;align-items:start}
@@ -27,7 +41,7 @@
  .ad{display:grid;grid-template-columns:1fr 1fr;gap:10px;margin-top:6px}
  .ad>div{background:var(--card2);border-radius:6px;padding:8px 10px} .ad .h{font-size:11px;text-transform:uppercase;letter-spacing:.04em;color:var(--mut)}
  .agg .h{color:var(--acc)} .dis .h{color:var(--ok)}
- .verdict{font-size:24px;font-weight:800;margin:2px 0} .disaggregate{color:var(--ok)} .hybrid{color:var(--warn)} .aggregate{color:var(--acc)}
+ .verdict{font-size:28px;font-weight:800;margin:2px 0;letter-spacing:-.3px} .disaggregate{color:var(--ok)} .hybrid{color:var(--warn)} .aggregate{color:var(--acc)}
  /* verdict carries a SHAPE prefix too (CSS ::before keyed on the verdict class the JS sets) — meaning is
     never color-only, so it passes a11y / colorblind. Pure presentation; no JS change. */
  .verdict::before{font-family:ui-monospace,Menlo,monospace;margin-right:9px;font-size:19px;vertical-align:1px}
@@ -116,13 +130,17 @@
    transfer-toll vs interference → <b>verdict</b> → $/Mtok → optimal operating point.
    <b class="honest">Disaggregation is not free — it helps for some workloads and regresses for others. This tool tells you which: when it helps, when it&rsquo;s a no-op, and when it costs you (at the 1P:1D floor it&rsquo;s a latency play, not a cost play).</b>
    Physics mirrors <code>analyze/calc.py</code> + <code>cost.py</code> + <code>optimizer.py</code>, calibrated to measured 550B/p5en.</div>
-  <div style="margin:10px 0;padding:8px 12px;border:1px solid #c89b3c;background:#2a2410;color:#e8d9a0;border-radius:6px;font-size:12px;line-height:1.45">
-    <b>Disclaimer.</b> Provided free of charge, as a utility, for quick <b>estimation and planning only</b>. AWS and the
-    authors make <b>no representation, warranty, or guarantee</b> of model performance, throughput, latency, or cost, and
-    <b>accept no liability</b> for any outcome arising from its use. Actual measured results will differ from the
-    calculated numbers — always validate on your own hardware with your own workload before deployment or purchasing
-    decisions. Provided <b>&ldquo;AS IS&rdquo;</b>.
-  </div>
+  <div class="disclaimer" role="note" aria-label="Disclaimer"><b>⚠ Disclaimer:</b> Provided free, as a utility, for quick <b>estimation and planning only</b>. AWS and the authors make <b>no representation, warranty, or guarantee</b> of model performance, throughput, latency, or cost, and <b>accept no liability</b> for any outcome of its use. Actual measured results will differ — always validate on your own hardware before deployment or purchasing decisions. Provided <b>&ldquo;AS IS&rdquo;</b>.</div>
+  <details class="glossary"><summary>Glossary — terms used below</summary>
+    <div class="gloss-grid">
+      <span><b>ISL</b> input seq length (prompt tokens)</span><span><b>OSL</b> output seq length (generated tokens)</span>
+      <span><b>KV</b> key/value attention cache</span><span><b>HBM</b> GPU high-bandwidth memory</span>
+      <span><b>TTFT</b> time to first token</span><span><b>ITL/TPOT</b> inter-token latency / time per output token</span>
+      <span><b>SLO/SLA</b> latency target / service-level agreement</span><span><b>TP/PP</b> tensor / pipeline parallelism</span>
+      <span><b>1P:1D</b> 1 prefill : 1 decode worker</span><span><b>MFU/MBU</b> model-FLOP / memory-bandwidth utilization</span>
+      <span><b>RDMA</b> remote direct memory access (EFA)</span><span><b>$/Mtok</b> cost per 1M output tokens</span>
+    </div>
+  </details>
 </header>
 <div class="wrap">
   <!-- ============ INPUTS (the architecture) ============ -->
@@ -356,6 +374,8 @@
 </div>
 
 <script>
+// a11y (WCAG 2.3.3): respect prefers-reduced-motion — disable Chart.js animation for motion-sensitive users.
+try{ if(window.Chart && window.matchMedia && matchMedia('(prefers-reduced-motion: reduce)').matches){ Chart.defaults.animation=false; } }catch(e){}
 // ============================ physics constants (mirror analyze/) ============================
 const INSTANCES = {
  "p5.48xlarge":     {gpu:"H100", gpus:8, hbm_GBs:3350, hbm_cap_GB:80,  fp16_TFLOPs:989,  efa_nics:32, efa_Gbps:100, nvlink_GBs:900},

--- a/Container-Root/eks/deployment/inference/agentic-ai/disagg-calculator/web/index.html
+++ b/Container-Root/eks/deployment/inference/agentic-ai/disagg-calculator/web/index.html
@@ -1,0 +1,934 @@
+<!DOCTYPE html>
+<!-- Author: Anton Alexander | Source: github.com/dmvevents/dynamo-disagg-optimizer · live: dmvevents.github.io/dynamo-disagg-optimizer/calculator.html -->
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Aggregation vs Disaggregation Optimizer — should you split prefill/decode?</title>
+<!-- Self-contained client-side tool. NO API keys here. Mirrors analyze/calc.py physics in JS.
+     Chart.js from CDN (charts only); the optional visual-LLM verdict is a server-side step (analyze/visual_verdict.py). -->
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+<style>
+ :root{--bg:#0d1117;--card:#161b22;--fg:#e6edf3;--mut:#8b949e;--acc:#58a6ff;--ok:#3fb950;--warn:#d29922;--bad:#f85149}
+ *{box-sizing:border-box} body{margin:0;background:var(--bg);color:var(--fg);font:14px/1.5 system-ui,Segoe UI,Roboto,sans-serif}
+ header{padding:18px 24px;border-bottom:1px solid #30363d} h1{margin:0;font-size:19px} .sub{color:var(--mut);font-size:13px;margin-top:4px}
+ h1 .brand{color:var(--mut);font-weight:400}            /* decision leads; the descriptor rides along, de-emphasized */
+ .sub .honest{color:var(--fg)}                          /* the agg-vs-disagg honesty line reads as a feature, not a footnote */
+ .wrap{display:grid;grid-template-columns:330px 1fr;gap:20px;padding:20px 24px}
+ .card{background:var(--card);border:1px solid #30363d;border-radius:10px;padding:16px}
+ /* ---- mobile: verdict first, single column, no horizontal scroll (the standup-glance case ~375px) ---- */
+ @media(max-width:760px){
+   header{padding:14px 16px} h1{font-size:17px}
+   .explain{padding:6px 16px 0} .wrap{grid-template-columns:1fr;gap:14px;padding:14px 16px}
+   .wrap>div:nth-child(2){order:-1}     /* OUTPUT (verdict) column above the INPUT column */
+   .grid{grid-template-columns:1fr}      /* charts + KPI stack */
+   canvas{max-height:300px}
+   table.sens{display:block;overflow-x:auto}   /* sensitivity tables scroll, page doesn't */
+ }
+ label{display:block;color:var(--mut);font-size:12px;margin:10px 0 3px} input,select{width:100%;background:#0d1117;color:var(--fg);border:1px solid #30363d;border-radius:6px;padding:7px}
+ .row{display:grid;grid-template-columns:1fr 1fr;gap:10px} button{margin-top:14px;width:100%;background:var(--acc);color:#06121f;border:0;border-radius:6px;padding:10px;font-weight:600;cursor:pointer}
+ .verdict{font-size:22px;font-weight:700;margin:4px 0} .verdict.disaggregate{color:var(--ok)} .verdict.hybrid{color:var(--warn)} .verdict.aggregate{color:var(--acc)}
+ /* verdict carries a SHAPE prefix too (CSS ::before keyed on the verdict class the JS sets), so the
+    meaning is never color-only — passes a11y / colorblind. Pure presentation; no JS change. */
+ .verdict::before{font-family:ui-monospace,Menlo,monospace;margin-right:9px;font-size:18px;vertical-align:1px}
+ .verdict.disaggregate::before{content:"▲"} .verdict.hybrid::before{content:"◆"} .verdict.aggregate::before{content:"■"}
+ .grid{display:grid;grid-template-columns:1fr 1fr;gap:16px} .kpi{display:flex;justify-content:space-between;border-bottom:1px solid #21262d;padding:5px 0;gap:8px}
+ .kpi b{color:var(--fg)} .mut{color:var(--mut)} canvas{max-height:240px} .why{color:var(--mut);font-size:13px;margin-top:6px}
+ .chartsum{font-size:11.5px;color:var(--mut);margin-top:6px;line-height:1.4}
+ /* ---- "Does disaggregation help here?" readout — a SEPARATE axis from the ■◆▲ topology verdict.
+    Topology = WHICH layout; this = does the agg→disagg SPLIT help/hurt, per axis. REGRESSES is the loudest
+    state (the user's whole point). Never color-only — band WORD + glyph + chip text all carry meaning. ---- */
+ .dva{border-radius:10px;padding:13px 15px;margin:12px 0 0;border:1px solid #30363d;border-left-width:5px;background:#0d1117}
+ .dva.helps{border-color:var(--ok);background:#0c1f13} .dva.helps .dva-word{color:var(--ok)}
+ .dva.noop{border-color:var(--mut);background:#161b22} .dva.noop .dva-word{color:var(--mut)}
+ .dva.mixed{border-color:var(--warn);background:#1d1505} .dva.mixed .dva-word{color:var(--warn)}
+ .dva.regresses{border-color:var(--bad);background:#2a1213;box-shadow:inset 0 0 0 1px var(--bad)} .dva.regresses .dva-word{color:var(--bad)}
+ .dva-q{font-size:11px;text-transform:uppercase;letter-spacing:.05em;color:var(--mut);margin-bottom:3px}
+ .dva-word{font-size:22px;font-weight:800;line-height:1.1;display:flex;align-items:baseline;gap:9px;flex-wrap:wrap}
+ .dva-word .gly{font-family:ui-monospace,Menlo,monospace;font-size:18px}
+ .dva-word .pct{font-size:12px;font-weight:600;color:var(--mut)}
+ .dva-sum{font-size:12.5px;color:var(--fg);margin:7px 0 9px;line-height:1.5}
+ .dva-chips{display:flex;flex-wrap:wrap;gap:8px}
+ .dva-chip{display:flex;align-items:center;gap:7px;background:#161b22;border:1px solid #30363d;border-radius:7px;padding:5px 10px;font-size:12px}
+ .dva-chip .ax{color:var(--mut);font-weight:600;text-transform:uppercase;font-size:10px;letter-spacing:.03em}
+ .dva-chip .x{font-family:ui-monospace,Menlo,monospace;font-weight:700;color:var(--fg)}
+ .dva-chip .bd{font-size:10px;font-weight:700;padding:1px 6px;border-radius:4px;text-transform:uppercase;letter-spacing:.02em}
+ .dva-chip.helps{border-color:var(--ok)} .dva-chip.helps .bd{background:#0f2a17;color:#56d364} .dva-chip.helps .x{color:#56d364}
+ .dva-chip.regresses{border-color:var(--bad)} .dva-chip.regresses .bd{background:#3a1718;color:#ff7b72} .dva-chip.regresses .x{color:#ff7b72}
+ .dva-chip.noop .bd{background:#21262d;color:var(--mut)}
+ .dva-foot{font-size:11px;color:var(--mut);margin-top:9px;line-height:1.5;border-top:1px solid #30363d;padding-top:8px}
+ .dva-foot b{color:var(--fg)} .dva-foot .anchor{color:#e3b341}
+ /* keyboard focus must be visible on the dark theme (WCAG 2.4.7) */
+ input:focus-visible,select:focus-visible,button:focus-visible,summary:focus-visible,a:focus-visible{outline:2px solid var(--acc);outline-offset:2px}
+ .cav{font-size:12px;color:var(--warn);margin-top:8px} code{background:#0d1117;padding:1px 5px;border-radius:4px}
+ .opt-best{border:1px solid var(--ok);background:#0f2a17;border-radius:8px;padding:12px}
+ .opt-none{border:1px solid var(--bad);background:#2a1213;border-radius:8px;padding:12px;color:var(--fg)}
+ .opt-best .lead{font-size:18px;font-weight:700;color:var(--ok);margin-bottom:6px}
+ .opt-none .lead{font-size:16px;font-weight:700;color:var(--bad);margin-bottom:6px}
+ .opt-best .chips{display:flex;flex-wrap:wrap;gap:6px;margin-top:8px}
+ .chip{background:#0d1117;border:1px solid #30363d;border-radius:5px;padding:3px 8px;font-size:12px;color:var(--fg)}
+ .chip .k{color:var(--mut)}
+ table.sens{width:100%;border-collapse:collapse;font-size:12px;margin-top:4px}
+ table.sens th,table.sens td{text-align:right;padding:4px 8px;border-bottom:1px solid #21262d}
+ table.sens th:first-child,table.sens td:first-child{text-align:left;color:var(--mut)}
+ table.sens th{color:var(--mut);font-weight:600} table.sens td.optcell{color:var(--ok);font-weight:700}
+ table.sens caption{caption-side:top;text-align:left;color:var(--fg);font-size:12px;padding:6px 0 2px}
+ /* ---- explainer section ---- */
+ .explain{padding:6px 24px 0;max-width:1200px}
+ .explain h2{font-size:16px;margin:16px 0 3px} .explain .lead2{color:var(--mut);font-size:13px;margin-bottom:12px}
+ .topo3{display:grid;grid-template-columns:repeat(3,1fr);gap:14px}
+ @media(max-width:900px){.topo3{grid-template-columns:1fr}}
+ .topo{background:var(--card);border:1px solid #30363d;border-radius:10px;padding:14px;border-top:3px solid #30363d}
+ .topo.agg{border-top-color:var(--acc)} .topo.hyb{border-top-color:var(--warn)} .topo.dis{border-top-color:var(--ok)}
+ .topo h3{margin:0 0 4px;font-size:15px} .topo.agg h3{color:var(--acc)} .topo.hyb h3{color:var(--warn)} .topo.dis h3{color:var(--ok)}
+ /* ---- inline SVG topology diagrams (replace the cramped ASCII .diag blocks) ---- */
+ .topo svg.topodiag{display:block;width:100%;max-width:100%;height:auto;background:#0d1117;border:1px solid #21262d;border-radius:6px;margin:8px 0}
+ .topodiag .node{fill:#0d1117;stroke:#30363d;stroke-width:1.5}
+ .topodiag .gpu{fill:#161b22;stroke-width:1.4} .topodiag .lbl{fill:var(--fg);font:600 9px ui-monospace,Menlo,monospace} .topodiag .lbl-sm{fill:var(--mut);font:8px ui-monospace,Menlo,monospace}
+ .topodiag .tag{font:700 7.5px ui-monospace,Menlo,monospace} .topodiag .note{fill:var(--mut);font:italic 8px system-ui,sans-serif}
+ .topo.agg .topodiag .gpu{stroke:var(--acc)} .topo.hyb .topodiag .gpu{stroke:var(--warn)} .topo.dis .topodiag .gpu{stroke:var(--ok)}
+ .topo p{margin:6px 0;font-size:12.5px;color:var(--fg)} .topo .pick{color:var(--mut);font-size:12px;margin-top:8px} .topo .pick b{color:var(--fg)}
+ .topo .def{font-size:12.5px;color:var(--fg);margin:6px 0} .topo .def code{font-size:11.5px}
+ details.exp{background:var(--card);border:1px solid #30363d;border-radius:10px;padding:0 14px;margin-top:12px;max-width:1200px}
+ details.exp>summary{cursor:pointer;padding:13px 0;font-weight:600;font-size:14px;color:var(--fg);list-style:none}
+ details.exp>summary::-webkit-details-marker{display:none}
+ details.exp>summary::before{content:"▸ ";color:var(--acc)} details.exp[open]>summary::before{content:"▾ "}
+ details.exp .ebody{padding:0 0 14px;font-size:13px;color:var(--fg)}
+ .ex{border-left:3px solid #30363d;padding:5px 0 5px 12px;margin:12px 0}
+ .ex.dis{border-left-color:var(--ok)} .ex.agg{border-left-color:var(--acc)} .ex.hyb{border-left-color:var(--warn)}
+ .ex .h{font-weight:600;margin-bottom:2px} .ex .d{color:var(--mut)}
+ .badge{font-size:10px;font-weight:700;padding:1px 6px;border-radius:4px;margin-left:6px;white-space:nowrap;letter-spacing:.02em}
+ .badge.meas{background:#0f2a17;color:#56d364;border:1px solid var(--ok)} .badge.pred{background:#2a2410;color:#e3b341;border:1px solid var(--warn)}
+ /* third provenance tier — DERIVED (computed from inputs) and ASSUMED (n=1 anchor / heuristic) */
+ .badge.der{background:#10243a;color:#79c0ff;border:1px solid var(--acc)} .badge.asm{background:#2a1e10;color:#e3b341;border:1px dashed var(--warn)}
+ .badge.tiny{font-size:9px;padding:0 4px;margin-left:5px}
+ /* legend chip row */
+ .provlegend{font-size:11px;color:var(--mut);margin:8px 0 0;display:flex;flex-wrap:wrap;gap:6px;align-items:center}
+ /* ---- provenance / honesty banner under the verdict (the research-skeptic's #1 demand) ---- */
+ .provbar{background:#1d1505;border:1px solid var(--warn);border-left:4px solid var(--warn);border-radius:8px;padding:9px 11px;margin:10px 0 0;font-size:12px;color:var(--fg);line-height:1.5}
+ .provbar b{color:#e3b341} .provbar code{background:#0d1117;padding:1px 5px;border-radius:4px}
+ /* the topology verdict is a neutral output: tag it so "aggregate" never reads as the tool failing its own premise */
+ .neutral-tag{font-size:11.5px;color:var(--mut);font-style:italic}
+ /* honest-by-design trust chip — the catalog split (~52% disagg / ~48% not) + cost-regress finding as a credibility signal */
+ .trustchip{display:inline-flex;align-items:center;gap:7px;background:#0c1f13;border:1px solid var(--ok);border-radius:999px;padding:4px 11px;margin:10px 0 0;font-size:11.5px;color:var(--fg);line-height:1.4}
+ .trustchip .dot{width:7px;height:7px;border-radius:50%;background:var(--ok);flex:none} .trustchip b{color:#56d364}
+ details.whatis{background:var(--card);border:1px solid var(--acc);border-radius:10px;margin:12px 0 0;padding:0 13px;max-width:1200px}
+ details.whatis>summary{cursor:pointer;padding:11px 0;font-weight:600;font-size:13.5px;color:var(--acc);list-style:none}
+ details.whatis>summary::-webkit-details-marker{display:none}
+ details.whatis>summary::before{content:"▸ ";color:var(--acc)} details.whatis[open]>summary::before{content:"▾ "}
+ details.whatis .wbody{padding:0 0 13px;font-size:12.5px;color:var(--fg);line-height:1.55}
+ details.whatis .wcol{display:grid;grid-template-columns:1fr 1fr;gap:14px}@media(max-width:760px){details.whatis .wcol{grid-template-columns:1fr}}
+ details.whatis ul{margin:4px 0;padding-left:18px} details.whatis li{margin:3px 0}
+ details.whatis .is h4{color:var(--ok);margin:0 0 4px;font-size:12.5px} details.whatis .isnt h4{color:var(--bad);margin:0 0 4px;font-size:12.5px}
+ .formula{font-family:ui-monospace,Menlo,monospace;background:#0d1117;border:1px solid #21262d;border-radius:6px;padding:9px;font-size:12px;margin:8px 0;white-space:pre-wrap;line-height:1.45}
+ .nm{display:grid;grid-template-columns:1fr 1fr;gap:14px}@media(max-width:900px){.nm{grid-template-columns:1fr}}
+ .nm .box{background:#0d1117;border:1px solid #21262d;border-radius:8px;padding:11px} .nm .box h4{margin:0 0 4px;font-size:13px;color:var(--fg)}
+ .collision{background:#11203a;border:1px solid var(--acc);border-radius:8px;padding:10px;margin:12px 0;font-size:12.5px;max-width:1200px}
+ /* ---- use-case selector ---- */
+ select.ucsel{border:1px solid var(--acc);background:#0d1117}
+ .uchint{font-size:11.5px;color:var(--mut);margin:4px 0 2px;min-height:14px} .uchint b{color:var(--fg)}
+ .uchint2{font-size:11px;color:var(--mut);background:#0d1117;border:1px solid #21262d;border-left:3px solid var(--acc);border-radius:0 6px 6px 0;padding:6px 8px;margin:6px 0 2px;line-height:1.4}
+ /* ---- use-case explainer table ---- */
+ table.uc{width:100%;border-collapse:collapse;font-size:12.5px;margin-top:8px}
+ table.uc th,table.uc td{text-align:left;padding:7px 10px;border-bottom:1px solid #21262d;vertical-align:top}
+ table.uc th{color:var(--mut);font-weight:600;font-size:11px;text-transform:uppercase;letter-spacing:.03em}
+ table.uc td.lean-dis{color:var(--ok);font-weight:600} table.uc td.lean-agg{color:var(--acc);font-weight:600} table.uc td.lean-hyb{color:var(--warn);font-weight:600}
+ table.uc td.io{font-family:ui-monospace,Menlo,monospace;color:var(--fg);white-space:nowrap} table.uc tr:hover{background:#0d1117}
+ table.uc .uc-name{color:var(--fg);font-weight:600}
+</style></head>
+<body>
+<header>
+  <h1>Aggregation vs Disaggregation Optimizer <span class="brand">— should you split prefill/decode?</span></h1>
+  <div class="sub">Enter an AWS instance + model + workload → get the <b>topology verdict</b>: aggregate, hybrid, or disaggregate. <b class="honest">Disaggregation is not free — it helps for some workloads and regresses for others. This tool tells you which: when it helps, when it&rsquo;s a no-op, and when it costs you (at the 1P:1D floor it&rsquo;s a latency play, not a cost play).</b> Physics mirrors <code>analyze/calc.py</code>; calibrated to measured Nemotron-3 Ultra 550B / p5en. Estimator — confirm with <code>driver/sweep.py</code>.</div>
+</header>
+
+<!-- ============ EXPLAINER ============ -->
+<section class="explain">
+  <h2>Aggregate vs Hybrid vs Disaggregate — what the verdict means</h2>
+  <div class="lead2">Every LLM request has two phases: <b>prefill</b> (read the whole prompt, compute-bound, bursty) and
+  <b>decode</b> (emit one token at a time, memory-bandwidth-bound, steady). The only question this tool answers is
+  <i>where you run those two phases relative to each other</i>. There are three choices:</div>
+
+  <div class="topo3">
+    <div class="topo agg">
+      <h3><span aria-hidden="true">■</span> Aggregate</h3>
+      <svg class="topodiag" viewBox="0 0 260 150" role="img" aria-label="Aggregate topology: one node holding four GPUs. Every GPU runs both prefill and decode for a request, in place. No KV cache is moved between nodes.">
+        <title>Aggregate — prefill and decode co-located on the same GPUs, no KV move</title>
+        <rect class="node" x="14" y="24" width="232" height="92" rx="8"/>
+        <text class="lbl" x="24" y="40">NODE — 1 GPU pool</text>
+        <!-- 4 GPU chips, each tagged with BOTH phases -->
+        <g>
+          <rect class="gpu" x="24" y="50" width="48" height="50" rx="5"/>
+          <rect class="gpu" x="80" y="50" width="48" height="50" rx="5"/>
+          <rect class="gpu" x="136" y="50" width="48" height="50" rx="5"/>
+          <rect class="gpu" x="192" y="50" width="48" height="50" rx="5"/>
+        </g>
+        <g class="tag" fill="var(--warn)" text-anchor="middle">
+          <text x="48" y="68">prefill</text><text x="104" y="68">prefill</text><text x="160" y="68">prefill</text><text x="216" y="68">prefill</text>
+        </g>
+        <g class="tag" fill="var(--ok)" text-anchor="middle">
+          <text x="48" y="92">decode</text><text x="104" y="92">decode</text><text x="160" y="92">decode</text><text x="216" y="92">decode</text>
+        </g>
+        <text class="note" x="130" y="134" text-anchor="middle">↻ both phases in place — no KV move</text>
+      </svg>
+      <p>Prefill and decode share the same GPUs. A request prefills, then decodes, in place. <b>No KV cache transfer.</b> A prefill burst <i>can</i> stall the decode stream of co-batched requests.</p>
+      <p class="pick">Picked when: <b>prefill is cheap vs decode</b> (little interference to remove), or the KV-transfer toll would cost more than it saves. <b>Cheapest $/token</b> at low–moderate load.</p>
+    </div>
+    <div class="topo hyb">
+      <h3><span aria-hidden="true">◆</span> Hybrid</h3>
+      <svg class="topodiag" viewBox="0 0 260 150" role="img" aria-label="Hybrid topology: one node with shared GPUs, still co-located. Prefill is chopped into small chunks that are interleaved between decode steps on the same GPUs' timeline, so a prefill burst can never monopolize a step. Interference is bounded and there is no cross-node KV hop.">
+        <title>Hybrid — chunked prefill interleaved with decode on the same GPUs, no cross-node hop</title>
+        <rect class="node" x="14" y="22" width="232" height="96" rx="8"/>
+        <text class="lbl" x="24" y="38">NODE — shared GPUs (chunked schedule)</text>
+        <!-- a single step timeline lane: decode steps (green) interleaved with sliced prefill chunks (amber) -->
+        <text class="lbl-sm" x="24" y="58">one GPU step timeline ▸</text>
+        <g>
+          <!-- decode steps -->
+          <rect class="gpu" x="24"  y="64" width="20" height="26" rx="3" fill="#0f2a17"/>
+          <rect class="gpu" x="76"  y="64" width="20" height="26" rx="3" fill="#0f2a17"/>
+          <rect class="gpu" x="128" y="64" width="20" height="26" rx="3" fill="#0f2a17"/>
+          <rect class="gpu" x="180" y="64" width="20" height="26" rx="3" fill="#0f2a17"/>
+          <rect class="gpu" x="218" y="64" width="20" height="26" rx="3" fill="#0f2a17"/>
+          <!-- prefill CHUNKS sliced between them (small, amber) -->
+          <rect x="48"  y="68" width="24" height="18" rx="3" fill="#3a2f12" stroke="var(--warn)" stroke-width="1.3"/>
+          <rect x="100" y="68" width="24" height="18" rx="3" fill="#3a2f12" stroke="var(--warn)" stroke-width="1.3"/>
+          <rect x="152" y="68" width="24" height="18" rx="3" fill="#3a2f12" stroke="var(--warn)" stroke-width="1.3"/>
+          <rect x="204" y="68" width="10" height="18" rx="2" fill="#3a2f12" stroke="var(--warn)" stroke-width="1.3"/>
+        </g>
+        <g class="tag" text-anchor="middle">
+          <text x="34" y="81" fill="var(--ok)">d</text><text x="86" y="81" fill="var(--ok)">d</text><text x="138" y="81" fill="var(--ok)">d</text><text x="190" y="81" fill="var(--ok)">d</text><text x="228" y="81" fill="var(--ok)">d</text>
+          <text x="60" y="80" fill="var(--warn)">P</text><text x="112" y="80" fill="var(--warn)">P</text><text x="164" y="80" fill="var(--warn)">P</text>
+        </g>
+        <text class="lbl-sm" x="24" y="104"><tspan fill="var(--ok)">d</tspan> = decode step &#160; <tspan fill="var(--warn)">P</tspan> = prefill chunk (sliced)</text>
+        <text class="note" x="130" y="134" text-anchor="middle">chunked-prefill — bursts can't block decode · no cross-node hop</text>
+      </svg>
+      <p class="def">The <b>middle verdict</b> — hybrid when <code>0.30·(1−cpr) ≤ fav &lt; 0.55·(1−cpr)</code>, i.e. <code>0.090 ≤ fav &lt; 0.165</code> at the default chunked-prefill recovery <code>cpr=0.7</code>. There <i>is</i> prefill→decode interference worth mitigating, but a full split isn't justified: either the KV-transfer toll is too high or the imbalance is only moderate.</p>
+      <p class="def">In practice it's TaiChi's <b>differentiated P/D</b> regime — prefill is <b>chunked</b> and interleaved with decode on the <b>same</b> GPUs so a prefill burst can't monopolize a step (interference bounded), with <b>no cross-node KV hop</b>. This is exactly what <code>chunked_prefill_recovery=0.7</code> models.</p>
+      <p class="pick">Picked when: <b>in between</b> — enough prefill interference to want separation, but not enough (or too high a KV toll) to justify a full disaggregated split.</p>
+    </div>
+    <div class="topo dis">
+      <h3><span aria-hidden="true">▲</span> Disaggregate</h3>
+      <svg class="topodiag" viewBox="0 0 260 150" role="img" aria-label="Disaggregate topology: two separate nodes. A prefill pool on the left and a decode pool on the right, each with its own GPUs. The KV cache is shipped from the prefill pool to the decode pool over EFA / NIXL RDMA. Decode never sees a prefill burst.">
+        <title>Disaggregate — separate prefill and decode pools, KV cache shipped over EFA / NIXL RDMA</title>
+        <!-- prefill pool -->
+        <rect class="node" x="10" y="34" width="96" height="78" rx="8"/>
+        <text class="lbl" x="20" y="50" fill="var(--warn)">PREFILL pool</text>
+        <rect class="gpu" x="20" y="58" width="36" height="44" rx="5"/>
+        <rect class="gpu" x="62" y="58" width="36" height="44" rx="5"/>
+        <text class="tag" x="38" y="84" fill="var(--warn)" text-anchor="middle">P</text>
+        <text class="tag" x="80" y="84" fill="var(--warn)" text-anchor="middle">P</text>
+        <!-- decode pool -->
+        <rect class="node" x="154" y="34" width="96" height="78" rx="8"/>
+        <text class="lbl" x="164" y="50" fill="var(--ok)">DECODE pool</text>
+        <rect class="gpu" x="164" y="58" width="36" height="44" rx="5"/>
+        <rect class="gpu" x="206" y="58" width="36" height="44" rx="5"/>
+        <text class="tag" x="182" y="84" fill="var(--ok)" text-anchor="middle">d</text>
+        <text class="tag" x="224" y="84" fill="var(--ok)" text-anchor="middle">d</text>
+        <!-- KV cache arrow crossing the fabric -->
+        <defs><marker id="kvarrow" markerWidth="9" markerHeight="9" refX="6" refY="3" orient="auto"><path d="M0,0 L7,3 L0,6 Z" fill="var(--ok)"/></marker></defs>
+        <line x1="106" y1="72" x2="150" y2="72" stroke="var(--ok)" stroke-width="2.4" marker-end="url(#kvarrow)"/>
+        <text class="tag" x="130" y="66" fill="var(--ok)" text-anchor="middle" font-size="8">KV cache</text>
+        <text class="lbl-sm" x="130" y="88" text-anchor="middle">EFA / NIXL</text>
+        <text class="lbl-sm" x="130" y="98" text-anchor="middle">RDMA</text>
+        <text class="note" x="130" y="134" text-anchor="middle">separate nodes — decode never sees a prefill burst</text>
+      </svg>
+      <p>Prefill and decode run on <b>separate GPU pools</b>; the KV cache is shipped prefill→decode over the fabric (EFA/NIXL RDMA). Decode never sees a prefill burst → clean, steady latency.</p>
+      <p class="pick">Picked when: <b>prefill bursts would stall many decode steps</b> under co-location (high interference) <b>and</b> KV transfer is cheap. Wins on SLO-attainment / tail latency, and on $/token only at scale.</p>
+    </div>
+  </div>
+
+  <h2 style="margin-top:20px">The use case <i>is</i> the workload — and the workload drives the verdict</h2>
+  <div class="lead2">You don't pick agg/disagg by model alone — you pick it by <b>what the model is doing</b>. The shape of
+  the traffic (how many tokens go <i>in</i> = ISL, how many come <i>out</i> = OSL) is the dominant lever. Pick your use case
+  in the calculator's <b>⭐ Use case</b> dropdown and it pre-fills ISL/OSL for you. Here's the mapping:</div>
+  <table class="uc">
+    <tr><th>Use case</th><th>Typical ISL → OSL</th><th>Why</th><th>Leans</th></tr>
+    <tr><td class="uc-name">🤖 Agent / tool-use</td><td class="io">8192 → 128</td><td>Big growing context (history + tools + retrieved data), each step emits a short action/tool-call. Massive prefill, tiny decode.</td><td class="lean-dis">Disaggregate</td></tr>
+    <tr><td class="uc-name">📚 RAG / Q&A</td><td class="io">4096 → 256</td><td>Retrieved chunks in, concise grounded answer out. Prefill-heavy.</td><td class="lean-dis">Disaggregate</td></tr>
+    <tr><td class="uc-name">📝 Summarization</td><td class="io">8192 → 256</td><td>Long doc in, short summary out — very prefill-heavy (mind the TTFT budget).</td><td class="lean-dis">Disaggregate*</td></tr>
+    <tr><td class="uc-name">💬 Chat / assistant</td><td class="io">512 → 256</td><td>Balanced conversational turn. Middle of the road.</td><td class="lean-hyb">Hybrid / Agg</td></tr>
+    <tr><td class="uc-name">🧑‍💻 Code generation</td><td class="io">1024 → 1024</td><td>Medium prompt, long code output. Roughly balanced.</td><td class="lean-hyb">Hybrid / Agg</td></tr>
+    <tr><td class="uc-name">🧠 Reasoning / CoT</td><td class="io">512 → 2048</td><td>Short question, long generated reasoning. Decode dominates, prefill is tiny → little interference to remove.</td><td class="lean-agg">Aggregate</td></tr>
+  </table>
+  <div class="lead2" style="margin-top:8px;font-size:12px">*Direction from the ISL:OSL pressure; the calculator computes the <i>actual</i> verdict including the KV-transfer toll, which can pull long-context cases back toward aggregate if the prompt is huge and the output short. Try it.</div>
+
+  <div class="collision">
+    <b>⚠ One word, two meanings — don't confuse them.</b> “Hybrid” above is a <b>serving topology</b> (the middle verdict).
+    Separately, <b>“hybrid-Mamba”</b> is a <b>model architecture</b> (e.g. Nemotron-3 Ultra 550B — attention + Mamba layers),
+    selectable in the <i>Family</i> dropdown. They are unrelated: a hybrid-Mamba <i>model</i> can be served with an
+    aggregate, hybrid, <i>or</i> disaggregate <i>topology</i>.
+  </div>
+</section>
+
+<details class="exp">
+  <summary>How the verdict is computed (the actual formula)</summary>
+  <div class="ebody">
+    <p>It is one number, <code>fav = toll × interference</code>, both derived from first-order rooflines in
+    <code>analyze/calc.py</code> (mirrored in this page's JS — they're kept identical):</p>
+    <div class="formula">interference = 1 − exp(−imbalance / 4)      # imbalance = prefill_ms / decode_ITL_ms
+                                          # → how many decode steps one prefill burst stalls
+toll         = 1 / (1 + 4 × transfer_overhead)  # transfer_overhead = KV_transfer_ms / decode_phase_ms
+                                          # → 1 when shipping the KV is ~free, →0 when it's expensive
+fav          = toll × interference
+
+  fav ≥ 0.55  → DISAGGREGATE     (lots of interference to remove, cheap to ship KV)
+  fav ≥ 0.30  → HYBRID           (in between)
+  else        → AGGREGATE        (prefill cheap, or KV too expensive to move)</div>
+    <p>Intuition: <b>disaggregation only pays off when it removes a lot of decode-stalling interference AND the KV cache
+    is cheap to move.</b> Long prompts + short outputs raise interference (favors disagg); short prompts, or a fat KV
+    cache over a slow link, raise the toll (favors agg). The verdict is a sliding scale, not a coin flip.</p>
+  </div>
+</details>
+
+<details class="exp">
+  <summary>Worked examples — what comes out, and which numbers are measured vs predicted</summary>
+  <div class="ebody">
+    <p style="margin-top:10px">Badges: <span class="badge meas">MEASURED</span> = real GPU benchmark on p5en (H200);
+    <span class="badge pred">PREDICTED</span> = calculator output, calibrated to the measured anchors but not itself benchmarked.</p>
+
+    <div class="ex agg">
+      <div class="h">Nemotron-3 Ultra 550B · short chat (ISL 512 / OSL 128) · 2 nodes <span class="badge meas">MEASURED</span></div>
+      <div class="d">Live A/B on p5en: aggregation <b>2.1× cheaper</b> than disaggregation ($95.88 vs $202.71 / 1M tok), 0 errors.
+      Short prompt → little prefill interference; the KV-over-EFA toll isn't repaid at this scale. <b>Verdict: aggregate</b> — and the live run confirmed it.</div>
+    </div>
+    <div class="ex agg">
+      <div class="h">Llama-3.1-70B · short chat · 2 nodes, 1 prefill : 1 decode <span class="badge meas">MEASURED</span></div>
+      <div class="d">Live A/B: at the minimum 1P:1D split, aggregation wins (3.54 vs 3.17 req/s) for <i>half</i> the GPUs — disagg's
+      +13% TTFT toll + fragmentation aren't yet amortized. Also pinned the dense decode-ITL at <b>19.9 ms</b> (roofline predicted 22.4 → correction 0.89×, i.e. graph-enabled dense models track the roofline). <b>Verdict: aggregate at this scale.</b></div>
+    </div>
+    <div class="ex dis">
+      <div class="h">Frontier model · RAG (ISL 4096 / OSL 512) · 8+ nodes <span class="badge pred">PREDICTED</span></div>
+      <div class="d">Long prompt → high prefill interference; spread over many nodes the KV toll + fragmentation amortize, so
+      disaggregation overtakes (~+15–22% goodput, cheaper $/Mtok). <b>Verdict: disaggregate</b> — a calibrated prediction; the live multi-node confirmation is capacity-gated.</div>
+    </div>
+    <div class="ex hyb">
+      <div class="h">Decode-heavy workload (short prompt, long output) <span class="badge pred">PREDICTED</span></div>
+      <div class="d">Prefill is tiny vs a long decode → low interference → the calculator lands <b>hybrid</b> (or aggregate). Splitting buys little because there's barely any prefill burst to isolate.</div>
+    </div>
+  </div>
+</details>
+
+<details class="exp">
+  <summary>What happens as you scale the number of nodes?</summary>
+  <div class="ebody">
+    <p style="margin-top:10px">“Adding nodes” means two <b>different</b> things, and they behave oppositely. The repo models both
+    (<code>analyze/node_scaling.py</code> and <code>analyze/pd_pool_scaling.py</code>):</p>
+    <div class="nm">
+      <div class="box">
+        <h4>1. Replica scaling — model fits, add independent copies</h4>
+        <p style="font-size:12.5px;margin:5px 0">Throughput grows <b>~linearly</b> with nodes; per-request latency stays <b>flat</b>; $/token stays flat.</p>
+        <div class="d" style="font-size:12px">Measured-shape example (550B/p5en): 1→8 nodes ≈ 3,222 → 23,712 tok/s (<b>7.4×</b>, router-eff ~0.92). This is the honest "just add servers" law.</div>
+      </div>
+      <div class="box">
+        <h4>2. Prefill/Decode pool scaling — the at-scale agg-vs-disagg crossover</h4>
+        <p style="font-size:12.5px;margin:5px 0">Disaggregation's <b>fixed costs amortize as you add nodes</b>: the integer prefill:decode split gets finer, so wasted capacity shrinks.</p>
+        <div class="d" style="font-size:12px">550B fragmentation penalty: <b>49% @ 2 nodes → ~1% @ 32 nodes</b>. So there's a computable <b>crossover</b>: small models flip to disagg at 1–2 nodes; frontier (8-GPU/replica) models around <b>5–7 nodes</b>.</div>
+      </div>
+    </div>
+    <p style="margin-top:10px"><b>The at-scale law, in one line:</b> in the work-conserving limit aggregation and disaggregation push the
+    <i>same</i> raw throughput — so disaggregation's only structural win (removing decode interference) is fixed, while its
+    costs (KV toll + P:D fragmentation) <i>shrink with scale</i>. ⟹ <b>the bigger the fleet, the more disaggregation wins.</b></p>
+    <p class="cav" style="font-size:12px">Honesty: the crossover <b>floor</b> (agg wins at the 1P:1D minimum) is MEASURED on two model families; the rising
+    <b>slope</b> beyond it is a calibrated PREDICTION (live confirmation is blocked by EFA capacity on the shared cluster).
+    Node-scaling is computed in the Python tools; this interactive calculator currently shows the per-replica verdict + cost knee below.</p>
+  </div>
+</details>
+
+<div class="wrap">
+  <div class="card">
+    <label for="inst">AWS instance</label>
+    <select id="inst"></select>
+    <label for="preset">Model preset</label>
+    <select id="preset"></select>
+    <div class="row">
+      <div><label for="params">Params (B)</label><input id="params" type="number" value="550"></div>
+      <div><label for="layers">Layers</label><input id="layers" type="number" value="118"></div>
+    </div>
+    <div class="row">
+      <div><label for="heads">Attn heads</label><input id="heads" type="number" value="96"></div>
+      <div><label for="kvheads">KV heads (GQA)</label><input id="kvheads" type="number" value="8"></div>
+    </div>
+    <div class="row">
+      <div><label for="hidden">Hidden</label><input id="hidden" type="number" value="12288"></div>
+      <div><label for="headdim">Head dim</label><input id="headdim" type="number" value="128"></div>
+    </div>
+    <div class="row">
+      <div><label for="wdtype">Weight dtype</label><select id="wdtype"><option>bf16</option><option>fp16</option><option>fp8</option><option>fp4</option></select></div>
+      <div><label for="tp">TP</label><input id="tp" type="number" value="8"></div>
+    </div>
+    <label for="usecase" style="color:var(--acc);font-weight:600;margin-top:14px">⭐ Use case → sets input/output length</label>
+    <select id="usecase" class="ucsel"></select>
+    <div id="ucHint" class="uchint"></div>
+    <div class="row">
+      <div><label for="isl">Input len (ISL) <span class="mut">— prompt/context in</span></label><input id="isl" type="number" value="512" oninput="ucCustom()"></div>
+      <div><label for="osl">Output len (OSL) <span class="mut">— tokens generated</span></label><input id="osl" type="number" value="128" oninput="ucCustom()"></div>
+    </div>
+    <div class="uchint2">↑ This ISL:OSL ratio is <b>the single biggest driver</b> of the verdict — long input + short output (RAG, agents) leans <b style="color:var(--ok)">disaggregate</b>; short input + long output (reasoning, chat) leans <b style="color:var(--acc)">aggregate</b>.</div>
+    <label for="family">Family</label>
+    <select id="family"><option value="dense">dense</option><option value="moe">moe</option><option value="hybrid-mamba">hybrid-mamba</option></select>
+    <button onclick="run()">Analyze</button>
+  </div>
+  <div>
+    <div class="card" style="margin-bottom:16px">
+      <div class="mut">Topology verdict for <b id="vmodel"></b> on <b id="vinst"></b> <span class="neutral-tag">— the honest answer, whichever way it lands</span></div>
+      <div class="verdict" id="verdict" role="status" aria-live="polite" aria-atomic="true">—</div>
+      <div class="why" id="why"></div>
+      <div class="cav" id="cav"></div>
+      <!-- ===== Does disaggregation HELP here? — a SEPARATE axis from the ■◆▲ topology verdict above.
+           Topology = WHICH layout; this = does the agg→disagg SPLIT help / do nothing / hurt, per axis. ===== -->
+      <div class="dva" id="dva" role="group" aria-labelledby="dvaQ">
+        <div class="dva-q" id="dvaQ">Does disaggregation help here?</div>
+        <div class="dva-word" id="dvaWord">—</div>
+        <div class="dva-sum" id="dvaSum"></div>
+        <div class="dva-chips" id="dvaChips"></div>
+        <div class="dva-foot">
+          Each axis is a speedup = <b>aggregation ÷ disaggregation</b>: <b>&gt;1</b> = disagg is better, <b>&lt;1</b> = disagg <b>regresses</b>, within ±10% = no-op.
+          <span class="anchor">Measured proof both outcomes are real:</span> 550B short-chat <b>regresses on cost ~0.5×</b> (agg won the live A/B 2.1×); a long-context agent workload <b>helps on ITL</b>.
+          At the 1P:1D floor disagg is a <b>latency play, not a cost play</b> — cost tops out ~0.59× (2× GPUs is a hard 2×), TTFT always pays the KV hop, ITL is the win. The cost win needs P:D right-sizing (<code>pd_pool_scaling.py</code>), not this floor — so an <b>overall &ldquo;HELPS&rdquo; is an at-scale / right-sized outcome, not a 1P:1D-floor one</b> (at the floor you trade cost+TTFT for ITL → MIXED).
+        </div>
+      </div>
+      <div class="provbar">
+        <b>How to read this:</b> a <b>directional L0 screen</b>, calibrated to a single measured anchor
+        (<b>n=1</b>): Nemotron-3 Ultra 550B, <b>bf16</b>, <b>H200 / p5en</b>, <b>TP8</b>. It models per-request
+        single-stream latency — <b>not</b> a validated multi-tenant simulator. Confirm any verdict with
+        <code>driver/sweep.py</code> on real GPUs before acting.
+      </div>
+      <div class="trustchip"><span class="dot" aria-hidden="true"></span><span>Honest by design — across our 240-cell catalog the verdict splits roughly evenly: <b>~52% disaggregate, ~48% aggregate-or-hybrid</b>. And on the cost axis at the 1P:1D floor, disagg almost always regresses (it&rsquo;s a latency play). A no-op or a regression is a real result, not a failure.</span></div>
+      <details class="whatis">
+        <summary>What this tool is — and what it is not</summary>
+        <div class="wbody">
+          <div class="wcol">
+            <div class="is">
+              <h4>✓ It IS</h4>
+              <ul>
+                <li>A fast, transparent <b>first-pass screen</b> (agg / hybrid / disaggregate) from model architecture + workload.</li>
+                <li>Calibrated to <b>real measured anchors</b> (550B/p5en ITL, KV-over-EFA transfer penalty) — see the badges below.</li>
+                <li>An <b>auditable derivation</b>: every term is a first-order roofline you can read and challenge.</li>
+              </ul>
+            </div>
+            <div class="isnt">
+              <h4>✗ It is NOT</h4>
+              <ul>
+                <li>A <b>benchmark</b> or a validated simulator — predicted numbers are calibrated, not measured.</li>
+                <li>A <b>multi-tenant / load-dependent goodput</b> model (batching, queueing, EP all-to-all are out of L0 scope).</li>
+                <li>Generalizable off the anchor without re-calibration — the <b>n=1</b> family correction is honest, not universal.</li>
+              </ul>
+            </div>
+          </div>
+          <div class="provlegend" style="margin-top:8px">Provenance of displayed numbers:
+            <span class="badge meas tiny">MEASURED</span> real GPU benchmark
+            <span class="badge der tiny">DERIVED</span> computed from your inputs
+            <span class="badge asm tiny">ASSUMED n=1</span> single-anchor calibration / heuristic
+            <span class="badge pred tiny">PREDICTED</span> calculator output (calibrated, not benchmarked — same tier as ASSUMED)
+          </div>
+        </div>
+      </details>
+    </div>
+    <div class="grid">
+      <div class="card"><canvas id="cTime" role="img" aria-label="Latency components bar chart"></canvas><div class="chartsum" id="cTime_sum" role="note"></div></div>
+      <div class="card"><canvas id="cFav" role="img" aria-label="Disaggregation favorability vs output length"></canvas><div class="chartsum" id="cFav_sum" role="note"></div></div>
+      <div class="card"><canvas id="cKV" role="img" aria-label="KV cache per request vs input length"></canvas><div class="chartsum" id="cKV_sum" role="note"></div></div>
+      <div class="card">
+        <div class="kpi"><span class="mut">KV / request <span class="badge der tiny">DERIVED</span></span><b id="kKV"></b></div>
+        <div class="kpi"><span class="mut">KV transfer time <span class="badge asm tiny" title="end-to-end KV-hop (fabric+handshake+serialization) calibrated to the measured 486MB→~127ms anchor, n=1">ASSUMED n=1</span></span><b id="kXfer"></b></div>
+        <div class="kpi"><span class="mut">Prefill compute <span class="badge der tiny">DERIVED</span></span><b id="kPre"></b></div>
+        <div class="kpi"><span class="mut">Decode ITL/token <span class="badge asm tiny" title="roofline × measured family correction (hybrid-Mamba 18.6×, dense 0.89×) — n=1 calibration">ASSUMED n=1</span></span><b id="kITL"></b></div>
+        <div class="kpi"><span class="mut">Fabric line rate <span class="badge der tiny">DERIVED</span></span><b id="kLine"></b></div>
+        <div class="kpi"><span class="mut">Prefill↔decode imbalance <span class="badge der tiny">DERIVED</span></span><b id="kImb"></b></div>
+      </div>
+    </div>
+
+    <div class="card" style="margin-top:16px">
+      <div class="mut" style="font-size:15px;font-weight:600;color:var(--fg)">Where does disaggregation flip? — help/regress vs context (ISL sweep)</div>
+      <div class="why">Speedup = aggregation ÷ disaggregation per axis, re-run over an ISL sweep at the current model/instance/OSL. Above the dashed <b>1.0</b> parity line = disagg <b>helps</b>; inside the shaded ±10% band = <b>no-op</b>; below = disagg <b>regresses</b>. Where each curve crosses 1.0 is where that axis flips. <b>ITL</b> (green) is the axis disagg buys as prefill grows; <b>cost</b> (blue) and <b>TTFT</b> (amber) sit below 1.0 — the 2×-GPU and KV-hop tolls no ISL repays at the 1P:1D floor.</div>
+      <canvas id="cDva" role="img" aria-label="Disaggregation cost, TTFT and ITL speedup versus aggregation as input length grows. Three lines on a y-axis of speedup ratio, with a parity reference line at 1.0 and a shaded plus or minus ten percent no-op band. Where each line crosses 1.0 is where that axis flips between disaggregation helping and regressing."></canvas>
+      <div class="chartsum" id="cDva_sum" role="note"></div>
+    </div>
+
+    <div class="card" style="margin-top:16px">
+      <div class="mut">Cost / SLA — <b id="cVerdict">—</b> <span id="cSav" class="mut"></span>
+        &nbsp;·&nbsp; instance <b id="cHr"></b>/hr (AWS on-demand, 2026-06-14; override below)</div>
+      <div class="why" id="cNote"></div>
+      <label for="priceOv" style="margin-top:8px">Override $/hr (capacity block / savings plan / spot) — blank = on-demand</label>
+      <input id="priceOv" type="number" placeholder="(on-demand)" style="max-width:200px" oninput="run()">
+    </div>
+    <div class="grid" style="margin-top:16px">
+      <div class="card"><canvas id="cCost" role="img" aria-label="Cost per 1M output tokens, aggregation vs disaggregation"></canvas><div class="chartsum" id="cCost_sum" role="note"></div></div>
+      <div class="card"><canvas id="cCostConc" role="img" aria-label="Cost vs concurrency crossover"></canvas><div class="chartsum" id="cCostConc_sum" role="note"></div></div>
+    </div>
+
+    <!-- ===== Optimal Settings Finder (ports analyze/optimizer.py to JS) ===== -->
+    <div class="card" style="margin-top:16px">
+      <div class="mut" style="font-size:15px;font-weight:600;color:var(--fg)">Optimal Settings Finder</div>
+      <div class="why">Sweeps the same knob grid as <code>analyze/optimizer.py</code> (topology · max-num-seqs · concurrency · chunk · cuda-graphs) with the same MEASURED-calibrated physics, then returns the config that wins your objective at your SLO. Reuses the instance + model + ISL/OSL selectors on the left.</div>
+      <div class="row" style="margin-top:8px">
+        <div><label for="sloTtft">SLO TTFT (ms)</label><input id="sloTtft" type="number" value="2000" oninput="optRun()"></div>
+        <div><label for="sloTpot">SLO TPOT / ITL (ms)</label><input id="sloTpot" type="number" value="120" oninput="optRun()"></div>
+      </div>
+      <label for="objective">Objective</label>
+      <select id="objective" onchange="optRun()">
+        <option value="cost">cost — minimize $/Mtok at SLO</option>
+        <option value="goodput">goodput — maximize tok/s at SLO</option>
+        <option value="latency">latency — minimize ITL at SLO</option>
+      </select>
+      <div id="optResult" style="margin-top:12px"></div>
+    </div>
+    <div class="card" style="margin-top:16px">
+      <div class="mut">Sensitivity — best <span id="optObjLabel">$/Mtok</span> achievable at each knob value (other knobs free; the optimizer's <code>_sensitivity</code>)</div>
+      <div id="optSens" style="margin-top:8px"></div>
+    </div>
+    <div class="grid" style="margin-top:16px">
+      <div class="card"><canvas id="cOptKnee" role="img" aria-label="Find the knee — cost per Mtok and tokens per second vs concurrency"></canvas><div class="chartsum" id="cOptKnee_sum" role="note"></div></div>
+    </div>
+  </div>
+</div>
+<script>
+// ---- mirror of analyze/calc.py (keep in sync) ----
+// hbm_GBs = HBM BANDWIDTH per GPU (decode roofline); hbm_cap_GB = HBM CAPACITY per GPU (memory fit / KV budget).
+const INSTANCES={
+ "p5.48xlarge":{gpu:"H100",gpus:8,hbm_GBs:3350,hbm_cap_GB:80, fp16_TFLOPs:989, efa_nics:32,efa_Gbps:100},
+ "p5en.48xlarge":{gpu:"H200",gpus:8,hbm_GBs:4800,hbm_cap_GB:141,fp16_TFLOPs:989, efa_nics:16,efa_Gbps:200},
+ "p6-b200.48xlarge":{gpu:"B200",gpus:8,hbm_GBs:8000,hbm_cap_GB:180,fp16_TFLOPs:2250,efa_nics:8,efa_Gbps:400},
+ "p4d.24xlarge":{gpu:"A100",gpus:8,hbm_GBs:2039,hbm_cap_GB:40, fp16_TFLOPs:312, efa_nics:4,efa_Gbps:100},
+};
+// arch params VERIFIED from each HF config.json. ptot=TOTAL params (memory fit); pact=ACTIVE params/token (compute).
+// MoE/hybrid split compute vs memory (pact<ptot); dense pact==ptot. n_attn_layers/n_mamba_layers + mamba_* carried
+// into the model so the hybrid-Mamba KV + SSM state mirror calc.py.
+const PRESETS={
+ "Nemotron-3 Ultra 550B":{ptot:550,pact:55,params:550,layers:108,n_attn_layers:12,n_mamba_layers:48,heads:64,kvheads:2,hidden:8192,headdim:128,wdtype:"bf16",tp:8,family:"hybrid-mamba",isl:512,osl:128,maxctx:262144,mamba_num_heads:256,mamba_head_dim:64,mamba_d_state:128,mamba_d_conv:4,mamba_cache_dtype:"fp32"},
+ "Nemotron-3 Ultra 550B (NVFP4)":{ptot:550,pact:55,params:550,layers:108,n_attn_layers:12,n_mamba_layers:48,heads:64,kvheads:2,hidden:8192,headdim:128,wdtype:"fp4",tp:8,family:"hybrid-mamba",isl:512,osl:128,maxctx:262144,mamba_num_heads:256,mamba_head_dim:64,mamba_d_state:128,mamba_d_conv:4,mamba_cache_dtype:"fp32"},  /* official ModelOpt MIXED_PRECISION ckpt; LIVE-PROVEN 1-node p5en/H200: 41GiB/GPU, ~82GiB KV, 3299 tok/s@bs64. On Hopper fp4 runs Marlin W4A16 (compute≈bf16) → memory win, not 4x prefill (arch-gate handles this). */
+ "Qwen2.5-32B":{ptot:32,pact:32,params:32,layers:64,heads:40,kvheads:8,hidden:5120,headdim:128,wdtype:"fp16",tp:2,family:"dense",isl:8192,osl:256},
+ "Qwen3-30B-A3B (MoE)":{ptot:30,pact:3,params:30,layers:48,heads:32,kvheads:4,hidden:4096,headdim:128,wdtype:"fp8",tp:4,family:"moe",isl:1024,osl:256},
+ "Llama-3.1-8B":{ptot:8,pact:8,params:8,layers:32,heads:32,kvheads:8,hidden:4096,headdim:128,wdtype:"bf16",tp:1,family:"dense",isl:256,osl:256},
+};
+// ---- USE CASES: the workload IS the use case. ISL:OSL ratio drives the verdict, so we make it pickable. ----
+// lean = which topology the ISL:OSL pressure points toward (the model still computes the real verdict).
+const USECASES={
+ "🤖 Agent / tool-use (long context, short actions)":{isl:8192,osl:128,lean:"dis",
+   note:"Agents accumulate a big, growing context (history+tools+RAG) but each step emits a short action/tool-call. Huge prefill, tiny decode → heavy prefill interference → disaggregation territory."},
+ "📚 RAG / Q&A (retrieved docs in, short answer)":{isl:4096,osl:256,lean:"dis",
+   note:"Several retrieved chunks go in; a concise grounded answer comes out. Big prefill, modest decode → disaggregation usually wins (especially at scale)."},
+ "📝 Summarization (long doc in, short summary)":{isl:8192,osl:256,lean:"dis",
+   note:"Long document in, short summary out. Very prefill-heavy → disaggregation-favored, but watch the TTFT budget (a huge prompt + KV transfer can blow it)."},
+ "💬 Chat / assistant (short turn, medium reply)":{isl:512,osl:256,lean:"hyb",
+   note:"Balanced conversational turn. Middle of the road — often hybrid, and aggregation is cheapest at low–moderate load."},
+ "🧠 Reasoning / chain-of-thought (short Q, long answer)":{isl:512,osl:2048,lean:"agg",
+   note:"Short question, long generated reasoning. Decode dominates, prefill is tiny → little interference to remove → aggregate."},
+ "🧑‍💻 Code generation (medium prompt, long code)":{isl:1024,osl:1024,lean:"hyb",
+   note:"Medium prompt, long code output. Roughly balanced → hybrid/aggregate; verdict shifts with model + GPU."},
+ "✍️ Custom (set ISL/OSL by hand)":{isl:null,osl:null,lean:null,
+   note:"Enter your own input/output lengths above."},
+};
+const DB={fp16:2,bf16:2,fp8:1,fp4:0.5,int8:1};
+const CAL={kv_transfer_efficiency:0.0095,mfu_prefill:0.45,mbu_decode:0.65};
+const DTYPE_PEAK_MULT={fp16:1.0,bf16:1.0,fp8:2.0,int8:2.0,fp4:4.0};            // tensor-core peak: fp8 ~2x, fp4 ~4x
+const DECISION={interference_scale:4.0,toll_scale:4.0,threshold_disagg:0.55,threshold_hybrid:0.30,chunked_prefill_recovery:0.7};
+// measured calibration correction factors (median measured/predicted from analyze/calibration.py ledger)
+const ITL_CORRECTION={"hybrid-mamba":18.636,"dense":0.887,"moe":1.0,"moe-mla":1.0}; // measured medians from analyze/calibration.py ledger (dense from live 70B A/B; moe/mla unmeasured=1.0)
+// ---- KV helpers shared by analyze() AND kvConcCap() so they can never diverge (calc.py:kv_bytes_per_token) ----
+function kvBpt(m){                       // ATTENTION KV/token — GQA-aware + MLA-branched, attention layers only
+ const hd=m.headdim||m.hidden/Math.max(m.heads,1);
+ const db=DB[m.kv_dtype||m.wdtype]||2;
+ if(m.family==="moe-mla") return ((m.lora||512)+(m.rope||64))*m.layers*db;     // compressed latent, NOT full heads
+ const attn=m.n_attn_layers!=null?m.n_attn_layers:m.layers;                    // hybrid-Mamba: n_attn_layers << layers
+ return 2*m.kvheads*hd*attn*db;
+}
+function mambaStateBytes(m){             // constant Mamba-2 SSM+conv state per request — calc.py:mamba_state_bytes
+ if(m.family!=="hybrid-mamba") return 0;
+ const nm=m.n_mamba_layers||0;
+ const cdb=DB[m.mamba_cache_dtype||"fp32"]||4;
+ if(m.mamba_num_heads&&m.mamba_head_dim&&nm){
+   const ssm =m.mamba_num_heads*m.mamba_head_dim*(m.mamba_d_state||128)*cdb;
+   const conv=m.mamba_num_heads*m.mamba_head_dim*(m.mamba_d_conv||4)*cdb;
+   return (ssm+conv)*nm;
+ }
+ return 0;
+}
+function analyze(g,m,wl){                // faithful JS port of calc.py:analyze()
+ const pAct=m.pact||m.params, wdb=DB[m.wdtype]||2;
+ const n_attn=m.n_attn_layers!=null?m.n_attn_layers:m.layers;
+ // (A) KV per request: ATTENTION KV (grows with ISL) + constant Mamba SSM state (if hybrid-mamba)
+ const kv_bpt=kvBpt(m);
+ const attn_bytes=kv_bpt*wl.isl, mamba_bytes=mambaStateBytes(m);
+ const kv_bytes=attn_bytes+mamba_bytes, kv_MB=kv_bytes/1e6;                    // total bytes disagg must ship
+ const attn_MB=attn_bytes/1e6, mamba_MB=mamba_bytes/1e6;
+ // (B) fabric + KV-transfer time (disagg only) — uses TOTAL kv bytes
+ const line=g.efa_nics*g.efa_Gbps/8.0;
+ const ach=Math.max(line*CAL.kv_transfer_efficiency,1.0);
+ const xfer=(kv_bytes/1e9)/ach*1000;
+ // (C) prefill compute (ACTIVE params): linear GEMM term + quadratic attention term, dtype-peak-scaled
+ const flops=2*pAct*1e9*wl.isl + 4.0*(wl.isl*wl.isl)*m.hidden*n_attn;
+ // ARCH GATE (live-corrected 2026-06-19): fp4 4x is Blackwell-only; on Hopper NVFP4 runs Marlin W4A16 (~1x). fp8 native sm89+.
+ const _bw=(g.gpu==="B200"||g.gpu==="B100"||g.gpu==="GB200"), _hop=_bw||g.gpu==="H100"||g.gpu==="H200";
+ const _raw=DTYPE_PEAK_MULT[m.wdtype]||1.0;
+ const dtype_peak_mult=(m.wdtype==="fp4"&&!_bw)?1.0:((m.wdtype==="fp8"||m.wdtype==="int8")&&!_hop)?1.0:_raw;
+ const cgf=g.fp16_TFLOPs*dtype_peak_mult*1e3*m.tp*CAL.mfu_prefill;
+ const pre=flops/(cgf*1e9)*1000;
+ // (D) decode per-token (ACTIVE params + KV-read so far, HBM-bound), then CALIBRATION correction
+ const avg_ctx=wl.isl+wl.osl/2.0;
+ const kv_read=kv_bpt*avg_ctx;                                                // attention KV re-read each step (avg)
+ const pbytes=pAct*1e9*wdb, hbm=g.hbm_GBs*m.tp*CAL.mbu_decode;
+ const itl_roofline=(pbytes+kv_read)/1e9/hbm*1000;
+ const corr=ITL_CORRECTION[m.family]||1.0;                                    // measured-anchor correction
+ const itl=itl_roofline*corr;                                                 // CALIBRATION WIRED IN
+ // (E) decision: interference removed (favors disagg) vs transfer toll added; chunked-prefill discounts interference
+ const cpr=(wl.chunked_prefill_recovery!=null)?wl.chunked_prefill_recovery:DECISION.chunked_prefill_recovery;
+ const dphase=itl*wl.osl;
+ const tof=xfer/Math.max(dphase,1e-6);
+ const imb=pre/Math.max(itl,1e-6);
+ const interference_raw=1-Math.exp(-imb/DECISION.interference_scale);
+ const interference=interference_raw*(1.0-cpr);
+ const toll=1/(1+tof*DECISION.toll_scale);
+ const fav=toll*interference;
+ const thr_disagg=DECISION.threshold_disagg*(1.0-cpr);                        // rescaled onto capped [0,1-cpr] axis
+ const thr_hybrid=DECISION.threshold_hybrid*(1.0-cpr);
+ let v,why;
+ if(fav>=thr_disagg){v="disaggregate";why="cheap KV transfer; prefill bursts would stall many decode steps under aggregation (high TPOT interference, even after chunked-prefill).";}
+ else if(fav>=thr_hybrid){v="hybrid";why="non-trivial interference but transfer/imbalance moderate — TaiChi hybrid (differentiated P/D instances) likely best.";}
+ else{v="aggregate";why="prefill cheap relative to decode (low interference, incl. chunked-prefill) and/or KV transfer toll high — colocate.";}
+ // SLO gate (mirror calc.py): respect the TTFT budget — if shipping the KV eats >50% of it, disagg isn't viable.
+ const v_pre_slo=v; const slo_notes=[]; let disagg_slo_viable=true;
+ if(wl.slo_ttft_ms!=null){
+   if(pre+xfer > wl.slo_ttft_ms){disagg_slo_viable=false; slo_notes.push("prefill+transfer "+(pre+xfer).toFixed(0)+"ms exceeds TTFT budget "+wl.slo_ttft_ms.toFixed(0)+"ms — disagg can't meet the TTFT SLO");}
+ }
+ if(wl.slo_tpot_ms!=null && itl > wl.slo_tpot_ms) slo_notes.push("predicted ITL "+itl.toFixed(0)+"ms exceeds TPOT budget "+wl.slo_tpot_ms.toFixed(0)+"ms");
+ if(v==="disaggregate" && !disagg_slo_viable){v="aggregate";why="favorability prefers disagg, but KV transfer would breach the TTFT SLO — colocate (no transfer hop).";}
+ // DOES DISAGGREGATION HELP HERE? — per-axis speedup = aggregation/disaggregation (>1 disagg BETTER, <1
+ // REGRESSES). Bit-identical to calc.py:analyze() disagg_vs_agg block + calculator.html derive(). Reuses the
+ // already-computed interference / pre / xfer — adds NOTHING to the physics, only reads it.
+ const DISAGG_BAND=0.10;                                        // ±10% around parity = NO-OP (within n=1 noise)
+ const _band=sp=>sp>=1.0+DISAGG_BAND?"helps":(sp<=1.0-DISAGG_BAND?"regresses":"no-op");
+ const dva_itl=1.0+interference;                                // agg ITL inflated by co-batch stall; disagg removes it
+ const dva_ttft=pre/Math.max(pre+xfer,1e-9);                    // disagg adds KV hop to first-token path
+ const cost_uplift=1.0/Math.max(1.0-0.5*interference,0.3);      // cost.py decode-goodput uplift
+ const dva_cost=cost_uplift/2.0;                                // 1P:1D floor: uplift vs 2× GPUs (price-independent)
+ const dva_bands={cost:_band(dva_cost),ttft:_band(dva_ttft),itl:_band(dva_itl)};
+ const _b=[dva_bands.cost,dva_bands.ttft,dva_bands.itl];
+ const _ax={cost_per_token:{sp:dva_cost,band:dva_bands.cost},ttft:{sp:dva_ttft,band:dva_bands.ttft},itl:{sp:dva_itl,band:dva_bands.itl}};
+ const _list=sep=>Object.entries(_ax).map(([k,v])=>`${k} ${v.sp.toFixed(3)}x`).join(sep);
+ let dva_overall,dva_summary;
+ if(_b.includes("regresses")&&!_b.includes("helps")){
+   dva_overall="regresses"; dva_summary="disaggregation REGRESSES here vs aggregation — "+_list(", ");
+ } else if(_b.includes("helps")&&!_b.includes("regresses")){
+   dva_overall="helps"; dva_summary="disaggregation HELPS here vs aggregation — "+_list(", ");
+ } else if(_b.includes("helps")&&_b.includes("regresses")){
+   dva_overall="mixed";
+   dva_summary="MIXED: disagg helps on "+Object.entries(_ax).filter(([k,v])=>v.band==="helps").map(([k])=>k).join("/")
+     +" but regresses on "+Object.entries(_ax).filter(([k,v])=>v.band==="regresses").map(([k])=>k).join("/")
+     +" — pick on your priority axis (cost vs latency)";
+ } else {
+   dva_overall="no-op";
+   dva_summary="disaggregation is roughly a NO-OP here (within ±"+Math.round(DISAGG_BAND*100)+"% of aggregation on every axis) — the split's cost ≈ its benefit; stay aggregated for simplicity";
+ }
+ return {kv_MB,attn_MB,mamba_MB,xfer,pre,itl,itl_roofline,corr,dphase,line,imb,interference,interference_raw,toll,fav,cpr,thr_disagg,thr_hybrid,v,why,v_pre_slo,disagg_slo_viable,slo_notes,
+   dva_cost,dva_ttft,dva_itl,dva_overall,dva_summary,dva_bands,dva_band_pct:Math.round(DISAGG_BAND*100)};
+}
+// ---- cost mirror of analyze/cost.py : $/Mtok agg vs disagg (live AWS on-demand $/hr, 2026-06-14) ----
+const PRICE={"p5.48xlarge":55.04,"p5en.48xlarge":63.296,"p4d.24xlarge":21.9576,"p6-b200.48xlarge":113.9328};
+function cost(instName,g,m,wl,r,priceOverride){
+ const gpuHr=(priceOverride||PRICE[instName])/8.0;
+ const estPerGpu=(1000.0/r.itl)*0.9;            // SLA-derated single-stream output tok/s/gpu
+ const cpm=(tps,n)=>(gpuHr*n)/(Math.max(tps,1e-9)*3600.0)*1e6;
+ const gig=m.tp*(m.pp||1);                       // GPUs per replica (tp*pp); PP spans nodes → costs proportionally
+ const aggTps=estPerGpu*m.tp, aggC=cpm(aggTps,gig);
+ const uplift=1.0/Math.max(1.0-0.5*r.interference,0.3), disTps=estPerGpu*m.tp*uplift, disGpu=gig*2, disC=cpm(disTps,disGpu);
+ const cheaper=disC<aggC?"disaggregate":"aggregate", sav=aggC?(aggC-disC)/aggC*100:0;
+ return {aggC,disC,aggGpu:gig,disGpu,cheaper,sav,wholeHr:gpuHr*8};
+}
+// fields with no form input (TOTAL/ACTIVE params, attention/mamba split + Mamba SSM geometry, max ctx) are carried
+// from the active preset. stored per family so a user manually flipping `family` away doesn't drag stale mamba/MoE
+// fields onto another model (mirror of calculator.html _presetExtra).
+let _presetExtra={family:null, ptot:null, pact:null, maxctx:null, n_attn_layers:null, n_mamba_layers:null,
+  mamba_num_heads:null, mamba_head_dim:null, mamba_d_state:null, mamba_d_conv:null, mamba_cache_dtype:null};
+function loadPreset(x){
+ if(!x)return;
+ for(const id of["params","layers","heads","kvheads","hidden","headdim","tp","isl","osl"])document.getElementById(id).value=x[id];
+ document.getElementById("wdtype").value=x.wdtype;document.getElementById("family").value=x.family;
+ _presetExtra={family:x.family, ptot:x.ptot??null, pact:x.pact??null, maxctx:x.maxctx??null,
+   n_attn_layers:x.n_attn_layers??null, n_mamba_layers:x.n_mamba_layers??null,
+   mamba_num_heads:x.mamba_num_heads??null, mamba_head_dim:x.mamba_head_dim??null,
+   mamba_d_state:x.mamba_d_state??null, mamba_d_conv:x.mamba_d_conv??null, mamba_cache_dtype:x.mamba_cache_dtype??null};
+ syncUseCase();run();
+}
+function fillSelects(){
+ const i=document.getElementById('inst');Object.keys(INSTANCES).forEach(k=>i.add(new Option(k,k)));i.value="p5en.48xlarge";
+ const p=document.getElementById('preset');Object.keys(PRESETS).forEach(k=>p.add(new Option(k,k)));
+ p.onchange=()=>loadPreset(PRESETS[p.value]);
+ const uc=document.getElementById('usecase');Object.keys(USECASES).forEach(k=>uc.add(new Option(k,k)));
+ uc.value="💬 Chat / assistant (short turn, medium reply)";
+ uc.onchange=()=>{const x=USECASES[uc.value];if(!x)return;if(x.isl!=null){document.getElementById('isl').value=x.isl;document.getElementById('osl').value=x.osl;}showUcHint();run();};
+ loadPreset(PRESETS[p.value]);   // seed _presetExtra + form from the first preset
+}
+// build the model object from the form, carrying preset-only fields (params→ptot/pact default; family-gated extras).
+function readModel(){
+ const f=document.getElementById('family').value, pp=+params.value;
+ const m={family:f, params:pp, ptot:pp, pact:pp, layers:+layers.value, heads:+heads.value, kvheads:+kvheads.value,
+   hidden:+hidden.value, headdim:+headdim.value, wdtype:wdtype.value, tp:+tp.value,
+   lora:+(document.getElementById('lora')?.value||512), rope:+(document.getElementById('rope')?.value||64)};
+ // carry TOTAL/ACTIVE params + attention/mamba split + Mamba geometry + maxctx from the active preset,
+ // but only while the form family still matches the preset's family (else they don't apply to this arch).
+ if(_presetExtra && _presetExtra.family===f){
+   if(_presetExtra.ptot!=null) m.ptot=_presetExtra.ptot;
+   if(_presetExtra.pact!=null) m.pact=_presetExtra.pact;
+   if(_presetExtra.maxctx!=null) m.maxctx=_presetExtra.maxctx;
+   if(_presetExtra.n_attn_layers!=null)  m.n_attn_layers=_presetExtra.n_attn_layers;
+   if(_presetExtra.n_mamba_layers!=null) m.n_mamba_layers=_presetExtra.n_mamba_layers;
+   for(const k of ["mamba_num_heads","mamba_head_dim","mamba_d_state","mamba_d_conv","mamba_cache_dtype"])
+     if(_presetExtra[k]!=null) m[k]=_presetExtra[k];
+ }
+ return m;
+}
+// reflect the current ISL/OSL onto the use-case dropdown: match a known use case or show Custom
+function syncUseCase(){
+ const isl=+document.getElementById('isl').value, osl=+document.getElementById('osl').value, uc=document.getElementById('usecase');
+ let match="✍️ Custom (set ISL/OSL by hand)";
+ for(const[k,v]of Object.entries(USECASES))if(v.isl===isl&&v.osl===osl){match=k;break;}
+ if(uc.value!==match)uc.value=match; showUcHint();
+}
+function ucCustom(){ document.getElementById('usecase').value="✍️ Custom (set ISL/OSL by hand)"; showUcHint(); }
+function showUcHint(){
+ const x=USECASES[document.getElementById('usecase').value]; const el=document.getElementById('ucHint');
+ if(!el)return; el.innerHTML = x&&x.note ? x.note : "";
+}
+let charts={};
+// a11y: write a one-line text summary under a chart (screen-reader / no-canvas fallback).
+// pure DOM text write; touches no physics. no-op if the element is absent.
+function _sum(id,txt){ const el=document.getElementById(id); if(el) el.textContent=txt; }
+function bar(id,labels,data,colors,title){
+ if(charts[id])charts[id].destroy();
+ charts[id]=new Chart(document.getElementById(id),{type:'bar',data:{labels,datasets:[{label:title,data,backgroundColor:colors}]},
+  options:{plugins:{legend:{display:false},title:{display:true,text:title,color:'#e6edf3'}},scales:{x:{ticks:{color:'#8b949e'}},y:{ticks:{color:'#8b949e'}}}}});
+}
+function run(){
+ syncUseCase();   // keep the use-case dropdown + hint in sync with whatever ISL/OSL currently are
+ const g=INSTANCES[document.getElementById('inst').value];
+ const m=readModel();
+ const _st=+document.getElementById('sloTtft').value, _sp=+document.getElementById('sloTpot').value;
+ const wl={isl:+isl.value,osl:+osl.value, slo_ttft_ms:_st>0?_st:null, slo_tpot_ms:_sp>0?_sp:null};   // SLO gate feeds the verdict
+ const r=analyze(g,m,wl);
+ const vEl=document.getElementById('verdict');vEl.textContent=r.v.toUpperCase();vEl.className="verdict "+r.v;
+ document.getElementById('why').textContent=r.why;
+ document.getElementById('vmodel').textContent=(preset.value||"custom")+" ("+m.family+")";
+ document.getElementById('vinst').textContent=document.getElementById('inst').value+" ("+g.gpu+")";
+ document.getElementById('cav').textContent = m.family==="hybrid-mamba"?"⚠ hybrid-Mamba: PP1 only on EFA; KV pull descriptor-bound. Confirm with driver/sweep.py.":"Estimator — confirm verdict with driver/sweep.py on real GPUs.";
+ kKV.textContent=r.kv_MB.toFixed(1)+" MB"; kXfer.textContent=r.xfer.toFixed(1)+" ms"; kPre.textContent=r.pre.toFixed(0)+" ms";
+ kITL.textContent=r.itl.toFixed(1)+" ms"; kLine.textContent=r.line.toFixed(0)+" GB/s"; kImb.textContent=r.imb.toFixed(1)+"×";
+ bar('cTime',['KV xfer','Prefill','Decode/tok','Decode phase'],[r.xfer,r.pre,r.itl,r.dphase],['#58a6ff','#d29922','#3fb950','#8957e5'],'Latency components (ms)');
+ _sum('cTime_sum','Latency components (ms): KV transfer '+r.xfer.toFixed(1)+', prefill '+r.pre.toFixed(0)+', decode/token '+r.itl.toFixed(1)+', full decode phase '+r.dphase.toFixed(0)+'.');
+ // favorability sweep over OSL to show where the verdict flips
+ const osls=[64,128,256,512,1024],favs=osls.map(o=>analyze(g,m,{isl:wl.isl,osl:o}).fav);
+ if(charts.cFav)charts.cFav.destroy();
+ charts.cFav=new Chart(document.getElementById('cFav'),{type:'line',data:{labels:osls,datasets:[{label:'disagg favorability vs OSL',data:favs,borderColor:'#3fb950',tension:.3}]},options:{plugins:{title:{display:true,text:'Disagg favorability vs output length',color:'#e6edf3'},legend:{display:false}},scales:{x:{title:{display:true,text:'OSL',color:'#8b949e'},ticks:{color:'#8b949e'}},y:{min:0,max:1,ticks:{color:'#8b949e'}}}}});
+ _sum('cFav_sum','Disagg favorability (0–1) as output length grows '+osls[0]+'→'+osls[osls.length-1]+' tokens: '+favs.map(x=>x.toFixed(2)).join(' → ')+'. Disaggregate ≥ '+r.thr_disagg.toFixed(2)+', hybrid ≥ '+r.thr_hybrid.toFixed(2)+'.');
+ // KV vs ISL
+ const isls=[256,512,1024,2048,4096,8192],kvs=isls.map(s=>analyze(g,m,{isl:s,osl:wl.osl}).kv_MB);
+ bar('cKV',isls,kvs,isls.map(()=>'#58a6ff'),'KV cache per request vs ISL (MB)');
+ _sum('cKV_sum','KV cache per request (MB) as input length grows '+isls[0]+'→'+isls[isls.length-1]+' tokens: '+kvs.map(x=>x.toFixed(0)).join(' → ')+'.');
+
+ // ---- COST / SLA panel + charts ----
+ const instName=document.getElementById('inst').value;
+ const ov=parseFloat(document.getElementById('priceOv').value)||null;
+ const c=cost(instName,g,m,wl,r,ov);
+ const cv=document.getElementById('cVerdict'); cv.textContent="cheaper: "+c.cheaper.toUpperCase(); cv.className="verdict "+c.cheaper; cv.style.fontSize="16px";
+ document.getElementById('cSav').textContent="("+(c.sav>=0?"+":"")+c.sav.toFixed(0)+"% vs the other)";
+ document.getElementById('cHr').textContent="$"+c.wholeHr.toFixed(2);
+ document.getElementById('cNote').textContent = (c.cheaper!==r.v)
+   ? "⚠ Cost and latency DISAGREE: latency favors "+r.v.toUpperCase()+", cost favors "+c.cheaper.toUpperCase()+". Disagg buys TTFT/SLA-attainment; agg buys $/token. Choose on your priority."
+   : "Cost and latency agree on "+c.cheaper.toUpperCase()+".";
+ bar('cCost',['aggregation ('+c.aggGpu+'gpu)','disaggregation ('+c.disGpu+'gpu)'],[c.aggC,c.disC],
+     ['#58a6ff', c.disC<=c.aggC?'#3fb950':'#f85149'],'Cost per 1M output tokens ($)');
+ _sum('cCost_sum','Cost per 1M output tokens: aggregation ($'+c.aggC.toFixed(2)+', '+c.aggGpu+' GPU) vs disaggregation ($'+c.disC.toFixed(2)+', '+c.disGpu+' GPU). Cheaper: '+c.cheaper+'.');
+ // cost vs concurrency crossover (agg saturates at interference; disagg scales further)
+ const concs=[1,4,16,64,256], base=(1000/r.itl)*0.9;
+ const aggCC=concs.map(x=>{const tps=base*m.tp*Math.min(x,8)/8*8; return cost(instName,g,m,wl,r,ov).wholeHr/8*m.tp/(Math.max(tps,1)*3600)*1e6;});
+ const disCC=concs.map(x=>{const tps=base*m.tp*Math.min(x,32)/32*16; return cost(instName,g,m,wl,r,ov).wholeHr/8*(m.tp*2)/(Math.max(tps,1)*3600)*1e6;});
+ if(charts.cCostConc)charts.cCostConc.destroy();
+ charts.cCostConc=new Chart(document.getElementById('cCostConc'),{type:'line',data:{labels:concs,datasets:[
+   {label:'aggregation',data:aggCC,borderColor:'#58a6ff',tension:.3},
+   {label:'disaggregation',data:disCC,borderColor:'#3fb950',tension:.3}]},
+   options:{plugins:{title:{display:true,text:'Cost vs concurrency (where disagg overtakes agg)',color:'#e6edf3'}},scales:{x:{type:'logarithmic',title:{display:true,text:'concurrency',color:'#8b949e'},ticks:{color:'#8b949e'}},y:{title:{display:true,text:'$/1M tok',color:'#8b949e'},ticks:{color:'#8b949e'}}}}});
+ _sum('cCostConc_sum','Cost vs concurrency ($/1M tok) over '+concs[0]+'→'+concs[concs.length-1]+' concurrent requests — aggregation: '+aggCC.map(x=>'$'+x.toFixed(0)).join(' → ')+'; disaggregation: '+disCC.map(x=>'$'+x.toFixed(0)).join(' → ')+'.');
+
+ // ---- "Does disaggregation help here?" banner (reads r.dva_* — bit-identical to calc.py disagg_vs_agg) ----
+ renderDva(r);
+ // ---- chart: where does disagg flip? cost/TTFT/ITL speedup vs ISL, parity line @1.0 + ±10% no-op band ----
+ const dIsls=[256,512,1024,2048,4096,8192,16384,32768];
+ const dRows=dIsls.map(s=>analyze(g,m,{isl:s,osl:wl.osl}));
+ const dCost=dRows.map(x=>x.dva_cost), dTtft=dRows.map(x=>x.dva_ttft), dItl=dRows.map(x=>x.dva_itl);
+ const bandw=r.dva_band_pct/100, lo=1-bandw, hi=1+bandw;
+ const allv=dCost.concat(dTtft,dItl,[1]); const yMax=Math.max(hi+0.05,Math.max(...allv)*1.08), yMin=Math.min(lo-0.05,Math.min(...allv)*0.92);
+ const flat=v=>dIsls.map(()=>v);
+ if(charts.cDva)charts.cDva.destroy();
+ charts.cDva=new Chart(document.getElementById('cDva'),{type:'line',
+   data:{labels:dIsls,datasets:[
+     {label:'no-op band +10%',data:flat(hi),borderColor:'rgba(139,148,158,.35)',borderWidth:1,borderDash:[2,3],pointRadius:0,fill:'+1',backgroundColor:'rgba(139,148,158,.12)',order:9},
+     {label:'no-op band −10%',data:flat(lo),borderColor:'rgba(139,148,158,.35)',borderWidth:1,borderDash:[2,3],pointRadius:0,fill:false,order:9},
+     {label:'parity (1.0)',data:flat(1),borderColor:'#8b949e',borderWidth:1.5,borderDash:[6,4],pointRadius:0,order:8},
+     {label:'Cost (÷2× GPUs)',data:dCost,borderColor:'#58a6ff',backgroundColor:'#58a6ff',tension:.25,pointRadius:2,order:1},
+     {label:'TTFT (+KV hop)',data:dTtft,borderColor:'#d29922',backgroundColor:'#d29922',tension:.25,pointRadius:2,order:1},
+     {label:'ITL (−interference)',data:dItl,borderColor:'#3fb950',backgroundColor:'#3fb950',tension:.25,pointRadius:2,borderWidth:2.4,order:0}]},
+   options:{responsive:true,interaction:{mode:'index',intersect:false},
+     plugins:{title:{display:true,text:'Where disagg flips — speedup (agg ÷ disagg) vs ISL',color:'#e6edf3'},
+       legend:{labels:{color:'#8b949e',boxWidth:12,filter:i=>!i.text.startsWith('no-op band')}},
+       tooltip:{callbacks:{label:c=>c.dataset.label+': '+(+c.parsed.y).toFixed(3)+'× '+(c.parsed.y>=hi?'(helps)':c.parsed.y<=lo?'(regresses)':'(no-op)')}}},
+     scales:{x:{type:'logarithmic',title:{display:true,text:'ISL — input length (OSL fixed)',color:'#8b949e'},ticks:{color:'#8b949e'}},
+       y:{min:yMin,max:yMax,title:{display:true,text:'speedup  (agg ÷ disagg) — >1 disagg better',color:'#8b949e'},ticks:{color:'#8b949e'},grid:{color:'#21262d'}}}}});
+ const cross=arr=>{for(let i=1;i<arr.length;i++){if((arr[i-1]-1)*(arr[i]-1)<0)return 'crosses 1.0 between ISL '+dIsls[i-1]+' and '+dIsls[i];}return (arr[arr.length-1]>=1?'stays ≥1 (helps) across the sweep':'stays <1 (regresses) across the sweep');};
+ _sum('cDva_sum','Disagg-vs-agg speedup as ISL grows '+dIsls[0]+'→'+dIsls[dIsls.length-1]+' (OSL '+wl.osl+'): '+
+   'Cost '+dCost[0].toFixed(2)+'→'+dCost[dCost.length-1].toFixed(2)+'× ('+cross(dCost)+'); '+
+   'TTFT '+dTtft[0].toFixed(2)+'→'+dTtft[dTtft.length-1].toFixed(2)+'× ('+cross(dTtft)+'); '+
+   'ITL '+dItl[0].toFixed(2)+'→'+dItl[dItl.length-1].toFixed(2)+'× ('+cross(dItl)+'). '+
+   'Above 1.0 = disagg helps, below = disagg regresses, ±10% band = no-op.');
+
+ optRun();   // refresh the Optimal Settings Finder against the (possibly changed) instance/model/ISL/OSL
+}
+// populate the help/regress banner from an analyze() result (pure DOM; physics already done in analyze)
+function renderDva(r){
+ const box=document.getElementById('dva'); if(!box)return;
+ box.className='dva '+(r.dva_overall==='no-op'?'noop':r.dva_overall);
+ const word={helps:'HELPS',regresses:'REGRESSES','no-op':'NO-OP',mixed:'MIXED'}[r.dva_overall]||'—';
+ const gly={helps:'▲',regresses:'▼','no-op':'＝',mixed:'◆'}[r.dva_overall]||'';
+ document.getElementById('dvaWord').innerHTML='<span class="gly" aria-hidden="true">'+gly+'</span><span>'+word+'</span><span class="pct">disaggregation vs aggregation, here</span>';
+ document.getElementById('dvaSum').textContent=r.dva_summary;
+ const f2=(v)=>(+v).toFixed(2);
+ const chip=(ax,sp,bd)=>'<span class="dva-chip '+(bd==='no-op'?'noop':bd)+'"><span class="ax">'+ax+'</span><span class="x">'+f2(sp)+'×</span><span class="bd">'+bd+'</span></span>';
+ document.getElementById('dvaChips').innerHTML=
+   chip('Cost',r.dva_cost,r.dva_bands.cost)+chip('TTFT',r.dva_ttft,r.dva_bands.ttft)+chip('ITL',r.dva_itl,r.dva_bands.itl);
+}
+// ===== Optimal Settings Finder — port of analyze/optimizer.py (keep in sync) =====
+// MEASURED calibration anchors (optimizer.py CAL_OBS["nemotron-ultra-550b@p5en"]; synced to calculator.html ANCHOR).
+const OPT_CAL={itl0:78.0,b_knee:32.0,itl_max:250.0,tp8_cudagraph_oom:true,disagg_ttft_penalty:127.0,disagg_tput_factor:0.95};
+const OPT_GRID={topology:["agg","disagg"],max_num_seqs:[16,32,64,128,256],
+  concurrency:[1,4,8,16,32,64,128,256],chunk:[2048,4096,8192],cuda_graphs:[false,true]};
+const UTIL_CEILING=0.98;
+function optItl(batch){return OPT_CAL.itl0*Math.max(1.0,batch/OPT_CAL.b_knee);}      // ITL(batch): flat→linear at b_knee
+// KV-budget concurrency cap = calc.py memory_fit.concurrency_at_workload (TOTAL params for memory; family-aware KV).
+function kvConcCap(g,instName,m,wl){
+ const kv_bpt=kvBpt(m);                                                               // family-aware (GQA/MLA/hybrid)
+ const weights_GB=m.ptot*(DB[m.wdtype]||2);                                            // TOTAL resident weights
+ const total_hbm_GB=m.tp*(m.pp||1)*(g.hbm_cap_GB||80);                                 // INSTANCES capacity × tp*pp GPUs (PP spreads layers across nodes)
+ const kv_budget_GB=total_hbm_GB*UTIL_CEILING-weights_GB;
+ const fits=kv_budget_GB>0.5;
+ if(!fits) return 0.0;
+ // per-request average footprint: attention KV grows during decode (~isl+osl/2) + constant Mamba state
+ const per_req_avg_bytes=kv_bpt*(wl.isl+wl.osl/2.0)+mambaStateBytes(m);
+ return (per_req_avg_bytes>0)?(kv_budget_GB*1e9/per_req_avg_bytes):0.0;                // reqs of this workload in KV
+}
+// Predict one knob combo (optimizer.py model_point). Returns null if batch<1; {feasible:false} if graphs OOM.
+function optPoint(g,instName,m,wl,topo,conc,mns,chunk,cg){
+ const kv_conc=Math.max(kvConcCap(g,instName,m,wl),1);
+ const batch=Math.min(conc,mns,kv_conc);
+ if(batch<1)return null;
+ let itl=optItl(batch),feasible=true,note="";
+ if(cg){ if(OPT_CAL.tp8_cudagraph_oom){feasible=false;note="CUDA graphs OOM at TP8 (MEASURED) — needs TP16 or fp8 KV";} else {itl*=0.82;} }
+ let ttft=110.0*Math.pow(batch,0.45)*Math.pow(8192.0/chunk,0.15);
+ let out=batch/itl*1000.0;
+ if(topo==="disagg"){ttft+=OPT_CAL.disagg_ttft_penalty;out*=OPT_CAL.disagg_tput_factor;}
+ return {batch,ttft_ms:+ttft.toFixed(1),itl_ms:+itl.toFixed(1),out_tok_s:+out.toFixed(1),feasible,note,kv_conc};
+}
+const OPT_KEYFN={cost:r=>r.usd_per_Mtok,goodput:r=>-r.out_tok_s,latency:r=>r.itl_ms};
+function optimize(g,instName,m,wl,sloTtft,sloTpot,objective,gpuHr){
+ const tp=m.tp,pts=[];let graphsFiltered=false;
+ for(const topo of OPT_GRID.topology){
+  const gpus=tp*(topo==="disagg"?2:1);
+  for(const mns of OPT_GRID.max_num_seqs)for(const conc of OPT_GRID.concurrency){ if(conc<1)continue;
+   for(const chunk of OPT_GRID.chunk)for(const cg of OPT_GRID.cuda_graphs){
+    const p=optPoint(g,instName,m,wl,topo,conc,mns,chunk,cg);
+    if(p===null)continue;
+    if(!p.feasible){graphsFiltered=true;continue;}
+    if(p.ttft_ms>sloTtft||p.itl_ms>sloTpot)continue;                                   // joint SLO gate (TTFT + ITL)
+    const usd=(gpuHr*gpus)/Math.max(p.out_tok_s*3600.0,1e-9)*1e6;
+    pts.push({topology:topo,gpus,max_num_seqs:mns,concurrency:conc,max_num_batched_tokens:chunk,
+              cuda_graphs:cg,...p,usd_per_Mtok:+usd.toFixed(2)});
+   }
+  }
+ }
+ const constraints=OPT_CAL.tp8_cudagraph_oom?["CUDA graphs OOM at TP8 (measured) — graph configs filtered out unless TP16/fp8"]:[];
+ if(!pts.length)return {optimum:null,n_feasible:0,reason:"no knob combo meets the SLO — loosen SLO / add GPUs / fp8 KV",constraints,graphsFiltered};
+ const keyfn=OPT_KEYFN[objective];
+ let best=pts[0];for(const r of pts)if(keyfn(r)<keyfn(best))best=r;
+ // sensitivity: best objective at each value of each knob (optimizer.py _sensitivity)
+ const sens={};
+ for(const knob of ["topology","max_num_seqs","concurrency","max_num_batched_tokens"]){
+  const byVal={};
+  for(const r of pts){const v=r[knob];if(byVal[v]===undefined||keyfn(r)<keyfn(byVal[v]))byVal[v]=r;}
+  sens[knob]=byVal;
+ }
+ return {optimum:best,n_feasible:pts.length,sensitivity:sens,constraints,graphsFiltered};
+}
+function optRun(){
+ const instName=document.getElementById('inst').value, g=INSTANCES[instName];
+ const m=readModel();   // carries ptot/pact + family-aware KV fields so kvConcCap() mirrors calc.py memory_fit
+ const wl={isl:+isl.value,osl:+osl.value};
+ const sloTtft=+document.getElementById('sloTtft').value, sloTpot=+document.getElementById('sloTpot').value;
+ const objective=document.getElementById('objective').value;
+ const ov=parseFloat(document.getElementById('priceOv').value)||null;
+ const gpuHr=(ov||PRICE[instName])/8.0;
+ const unit=objective==="cost"?"$/Mtok":(objective==="goodput"?"tok/s":"ITL ms");
+ document.getElementById('optObjLabel').textContent=unit;
+ const res=optimize(g,instName,m,wl,sloTtft,sloTpot,objective,gpuHr);
+ const out=document.getElementById('optResult'), sensEl=document.getElementById('optSens');
+ if(!res.optimum){
+  out.innerHTML='<div class="opt-none"><div class="lead">No feasible config</div>'+
+    '<div>'+res.reason+'.</div><div class="why" style="margin-top:6px">Tried '+
+    (OPT_GRID.topology.length*OPT_GRID.max_num_seqs.length*OPT_GRID.concurrency.length*OPT_GRID.chunk.length*OPT_GRID.cuda_graphs.length)+
+    ' combos. Measured ITL floor is '+OPT_CAL.itl0+'ms, so any SLO TPOT below that fails by construction.</div></div>';
+  sensEl.innerHTML='<div class="mut">— (no feasible points)</div>';
+  if(charts.cOptKnee){charts.cOptKnee.destroy();delete charts.cOptKnee;}
+  // still draw an (infeasible) curve hint? No — keep empty to signal nothing clears the SLO.
+  bar('cOptKnee',[],[],[],'$/Mtok & tok/s vs concurrency — no feasible config');
+  _sum('cOptKnee_sum','No feasible config at this SLO — nothing to chart.');
+  return;
+ }
+ const o=res.optimum;
+ out.innerHTML='<div class="opt-best"><div class="lead">OPTIMAL — '+o.topology.toUpperCase()+
+   ' &nbsp;·&nbsp; $'+o.usd_per_Mtok+'/Mtok &nbsp;·&nbsp; '+o.out_tok_s+' tok/s</div>'+
+   '<div class="chips">'+
+     '<span class="chip"><span class="k">topology</span> '+o.topology+'</span>'+
+     '<span class="chip"><span class="k">concurrency</span> '+o.concurrency+'</span>'+
+     '<span class="chip"><span class="k">max-num-seqs</span> '+o.max_num_seqs+'</span>'+
+     '<span class="chip"><span class="k">chunk</span> '+o.max_num_batched_tokens+'</span>'+
+     '<span class="chip"><span class="k">cuda-graphs</span> '+o.cuda_graphs+'</span>'+
+     '<span class="chip"><span class="k">TTFT</span> '+o.ttft_ms+' ms</span>'+
+     '<span class="chip"><span class="k">ITL</span> '+o.itl_ms+' ms</span>'+
+     '<span class="chip"><span class="k">eff. batch</span> '+(+o.batch.toFixed(1))+'</span>'+
+     '<span class="chip"><span class="k">GPUs</span> '+o.gpus+'</span>'+
+   '</div>'+
+   '<div class="why" style="margin-top:8px">Best of '+res.n_feasible+' SLO-feasible configs at SLO(TTFT ≤ '+sloTtft+'ms, TPOT ≤ '+sloTpot+'ms), objective = '+objective+'.</div>'+
+   (res.graphsFiltered?'<div class="cav">⚠ '+res.constraints[0]+'.</div>':'')+
+   '</div>';
+ // ---- sensitivity tables (one per knob) ----
+ const fmt=(r)=>({cost:'$'+r.usd_per_Mtok,goodput:r.out_tok_s+' tok/s',latency:r.itl_ms+' ms'}[objective]);
+ let html='';
+ const labels={topology:"Topology",max_num_seqs:"max-num-seqs",concurrency:"Concurrency",max_num_batched_tokens:"Chunk"};
+ for(const knob of ["topology","max_num_seqs","concurrency","max_num_batched_tokens"]){
+  const byVal=res.sensitivity[knob];
+  const keys=Object.keys(byVal).sort((a,b)=>{const na=+a,nb=+b;return (isNaN(na)||isNaN(nb))?(a<b?-1:1):na-nb;});
+  html+='<table class="sens"><caption>'+labels[knob]+'</caption><tr><th>value</th><th>best '+unit+'</th><th>tok/s</th><th>TTFT</th><th>ITL</th></tr>';
+  for(const k of keys){const r=byVal[k];const isOpt=(''+o[knob])===(''+k);
+   html+='<tr><td>'+k+(isOpt?' ★':'')+'</td><td class="'+(isOpt?'optcell':'')+'">'+fmt(r)+'</td><td>'+r.out_tok_s+'</td><td>'+r.ttft_ms+'</td><td>'+r.itl_ms+'</td></tr>';}
+  html+='</table>';
+ }
+ sensEl.innerHTML=html;
+ // ---- "find the knee" chart: $/Mtok (left) + tok/s (right) vs concurrency, for the OPTIMAL topology ----
+ // Hold the other knobs at the optimum; sweep concurrency over the grid (ignore SLO so the full curve shows).
+ const concs=OPT_GRID.concurrency;
+ const cpm=[],tps=[];
+ for(const c of concs){
+  const p=optPoint(g,instName,m,wl,o.topology,c,o.max_num_seqs,o.max_num_batched_tokens,o.cuda_graphs);
+  if(p&&p.feasible){cpm.push(+((gpuHr*o.gpus)/Math.max(p.out_tok_s*3600.0,1e-9)*1e6).toFixed(2));tps.push(p.out_tok_s);}
+  else{cpm.push(null);tps.push(null);}
+ }
+ if(charts.cOptKnee)charts.cOptKnee.destroy();
+ charts.cOptKnee=new Chart(document.getElementById('cOptKnee'),{data:{labels:concs,datasets:[
+   {type:'line',label:'$/Mtok',data:cpm,borderColor:'#58a6ff',yAxisID:'y',tension:.3},
+   {type:'line',label:'tok/s',data:tps,borderColor:'#3fb950',yAxisID:'y1',tension:.3}]},
+   options:{plugins:{title:{display:true,text:'Find the knee — $/Mtok & tok/s vs concurrency ('+o.topology+')',color:'#e6edf3'},legend:{labels:{color:'#8b949e'}}},
+     scales:{x:{type:'logarithmic',title:{display:true,text:'concurrency',color:'#8b949e'},ticks:{color:'#8b949e'}},
+       y:{position:'left',title:{display:true,text:'$/1M tok',color:'#58a6ff'},ticks:{color:'#58a6ff'}},
+       y1:{position:'right',title:{display:true,text:'tok/s',color:'#3fb950'},ticks:{color:'#3fb950'},grid:{drawOnChartArea:false}}}}});
+ _sum('cOptKnee_sum','Find the knee for the optimal '+o.topology+' topology over concurrency '+concs[0]+'→'+concs[concs.length-1]+': $/Mtok '+cpm.map(x=>x==null?'—':'$'+x.toFixed(0)).join(' → ')+'; tok/s '+tps.map(x=>x==null?'—':x.toFixed(0)).join(' → ')+'.');
+}
+fillSelects(); run();
+</script>
+</body></html>

--- a/Container-Root/eks/deployment/inference/agentic-ai/disagg-calculator/web/index.html
+++ b/Container-Root/eks/deployment/inference/agentic-ai/disagg-calculator/web/index.html
@@ -5,12 +5,18 @@
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>Aggregation vs Disaggregation Optimizer — should you split prefill/decode?</title>
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 16 16%27%3E%3Crect width=%2716%27 height=%2716%27 rx=%273%27 fill=%27%230d1117%27/%3E%3Crect x=%273%27 y=%279%27 width=%273%27 height=%274%27 fill=%27%2358a6ff%27/%3E%3Crect x=%277%27 y=%276%27 width=%273%27 height=%277%27 fill=%27%23d29922%27/%3E%3Crect x=%2711%27 y=%273%27 width=%273%27 height=%2710%27 fill=%27%233fb950%27/%3E%3C/svg%3E">
 <!-- Self-contained client-side tool. NO API keys here. Mirrors analyze/calc.py physics in JS.
      Chart.js from CDN (charts only); the optional visual-LLM verdict is a server-side step (analyze/visual_verdict.py). -->
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
 <style>
  :root{--bg:#0d1117;--card:#161b22;--fg:#e6edf3;--mut:#8b949e;--acc:#58a6ff;--ok:#3fb950;--warn:#d29922;--bad:#f85149}
  *{box-sizing:border-box} body{margin:0;background:var(--bg);color:var(--fg);font:14px/1.5 system-ui,Segoe UI,Roboto,sans-serif}
+ .disclaimer{margin:10px 24px 0;padding:9px 13px;border:1px solid #c89b3c;border-left:4px solid #c89b3c;background:#2a2410;color:#e8d9a0;border-radius:6px;font-size:12px;line-height:1.5}
+ .disclaimer b{color:#f0c552}
+ .glossary{margin:8px 24px 0;font-size:12px;color:var(--mut)} .glossary summary{cursor:pointer;color:var(--acc)}
+ .gloss-grid{display:grid;grid-template-columns:1fr 1fr;gap:3px 24px;margin-top:6px} .gloss-grid b{color:var(--fg)}
+ @media(max-width:760px){.gloss-grid{grid-template-columns:1fr}}
  header{padding:18px 24px;border-bottom:1px solid #30363d} h1{margin:0;font-size:19px} .sub{color:var(--mut);font-size:13px;margin-top:4px}
  h1 .brand{color:var(--mut);font-weight:400}            /* decision leads; the descriptor rides along, de-emphasized */
  .sub .honest{color:var(--fg)}                          /* the agg-vs-disagg honesty line reads as a feature, not a footnote */
@@ -24,10 +30,27 @@
    .grid{grid-template-columns:1fr}      /* charts + KPI stack */
    canvas{max-height:300px}
    table.sens{display:block;overflow-x:auto}   /* sensitivity tables scroll, page doesn't */
+   table.uc{display:block;overflow-x:auto;max-width:100%}   /* use-case table scrolls within itself, not the page */
+   .card{padding:12px;min-width:0}             /* cards must not force min-content width on mobile */
+   .wrap>div{min-width:0}                       /* grid children shrink instead of overflowing */
+ }
+ html,body{overflow-x:hidden}                    /* belt-and-suspenders: no page-level horizontal scroll */
+ @media(prefers-reduced-motion:reduce){*{animation-duration:.001ms!important;transition-duration:.001ms!important}}  /* WCAG 2.3.3 — respect motion sensitivity */
+ /* print / PDF: people screenshot+PDF a verdict for sign-off — keep it legible + the disclaimer must survive */
+ @media print{
+   :root{--bg:#fff;--card:#fff;--fg:#111;--mut:#444}
+   body{background:#fff;color:#111}
+   details{display:block!important} details>summary{font-weight:600}  /* expand glossary/methodology in print */
+   .disclaimer{border:1px solid #b8860b;background:#fff8e6;color:#5a4500;-webkit-print-color-adjust:exact;print-color-adjust:exact}
+   button,.opt-none{display:none}                                     /* hide interactive-only controls */
+   .card{border:1px solid #ccc;break-inside:avoid}
+   .topo,.diag,pre,.formula{background:#f6f8fa!important;color:#111!important;-webkit-print-color-adjust:exact;print-color-adjust:exact}
+   .explain{break-inside:avoid}
  }
  label{display:block;color:var(--mut);font-size:12px;margin:10px 0 3px} input,select{width:100%;background:#0d1117;color:var(--fg);border:1px solid #30363d;border-radius:6px;padding:7px}
  .row{display:grid;grid-template-columns:1fr 1fr;gap:10px} button{margin-top:14px;width:100%;background:var(--acc);color:#06121f;border:0;border-radius:6px;padding:10px;font-weight:600;cursor:pointer}
- .verdict{font-size:22px;font-weight:700;margin:4px 0} .verdict.disaggregate{color:var(--ok)} .verdict.hybrid{color:var(--warn)} .verdict.aggregate{color:var(--acc)}
+ .verdict{font-size:30px;font-weight:800;margin:4px 0;letter-spacing:-.3px;line-height:1.15} .verdict.disaggregate{color:var(--ok)} .verdict.hybrid{color:var(--warn)} .verdict.aggregate{color:var(--acc)}
+ .verdict-label{font-size:11px;text-transform:uppercase;letter-spacing:.08em;color:var(--mut);font-weight:600;margin-top:6px}
  /* verdict carries a SHAPE prefix too (CSS ::before keyed on the verdict class the JS sets), so the
     meaning is never color-only — passes a11y / colorblind. Pure presentation; no JS change. */
  .verdict::before{font-family:ui-monospace,Menlo,monospace;margin-right:9px;font-size:18px;vertical-align:1px}
@@ -139,14 +162,18 @@
 <body>
 <header>
   <h1>Aggregation vs Disaggregation Optimizer <span class="brand">— should you split prefill/decode?</span></h1>
-  <div class="sub">Enter an AWS instance + model + workload → get the <b>topology verdict</b>: aggregate, hybrid, or disaggregate. <b class="honest">Disaggregation is not free — it helps for some workloads and regresses for others. This tool tells you which: when it helps, when it&rsquo;s a no-op, and when it costs you (at the 1P:1D floor it&rsquo;s a latency play, not a cost play).</b> Physics mirrors <code>analyze/calc.py</code>; calibrated to measured Nemotron-3 Ultra 550B / p5en. Estimator — confirm with a live sweep.</div>
-  <div style="margin:10px 0;padding:8px 12px;border:1px solid #c89b3c;background:#2a2410;color:#e8d9a0;border-radius:6px;font-size:12px;line-height:1.45">
-    <b>Disclaimer.</b> Provided free of charge, as a utility, for quick <b>estimation and planning only</b>. AWS and the
-    authors make <b>no representation, warranty, or guarantee</b> of model performance, throughput, latency, or cost, and
-    <b>accept no liability</b> for any outcome arising from its use. Actual measured results will differ from the
-    calculated numbers — always validate on your own hardware with your own workload before deployment or purchasing
-    decisions. Provided <b>&ldquo;AS IS&rdquo;</b>.
-  </div>
+  <div class="sub">Enter an AWS instance + model + workload → get the <b>topology verdict</b>: aggregate, hybrid, or disaggregate. <b class="honest">Disaggregation is not free — it helps for some workloads and regresses for others. This tool tells you which: when it helps, when it&rsquo;s a no-op, and when it costs you (at the 1P:1D floor it&rsquo;s a latency play, not a cost play).</b> Physics mirrors <code>analyze/calc.py</code>; calibrated to measured Nemotron-3 Ultra 550B / p5en. Estimator — confirm with a live GPU sweep.</div>
+  <div class="disclaimer" role="note" aria-label="Disclaimer"><b>⚠ Disclaimer:</b> Provided free, as a utility, for quick <b>estimation and planning only</b>. AWS and the authors make <b>no representation, warranty, or guarantee</b> of model performance, throughput, latency, or cost, and <b>accept no liability</b> for any outcome of its use. Actual measured results will differ — always validate on your own hardware before deployment or purchasing decisions. Provided <b>&ldquo;AS IS&rdquo;</b>.</div>
+  <details class="glossary"><summary>Glossary — terms used below</summary>
+    <div class="gloss-grid">
+      <span><b>ISL</b> input seq length (prompt tokens)</span><span><b>OSL</b> output seq length (generated tokens)</span>
+      <span><b>KV</b> key/value attention cache</span><span><b>HBM</b> GPU high-bandwidth memory</span>
+      <span><b>TTFT</b> time to first token</span><span><b>ITL/TPOT</b> inter-token latency / time per output token</span>
+      <span><b>SLO/SLA</b> latency target / service-level agreement</span><span><b>TP/PP</b> tensor / pipeline parallelism</span>
+      <span><b>1P:1D</b> 1 prefill : 1 decode worker</span><span><b>MFU/MBU</b> model-FLOP / memory-bandwidth utilization</span>
+      <span><b>RDMA</b> remote direct memory access (EFA)</span><span><b>$/Mtok</b> cost per 1M output tokens</span>
+    </div>
+  </details>
 </header>
 
 <!-- ============ EXPLAINER ============ -->
@@ -284,6 +311,11 @@ fav          = toll × interference
     <p>Intuition: <b>disaggregation only pays off when it removes a lot of decode-stalling interference AND the KV cache
     is cheap to move.</b> Long prompts + short outputs raise interference (favors disagg); short prompts, or a fat KV
     cache over a slow link, raise the toll (favors agg). The verdict is a sliding scale, not a coin flip.</p>
+    <p class="mut" style="font-size:12.5px">Under the hood the two inputs are <b>not</b> naive rooflines — <code>prefill_ms</code> adds the
+    <b>O(ISL²) quadratic-attention</b> term (dominates at long context, not just linear <code>2·P·ISL</code>) scaled by the
+    <b>quantized peak</b> (fp8 ≈2×, fp4 ≈4× vs bf16); <code>decode_ITL</code> adds the <b>context-dependent KV-read</b> (each token
+    re-reads the whole KV cache so far) on top of the measured family calibration; and chunked-prefill recovery, the hybrid-Mamba
+    constant SSM state, and an SLO gate are all folded in. Every one mirrors <code>analyze/calc.py</code> exactly (parity-tested).</p>
   </div>
 </details>
 
@@ -490,6 +522,8 @@ fav          = toll × interference
   </div>
 </div>
 <script>
+// a11y (WCAG 2.3.3): respect prefers-reduced-motion — disable Chart.js animation for motion-sensitive users.
+try{ if(window.Chart && window.matchMedia && matchMedia('(prefers-reduced-motion: reduce)').matches){ Chart.defaults.animation=false; } }catch(e){}
 // ---- mirror of analyze/calc.py (keep in sync) ----
 // hbm_GBs = HBM BANDWIDTH per GPU (decode roofline); hbm_cap_GB = HBM CAPACITY per GPU (memory fit / KV budget).
 const INSTANCES={
@@ -701,10 +735,10 @@ let charts={};
 // a11y: write a one-line text summary under a chart (screen-reader / no-canvas fallback).
 // pure DOM text write; touches no physics. no-op if the element is absent.
 function _sum(id,txt){ const el=document.getElementById(id); if(el) el.textContent=txt; }
-function bar(id,labels,data,colors,title){
+function bar(id,labels,data,colors,title,xlab,ylab){
  if(charts[id])charts[id].destroy();
  charts[id]=new Chart(document.getElementById(id),{type:'bar',data:{labels,datasets:[{label:title,data,backgroundColor:colors}]},
-  options:{plugins:{legend:{display:false},title:{display:true,text:title,color:'#e6edf3'}},scales:{x:{ticks:{color:'#8b949e'}},y:{ticks:{color:'#8b949e'}}}}});
+  options:{plugins:{legend:{display:false},title:{display:true,text:title,color:'#e6edf3'}},scales:{x:{title:xlab?{display:true,text:xlab,color:'#8b949e'}:{display:false},ticks:{color:'#8b949e'}},y:{title:ylab?{display:true,text:ylab,color:'#8b949e'}:{display:false},ticks:{color:'#8b949e'}}}}});
 }
 function run(){
  syncUseCase();   // keep the use-case dropdown + hint in sync with whatever ISL/OSL currently are
@@ -720,16 +754,16 @@ function run(){
  document.getElementById('cav').textContent = m.family==="hybrid-mamba"?"⚠ hybrid-Mamba: PP1 only on EFA; KV pull descriptor-bound. Confirm with a live GPU sweep.":"Estimator — confirm verdict with a live GPU sweep on real GPUs.";
  kKV.textContent=r.kv_MB.toFixed(1)+" MB"; kXfer.textContent=r.xfer.toFixed(1)+" ms"; kPre.textContent=r.pre.toFixed(0)+" ms";
  kITL.textContent=r.itl.toFixed(1)+" ms"; kLine.textContent=r.line.toFixed(0)+" GB/s"; kImb.textContent=r.imb.toFixed(1)+"×";
- bar('cTime',['KV xfer','Prefill','Decode/tok','Decode phase'],[r.xfer,r.pre,r.itl,r.dphase],['#58a6ff','#d29922','#3fb950','#8957e5'],'Latency components (ms)');
+ bar('cTime',['KV xfer','Prefill','Decode/tok','Decode phase'],[r.xfer,r.pre,r.itl,r.dphase],['#58a6ff','#d29922','#3fb950','#8957e5'],'Latency components',null,'milliseconds');
  _sum('cTime_sum','Latency components (ms): KV transfer '+r.xfer.toFixed(1)+', prefill '+r.pre.toFixed(0)+', decode/token '+r.itl.toFixed(1)+', full decode phase '+r.dphase.toFixed(0)+'.');
  // favorability sweep over OSL to show where the verdict flips
  const osls=[64,128,256,512,1024],favs=osls.map(o=>analyze(g,m,{isl:wl.isl,osl:o}).fav);
  if(charts.cFav)charts.cFav.destroy();
- charts.cFav=new Chart(document.getElementById('cFav'),{type:'line',data:{labels:osls,datasets:[{label:'disagg favorability vs OSL',data:favs,borderColor:'#3fb950',tension:.3}]},options:{plugins:{title:{display:true,text:'Disagg favorability vs output length',color:'#e6edf3'},legend:{display:false}},scales:{x:{title:{display:true,text:'OSL',color:'#8b949e'},ticks:{color:'#8b949e'}},y:{min:0,max:1,ticks:{color:'#8b949e'}}}}});
+ charts.cFav=new Chart(document.getElementById('cFav'),{type:'line',data:{labels:osls,datasets:[{label:'disagg favorability vs OSL',data:favs,borderColor:'#3fb950',tension:.3}]},options:{plugins:{title:{display:true,text:'Disagg favorability vs output length',color:'#e6edf3'},legend:{display:false}},scales:{x:{title:{display:true,text:'OSL — output length (tokens)',color:'#8b949e'},ticks:{color:'#8b949e'}},y:{min:0,max:1,title:{display:true,text:'disagg favorability (0–1)',color:'#8b949e'},ticks:{color:'#8b949e'}}}}});
  _sum('cFav_sum','Disagg favorability (0–1) as output length grows '+osls[0]+'→'+osls[osls.length-1]+' tokens: '+favs.map(x=>x.toFixed(2)).join(' → ')+'. Disaggregate ≥ '+r.thr_disagg.toFixed(2)+', hybrid ≥ '+r.thr_hybrid.toFixed(2)+'.');
  // KV vs ISL
  const isls=[256,512,1024,2048,4096,8192],kvs=isls.map(s=>analyze(g,m,{isl:s,osl:wl.osl}).kv_MB);
- bar('cKV',isls,kvs,isls.map(()=>'#58a6ff'),'KV cache per request vs ISL (MB)');
+ bar('cKV',isls,kvs,isls.map(()=>'#58a6ff'),'KV cache per request','ISL — input length (tokens)','KV cache (MB)');
  _sum('cKV_sum','KV cache per request (MB) as input length grows '+isls[0]+'→'+isls[isls.length-1]+' tokens: '+kvs.map(x=>x.toFixed(0)).join(' → ')+'.');
 
  // ---- COST / SLA panel + charts ----
@@ -743,7 +777,7 @@ function run(){
    ? "⚠ Cost and latency DISAGREE: latency favors "+r.v.toUpperCase()+", cost favors "+c.cheaper.toUpperCase()+". Disagg buys TTFT/SLA-attainment; agg buys $/token. Choose on your priority."
    : "Cost and latency agree on "+c.cheaper.toUpperCase()+".";
  bar('cCost',['aggregation ('+c.aggGpu+'gpu)','disaggregation ('+c.disGpu+'gpu)'],[c.aggC,c.disC],
-     ['#58a6ff', c.disC<=c.aggC?'#3fb950':'#f85149'],'Cost per 1M output tokens ($)');
+     ['#58a6ff', c.disC<=c.aggC?'#3fb950':'#f85149'],'Cost per 1M output tokens',null,'$ / 1M tok');
  _sum('cCost_sum','Cost per 1M output tokens: aggregation ($'+c.aggC.toFixed(2)+', '+c.aggGpu+' GPU) vs disaggregation ($'+c.disC.toFixed(2)+', '+c.disGpu+' GPU). Cheaper: '+c.cheaper+'.');
  // cost vs concurrency crossover (agg saturates at interference; disagg scales further)
  const concs=[1,4,16,64,256], base=(1000/r.itl)*0.9;

--- a/Container-Root/eks/deployment/inference/agentic-ai/disagg-calculator/web/index.html
+++ b/Container-Root/eks/deployment/inference/agentic-ai/disagg-calculator/web/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<!-- Author: Anton Alexander | Source: github.com/dmvevents/dynamo-disagg-optimizer · live: dmvevents.github.io/dynamo-disagg-optimizer/calculator.html -->
+<!-- Author: Anton Alexander -->
 <html lang="en">
 <head>
 <meta charset="utf-8"/>

--- a/Container-Root/eks/deployment/inference/agentic-ai/disagg-calculator/web/index.html
+++ b/Container-Root/eks/deployment/inference/agentic-ai/disagg-calculator/web/index.html
@@ -139,7 +139,14 @@
 <body>
 <header>
   <h1>Aggregation vs Disaggregation Optimizer <span class="brand">— should you split prefill/decode?</span></h1>
-  <div class="sub">Enter an AWS instance + model + workload → get the <b>topology verdict</b>: aggregate, hybrid, or disaggregate. <b class="honest">Disaggregation is not free — it helps for some workloads and regresses for others. This tool tells you which: when it helps, when it&rsquo;s a no-op, and when it costs you (at the 1P:1D floor it&rsquo;s a latency play, not a cost play).</b> Physics mirrors <code>analyze/calc.py</code>; calibrated to measured Nemotron-3 Ultra 550B / p5en. Estimator — confirm with <code>driver/sweep.py</code>.</div>
+  <div class="sub">Enter an AWS instance + model + workload → get the <b>topology verdict</b>: aggregate, hybrid, or disaggregate. <b class="honest">Disaggregation is not free — it helps for some workloads and regresses for others. This tool tells you which: when it helps, when it&rsquo;s a no-op, and when it costs you (at the 1P:1D floor it&rsquo;s a latency play, not a cost play).</b> Physics mirrors <code>analyze/calc.py</code>; calibrated to measured Nemotron-3 Ultra 550B / p5en. Estimator — confirm with a live sweep.</div>
+  <div style="margin:10px 0;padding:8px 12px;border:1px solid #c89b3c;background:#2a2410;color:#e8d9a0;border-radius:6px;font-size:12px;line-height:1.45">
+    <b>Disclaimer.</b> Provided free of charge, as a utility, for quick <b>estimation and planning only</b>. AWS and the
+    authors make <b>no representation, warranty, or guarantee</b> of model performance, throughput, latency, or cost, and
+    <b>accept no liability</b> for any outcome arising from its use. Actual measured results will differ from the
+    calculated numbers — always validate on your own hardware with your own workload before deployment or purchasing
+    decisions. Provided <b>&ldquo;AS IS&rdquo;</b>.
+  </div>
 </header>
 
 <!-- ============ EXPLAINER ============ -->
@@ -391,7 +398,7 @@ fav          = toll × interference
         <b>How to read this:</b> a <b>directional L0 screen</b>, calibrated to a single measured anchor
         (<b>n=1</b>): Nemotron-3 Ultra 550B, <b>bf16</b>, <b>H200 / p5en</b>, <b>TP8</b>. It models per-request
         single-stream latency — <b>not</b> a validated multi-tenant simulator. Confirm any verdict with
-        <code>driver/sweep.py</code> on real GPUs before acting.
+        <code>a live GPU sweep</code> on real GPUs before acting.
       </div>
       <div class="trustchip"><span class="dot" aria-hidden="true"></span><span>Honest by design — across our 240-cell catalog the verdict splits roughly evenly: <b>~52% disaggregate, ~48% aggregate-or-hybrid</b>. And on the cost axis at the 1P:1D floor, disagg almost always regresses (it&rsquo;s a latency play). A no-op or a regression is a real result, not a failure.</span></div>
       <details class="whatis">
@@ -710,7 +717,7 @@ function run(){
  document.getElementById('why').textContent=r.why;
  document.getElementById('vmodel').textContent=(preset.value||"custom")+" ("+m.family+")";
  document.getElementById('vinst').textContent=document.getElementById('inst').value+" ("+g.gpu+")";
- document.getElementById('cav').textContent = m.family==="hybrid-mamba"?"⚠ hybrid-Mamba: PP1 only on EFA; KV pull descriptor-bound. Confirm with driver/sweep.py.":"Estimator — confirm verdict with driver/sweep.py on real GPUs.";
+ document.getElementById('cav').textContent = m.family==="hybrid-mamba"?"⚠ hybrid-Mamba: PP1 only on EFA; KV pull descriptor-bound. Confirm with a live GPU sweep.":"Estimator — confirm verdict with a live GPU sweep on real GPUs.";
  kKV.textContent=r.kv_MB.toFixed(1)+" MB"; kXfer.textContent=r.xfer.toFixed(1)+" ms"; kPre.textContent=r.pre.toFixed(0)+" ms";
  kITL.textContent=r.itl.toFixed(1)+" ms"; kLine.textContent=r.line.toFixed(0)+" GB/s"; kImb.textContent=r.imb.toFixed(1)+"×";
  bar('cTime',['KV xfer','Prefill','Decode/tok','Decode phase'],[r.xfer,r.pre,r.itl,r.dphase],['#58a6ff','#d29922','#3fb950','#8957e5'],'Latency components (ms)');


### PR DESCRIPTION
## What

Adds a **disaggregation calculator** — an architecture-first decision tool for the agg-vs-disagg LLM-serving question — at `Container-Root/eks/deployment/inference/agentic-ai/disagg-calculator/`, as a planning companion to the existing `inference/agentic-ai/nemotron/ultra` deployment.

Given a model's `config.json` + a GPU (HBM/bandwidth) + a workload (ISL/OSL, SLO), it reports the **memory fit**, predicted **TTFT/ITL/throughput**, **$/Mtok** for agg vs disagg, and a **verdict** (aggregate / hybrid / disaggregate) with the reasoning. Pure Python stdlib (no install) + two static HTML pages (no server) — clone and run, following the [do-framework](https://bit.ly/do-framework) principles.

## Why

The hard part of disaggregation is deciding *whether to* before spending GPU hours. This tool screens the decision analytically (the cheap layer), and is calibrated to live-measured numbers on p5en/H200 so it doesn't over-promise (a naive HBM roofline says hybrid models are "fast"; the live system is decode-latency-bound — the calculator corrects for that).

## Contents

```
disagg-calculator/
  analyze/calc.py + calibration.py   # the engine (see note)
  results/calibration/ledger.jsonl   # measured datapoints it calibrates against (seeded p5en/H200)
  web/{index,calculator}.html        # in-browser calculator, mirrors calc.py
  docs/{PRODUCTION-GUIDE,METHODOLOGY}.md
  README.md
```

> **Engine = two files.** `calc.py` lazily imports `calibration.py`; without it the calculator silently falls back to uncalibrated roofline numbers (decode ITL ~4 ms instead of the measured ~80 ms). They ship together. (This is why the file set here is the two-file engine + ledger, slightly more than the minimal `calc.py` alone.)

## Verification

- `python3 analyze/calc.py --selftest` → PASS (standalone, from the PR dir)
- Both HTML pages parse clean
- No private-registry / non-public references (do-framework publication rule)

## Notes for review

- **Author attribution** ("Author: Anton Alexander") is in every shipped file per the do-framework convention.
- **Scope:** this dir ships the *analytical layer*. The `PRODUCTION-GUIDE.md` also references an optional *live-sweep harness* (`driver/`, `cost.py`, `render_charts.py`) and L3 GPU-benchmark steps — those live in the companion research project and are clearly marked as such (a scope banner at the top of the guide). Happy to trim the guide to only the in-dir steps if you'd prefer a tighter surface.
