### PR TITLE
nemotron/ultra: NVFP4/BF16 precision toggle via MODEL_VARIANT (.env, no template change)

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/.env
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/.env
@@ -13,8 +13,22 @@ export INSTANCE_TYPE_FRONTEND=m5.8xlarge
 export INSTANCE_TYPE_WORKER=p5en.48xlarge
 export GPU_PER_WORKER=8
 export EFA_PER_WORKER=16
-export MODEL_NAME=nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16
-export MODEL_PATH=/shared/models/hf/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16
+# ---- Model precision toggle (Author: Anton Alexander) ----
+# Switch between the full-precision BF16 checkpoint and the NVFP4 (4-bit) checkpoint
+# WITHOUT editing the templates. BF16 is the default; set MODEL_VARIANT=nvfp4 to switch.
+#   - bf16  : nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16  (~1.1 TB weights; needs the full node budget)
+#   - nvfp4 : nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4 (4-bit weights; ~41 GiB/GPU, big KV headroom)
+# vLLM auto-detects the quantization from the checkpoint (no --quantization flag needed), so only the
+# model name/path change. Override MODEL_REPO to point at any other HF repo following the same -BF16/-NVFP4
+# suffix convention.
+export MODEL_VARIANT="${MODEL_VARIANT:-bf16}"
+export MODEL_REPO="${MODEL_REPO:-nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B}"
+case "${MODEL_VARIANT}" in
+  nvfp4|NVFP4|fp4) _PREC_SUFFIX="NVFP4" ;;
+  bf16|BF16|*)     _PREC_SUFFIX="BF16"  ;;
+esac
+export MODEL_NAME="${MODEL_REPO}-${_PREC_SUFFIX}"
+export MODEL_PATH="/shared/models/hf/${MODEL_NAME}"
 
 export ETCD_URL=http://dynamo-platform-etcd.dynamo-system.svc.cluster.local:2379
 export NATS_URL=nats://dynamo-platform-nats.dynamo-system.svc.cluster.local:4222

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/.env
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/.env
@@ -15,13 +15,13 @@ export GPU_PER_WORKER=8
 export EFA_PER_WORKER=16
 # ---- Model precision toggle (Author: Anton Alexander) ----
 # Switch between the full-precision BF16 checkpoint and the NVFP4 (4-bit) checkpoint
-# WITHOUT editing the templates. BF16 is the default; set MODEL_VARIANT=nvfp4 to switch.
+# WITHOUT editing the templates. BF16 is the default; set MODEL_VARIANT=NVFP4 to switch.
 #   - bf16  : nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16  (~1.1 TB weights; needs the full node budget)
 #   - nvfp4 : nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4 (4-bit weights; ~41 GiB/GPU, big KV headroom)
 # vLLM auto-detects the quantization from the checkpoint (no --quantization flag needed), so only the
 # model name/path change. Override MODEL_REPO to point at any other HF repo following the same -BF16/-NVFP4
 # suffix convention.
-export MODEL_VARIANT="${MODEL_VARIANT:-bf16}"
+export MODEL_VARIANT="${MODEL_VARIANT:-BF16}"
 export MODEL_REPO="${MODEL_REPO:-nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B}"
 case "${MODEL_VARIANT}" in
   nvfp4|NVFP4|fp4) _PREC_SUFFIX="NVFP4" ;;

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/.env
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/.env
@@ -13,8 +13,22 @@ export INSTANCE_TYPE_FRONTEND=m5.8xlarge
 export INSTANCE_TYPE_WORKER=p5en.48xlarge
 export GPU_PER_WORKER=8
 export EFA_PER_WORKER=16
-export MODEL_NAME=nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16
-export MODEL_PATH=/shared/models/hf/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16
+# ---- Model precision toggle (Author: Anton Alexander) ----
+# Switch between the full-precision BF16 checkpoint and the NVFP4 (4-bit) checkpoint
+# WITHOUT editing the templates. BF16 is the default; set MODEL_VARIANT=nvfp4 to switch.
+#   - bf16  : nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16  (~1.1 TB weights; needs the full node budget)
+#   - nvfp4 : nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4 (4-bit weights; ~41 GiB/GPU, big KV headroom)
+# vLLM auto-detects the quantization from the checkpoint (no --quantization flag needed), so only the
+# model name/path change. Override MODEL_REPO to point at any other HF repo following the same -BF16/-NVFP4
+# suffix convention.
+export MODEL_VARIANT="${MODEL_VARIANT:-bf16}"
+export MODEL_REPO="${MODEL_REPO:-nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B}"
+case "${MODEL_VARIANT}" in
+  nvfp4|NVFP4|fp4) _PREC_SUFFIX="NVFP4" ;;
+  bf16|BF16|*)     _PREC_SUFFIX="BF16"  ;;
+esac
+export MODEL_NAME="${MODEL_REPO}-${_PREC_SUFFIX}"
+export MODEL_PATH="/shared/models/hf/${MODEL_NAME}"
 
 export ETCD_URL=http://dynamo-platform-etcd.dynamo-system.svc.cluster.local:2379
 export NATS_URL=nats://dynamo-platform-nats.dynamo-system.svc.cluster.local:4222

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/.env
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/.env
@@ -15,13 +15,13 @@ export GPU_PER_WORKER=8
 export EFA_PER_WORKER=16
 # ---- Model precision toggle (Author: Anton Alexander) ----
 # Switch between the full-precision BF16 checkpoint and the NVFP4 (4-bit) checkpoint
-# WITHOUT editing the templates. BF16 is the default; set MODEL_VARIANT=nvfp4 to switch.
+# WITHOUT editing the templates. BF16 is the default; set MODEL_VARIANT=NVFP4 to switch.
 #   - bf16  : nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16  (~1.1 TB weights; needs the full node budget)
 #   - nvfp4 : nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4 (4-bit weights; ~41 GiB/GPU, big KV headroom)
 # vLLM auto-detects the quantization from the checkpoint (no --quantization flag needed), so only the
 # model name/path change. Override MODEL_REPO to point at any other HF repo following the same -BF16/-NVFP4
 # suffix convention.
-export MODEL_VARIANT="${MODEL_VARIANT:-bf16}"
+export MODEL_VARIANT="${MODEL_VARIANT:-BF16}"
 export MODEL_REPO="${MODEL_REPO:-nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B}"
 case "${MODEL_VARIANT}" in
   nvfp4|NVFP4|fp4) _PREC_SUFFIX="NVFP4" ;;


### PR DESCRIPTION
## What

Adds a one-setting **NVFP4 ↔ BF16 precision toggle** to `inference/agentic-ai/nemotron/ultra/{agg,disagg}/.env`. Set `MODEL_VARIANT` and the served checkpoint switches — **no template edits**:

```bash
export MODEL_VARIANT=nvfp4   # 4-bit checkpoint: ~41 GiB/GPU, large KV headroom, fits one node comfortably
export MODEL_VARIANT=bf16    # default (also the value when unset): full precision
```

## Why

The 550B BF16 checkpoint barely fits one p5en (degraded settings); the official NVFP4 checkpoint (`nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4`) fits one node at ~41 GiB/GPU with big KV headroom — live-verified serving on p5en/H200. Giving users a single `.env` switch lets the walkthrough cover both precisions instead of hardcoding one.

## How it works (no template change)

vLLM **auto-detects the quantization from the checkpoint** (there is no `--quantization` flag in the templates), so only `MODEL_NAME`/`MODEL_PATH` need to change. The toggle resolves those two from `MODEL_VARIANT`; `deployment.yaml-template` and `lws.yaml-template` already consume `${MODEL_PATH}`/`${MODEL_NAME}` verbatim. `MODEL_REPO` is overridable for any other HF repo using the same `-BF16`/`-NVFP4` suffix.

## Verification
- `MODEL_VARIANT` unset → BF16 (back-compat with the current default)
- `bf16`/`BF16` → `…-BF16`; `nvfp4`/`NVFP4`/`fp4` → `…-NVFP4`
- alt `MODEL_REPO=myorg/MyModel` → `myorg/MyModel-{BF16,NVFP4}` resolves
- `bash -n` clean on both files; diff touches only the two `MODEL_*` lines.

Author: Anton Alexander.
