### PR TITLE
nvidia-dynamo: update platform deploy scripts from Dynamo 1.2.0 to 1.3.1

### DIFF
--- a/Container-Root/eks/deployment/nvidia-dynamo/deploy.sh
+++ b/Container-Root/eks/deployment/nvidia-dynamo/deploy.sh
@@ -8,9 +8,9 @@
 # In-place upgrades are not supported (etcd 3.5->3.6 data-dir and kai-scheduler CRD conflicts).
 
 export DYNAMO_NAMESPACE=${DYNAMO_NAMESPACE:-dynamo-system}
-export DYNAMO_VERSION=${DYNAMO_VERSION:-"1.3.0"}
+export DYNAMO_VERSION=${DYNAMO_VERSION:-"1.3.1"}
 
-# The 1.3.0 operator reconciles PodSnapshot/PodSnapshotContent but the chart tarball does not
+# The 1.3.x operator reconciles PodSnapshot/PodSnapshotContent but the chart tarball does not
 # ship those two CRDs (they normally come from a crd-apply init container). Apply them from the
 # matching upstream tag first so the operator can never CrashLoop on a missing restmapping.
 # This is additive and idempotent - existing CRDs are left as-is.

--- a/Container-Root/eks/deployment/nvidia-dynamo/deploy.sh
+++ b/Container-Root/eks/deployment/nvidia-dynamo/deploy.sh
@@ -1,12 +1,34 @@
 #!/bin/bash
 
-# Requires default storage class
+# Deploy the NVIDIA Dynamo platform (operator, CRDs, etcd, NATS) on a clean EKS cluster.
 # Ref: https://docs.nvidia.com/dynamo/kubernetes-deployment/deployment-guide/quickstart
+#
+# Assumes a vanilla cluster (GPU/EFA device plugins, FSx CSI, LWS CRD already installed).
+# Fresh-install only: to move between Dynamo versions run ./remove.sh first, then this.
+# In-place upgrades are not supported (etcd 3.5->3.6 data-dir and kai-scheduler CRD conflicts).
 
-export DYNAMO_NAMESPACE=dynamo-system
-export DYNAMO_VERSION="1.2.0"
+export DYNAMO_NAMESPACE=${DYNAMO_NAMESPACE:-dynamo-system}
+export DYNAMO_VERSION=${DYNAMO_VERSION:-"1.3.0"}
+
+# The 1.3.0 operator reconciles PodSnapshot/PodSnapshotContent but the chart tarball does not
+# ship those two CRDs (they normally come from a crd-apply init container). Apply them from the
+# matching upstream tag first so the operator can never CrashLoop on a missing restmapping.
+# This is additive and idempotent - existing CRDs are left as-is.
+for CRD in podsnapshotcontents podsnapshots; do
+    kubectl apply -f https://raw.githubusercontent.com/ai-dynamo/dynamo/v${DYNAMO_VERSION}/deploy/operator/config/crd/bases/nvidia.com_${CRD}.yaml
+done
 
 helm fetch https://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/dynamo-platform-${DYNAMO_VERSION}.tgz
 
-helm upgrade --install dynamo-platform dynamo-platform-${DYNAMO_VERSION}.tgz --namespace "$DYNAMO_NAMESPACE"  --create-namespace -f values.yaml
+helm upgrade --install dynamo-platform dynamo-platform-${DYNAMO_VERSION}.tgz --namespace "$DYNAMO_NAMESPACE" --create-namespace -f values.yaml
 
+# Verify: Running is not started - wait for the operator rollout and the data plane to be Ready.
+kubectl -n "$DYNAMO_NAMESPACE" rollout status deploy/dynamo-platform-dynamo-operator-controller-manager --timeout=300s
+kubectl -n "$DYNAMO_NAMESPACE" wait pod dynamo-platform-etcd-0 --for=condition=Ready --timeout=300s
+kubectl -n "$DYNAMO_NAMESPACE" wait pod dynamo-platform-nats-0 --for=condition=Ready --timeout=300s
+
+echo ""
+echo "Dynamo CRDs:"
+kubectl get crd | grep "nvidia.com" | grep -E "dynamo|podsnapshot"
+echo ""
+kubectl -n "$DYNAMO_NAMESPACE" get pods

--- a/Container-Root/eks/deployment/nvidia-dynamo/remove.sh
+++ b/Container-Root/eks/deployment/nvidia-dynamo/remove.sh
@@ -1,15 +1,32 @@
 #!/bin/bash
 
+# Remove the NVIDIA Dynamo platform and return the cluster to its pre-deploy state.
 # Ref: https://docs.nvidia.com/dynamo/kubernetes-deployment/deployment-guide
 
-kubectl delete dgd --all -A
+export DYNAMO_NAMESPACE=${DYNAMO_NAMESPACE:-dynamo-system}
 
-export DYNAMO_NAMESPACE=dynamo-system
+# 1. Delete all Dynamo custom resources first so their finalizers run while the operator is alive.
+for CRD in $(kubectl get crd -o name | grep "nvidia.com" | grep -E "dynamo|podsnapshot"); do
+    RESOURCE=$(basename $CRD | cut -d. -f1)
+    kubectl delete $RESOURCE --all -A --ignore-not-found --timeout=120s
+done
 
+# 2. Uninstall the platform release (operator, etcd, NATS).
 helm delete dynamo-platform -n $DYNAMO_NAMESPACE
 
-kubectl get crd | grep "dynamo.*nvidia.com"
+# 3. Delete the Dynamo CRDs. Match both groups: dynamo*.nvidia.com AND podsnapshot*.nvidia.com -
+#    a bare "dynamo" grep leaves the two podsnapshot CRDs behind.
+kubectl get crd -o name | grep "nvidia.com" | grep -E "dynamo|podsnapshot" | xargs -r kubectl delete
 
-kubectl get crd | grep "dynamo.*nvidia.com" | awk '{print $1}' | xargs kubectl delete crd
+# 4. Delete the PVCs helm leaves behind (etcd data, NATS JetStream), then the namespace.
+kubectl delete pvc --all -n $DYNAMO_NAMESPACE --ignore-not-found --timeout=120s
+kubectl delete namespace $DYNAMO_NAMESPACE --ignore-not-found --timeout=120s
 
-
+# 5. Verify zero residue - all four checks should print nothing.
+echo ""
+echo "Verifying removal (all of the following should be empty):"
+kubectl get crd | grep "nvidia.com" | grep -E "dynamo|podsnapshot"
+kubectl get namespace $DYNAMO_NAMESPACE 2>/dev/null
+helm list -n $DYNAMO_NAMESPACE 2>/dev/null | grep dynamo-platform
+kubectl get pv 2>/dev/null | grep $DYNAMO_NAMESPACE
+echo "Done."

--- a/Container-Root/eks/deployment/nvidia-dynamo/values.yaml
+++ b/Container-Root/eks/deployment/nvidia-dynamo/values.yaml
@@ -39,6 +39,13 @@ global:
     # inject schedulerName and queue labels into pod templates.
     enabled: false
 
+  volcano-scheduler:
+    # -- EXPERIMENTAL: Whether to enable Volcano scheduler integration for Grove PodCliqueSets.
+    # Set to true when Volcano is available in the cluster and Grove is configured
+    # with Volcano scheduler support. The operator uses this to inject schedulerName
+    # and map nvidia.com/volcano-queue to Grove's Volcano queue annotation.
+    enabled: false
+
   grove:
     # -- Whether this chart should install the bundled Grove subchart.
     # When true, deploys the Grove operator cluster-wide. Integration is automatically enabled.
@@ -57,37 +64,39 @@ dynamo-operator:
   # -- Whether to enable the Dynamo Kubernetes operator deployment
   enabled: true
 
-  # -- Whether to manage CRDs via a pre-install/pre-upgrade hook Job.
-  # The Job runs the operator image with the crd-apply tool to apply CRDs via server-side apply.
+  # -- Whether the cluster-wide operator applies CRDs from its image through the crd-apply init container.
+  # When false, the chart installs no CRDs; apply them separately before starting a cluster-wide
+  # operator. Namespace-restricted installations must set this to false and use the CRDs managed by
+  # the cluster-wide operator.
   upgradeCRD: true
 
   # Environment variables to pass to operator Deployment.
   env: []
 
-  # -- NATS server address for operator communication (leave empty to use the bundled NATS chart). Format: "nats://hostname:port"
+  # -- NATS server address for operator communication (leave empty to use the bundled NATS chart). Format: `nats://hostname:4222`
   natsAddr: ""
 
-  # -- etcd server address for an external etcd instance. Only needed when using external etcd without the bundled subchart. Format: "http://hostname:port" or "https://hostname:port"
+  # -- etcd server address for an external etcd instance. Only needed when using external etcd without the bundled subchart. Format: `http://hostname:2379` or `https://hostname:2379`
   etcdAddr: ""
 
   # -- URL for the Model Express server if not deployed by this helm chart. This is ignored if Model Express server is installed by this helm chart (global.model-express.enabled is true).
   modelExpressURL: ""
-  # -- DEPRECATED: Namespace-restricted mode is deprecated and will be removed in a future release. Use cluster-wide mode (the default) instead. Do not enable this for new deployments.
+  # -- DEVELOPMENT AND TESTING ONLY: Namespace-restricted mode is not supported for production. Use cluster-wide mode for production deployments.
   namespaceRestriction:
-    # -- DEPRECATED: Do not enable for new deployments. Namespace-restricted mode is deprecated.
+    # -- DEVELOPMENT AND TESTING ONLY: Enable namespace-restricted reconciliation and admission. Not supported for production.
     enabled: false
-    # -- DEPRECATED: Only used in namespace-restricted mode, which is deprecated.
+    # -- DEVELOPMENT AND TESTING ONLY: Target namespace. Defaults to the Helm release namespace.
     targetNamespace:
-    # -- DEPRECATED: Only used in namespace-restricted mode, which is deprecated.
+    # -- DEVELOPMENT AND TESTING ONLY: Namespace ownership Lease settings.
     lease:
-      # -- DEPRECATED: Lease duration for namespace-restricted mode, which is deprecated.
+      # -- DEVELOPMENT AND TESTING ONLY: Namespace ownership Lease duration.
       duration: 30s
-      # -- DEPRECATED: Lease renew interval for namespace-restricted mode, which is deprecated.
+      # -- DEVELOPMENT AND TESTING ONLY: Namespace ownership Lease renewal interval.
       renewInterval: 10s
 
-  # -- DEPRECATED: GPU discovery for namespace-scoped operators is deprecated along with namespace-restricted mode.
+  # -- DEVELOPMENT AND TESTING ONLY: GPU discovery settings for namespace-restricted operators.
   gpuDiscovery:
-    # -- DEPRECATED: Only relevant when namespaceRestriction is enabled, which is deprecated.
+    # -- DEVELOPMENT AND TESTING ONLY: Enable GPU discovery in namespace-restricted mode.
     enabled: true
 
   # -- The Dynamo discovery backend to use. Default is "kubernetes" for Kubernetes API service discovery. Set to "etcd" to use ETCD for discovery. --
@@ -114,7 +123,7 @@ dynamo-operator:
         # -- Official NVIDIA Dynamo operator image repository
         repository: "nvcr.io/nvidia/ai-dynamo/kubernetes-operator"
         # -- Image tag (leave empty to use chart default)
-        tag: ""
+        tag: 1.3.0
         # -- Image pull policy - when to pull the image
         pullPolicy: IfNotPresent
 
@@ -223,11 +232,13 @@ dynamo-operator:
     # -- Webhook failure policy controls how Kubernetes handles requests when the webhook is unavailable. 'Fail' (recommended for production) rejects requests if the webhook cannot be reached, ensuring strict validation. 'Ignore' allows requests through if the webhook is unavailable, providing availability over validation guarantees.
     failurePolicy: Fail
 
+    # -- Failure policy for the Pod CREATE checkpoint-restore mutating webhook. Defaults to Ignore so a webhook outage falls back to cold-start instead of blocking workload Pods.
+    podCheckpointRestoreFailurePolicy: Ignore
+
     # -- Timeout in seconds for webhook validation calls. If the webhook doesn't respond within this time, the request will be handled according to the failurePolicy.
     timeoutSeconds: 10
 
-    # Namespace selector for webhook scope control
-    # -- Custom namespace selector for webhook validation. Use this to include or exclude specific namespaces from webhook validation. For CLUSTER-WIDE operators, you can exclude namespaces managed by namespace-restricted operators by using: matchExpressions: [{ key: "dynamo-operator", operator: "NotIn", values: ["namespace-restricted"] }]. For NAMESPACE-RESTRICTED operators, leave empty as it will be auto-configured to match only the operator's namespace.
+    # -- Unsupported; must remain empty. Helm configures global admission for the cluster-wide operator and target-namespace admission for restricted operators.
     namespaceSelector: {}
 
     # cert-manager integration for automated certificate lifecycle management
@@ -258,6 +269,8 @@ dynamo-operator:
   checkpoint:
     # -- Whether to enable checkpoint/restore functionality
     enabled: false
+    # -- Image used by best-effort artifact cleanup Jobs for automatically-created checkpoints. The image must provide /bin/sh and rm.
+    cleanupImage: busybox:1.36
     # -- Optional PVC storage used when the snapshot-agent is installed outside
     # workload namespaces with snapshot.storage.accessMode=podMount. Set
     # create=true for operator-managed namespace PVCs, or omit/create=false to
@@ -377,7 +390,6 @@ nats:
           size: 10Gi
           # Storage class name (leave empty for default)
           storageClassName: gp2
-
           # Advanced PVC configuration (merge additional fields)
           # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#persistentvolumeclaim-v1-core
           merge: {}

--- a/Container-Root/eks/deployment/nvidia-dynamo/values.yaml
+++ b/Container-Root/eks/deployment/nvidia-dynamo/values.yaml
@@ -123,7 +123,7 @@ dynamo-operator:
         # -- Official NVIDIA Dynamo operator image repository
         repository: "nvcr.io/nvidia/ai-dynamo/kubernetes-operator"
         # -- Image tag (leave empty to use chart default)
-        tag: 1.3.0
+        tag: 1.3.1
         # -- Image pull policy - when to pull the image
         pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## What

Updates `Container-Root/eks/deployment/nvidia-dynamo/` from Dynamo platform **1.2.0** to **1.3.0**:

- **`deploy.sh`** — installs `dynamo-platform-1.3.0` (version overridable via `DYNAMO_VERSION`). Pre-applies the two `podsnapshot{,content}s.nvidia.com` CRDs from the matching `ai-dynamo/dynamo` tag, then verifies the install (operator rollout status + etcd/nats Ready + CRD/pod listing) instead of trusting exit codes.
- **`remove.sh`** — full teardown that returns the cluster to its pre-deploy state: deletes all Dynamo custom resources first (so finalizers run while the operator is alive), uninstalls the release, deletes **all** `nvidia.com` Dynamo CRDs including the two `podsnapshot*` ones the previous grep missed, deletes leftover PVCs and the namespace, and prints residue checks.
- **`values.yaml`** — regenerated on the 1.3.0 chart defaults, preserving the same three site deltas this repo carried on 1.2.0 (bundled etcd on, `gp2` for etcd persistence and NATS JetStream PVC — EKS clusters commonly have no default StorageClass, and without the JetStream key `nats-0` hangs `Pending` forever). `kai-scheduler`/`grove` stay `install: false` per chart defaults and NVIDIA's own guidance to install them separately.

## Why

The published scripts deploy 1.2.0; validated deployments (Nemotron-3 Ultra aggregated + disaggregated, including PP>1) now target **1.3.0**. Fresh-install-only by design: in-place 1.2.0→1.3.0 upgrades hit the etcd 3.5→3.6 data-dir incompatibility and kai-scheduler CRD ownership conflicts, so the supported path is `remove.sh` → `deploy.sh`.

Two 1.3.0 chart gaps this PR compensates for (both root-caused and verified on an EKS p5en cluster, 2026-07-30):
1. The 1.3.0 chart tarball ships **no** `nvidia.com` CRDs for `PodSnapshot`/`PodSnapshotContent`, yet the 1.3.0 operator resolves both kinds at startup — without the pre-apply the operator CrashLoops on `failed to get restmapping: no matches for kind "PodSnapshotContent"`.
2. `nats.config.jetstream.fileStore.pvc.storageClassName` is the key that actually reaches the NATS StatefulSet `volumeClaimTemplates`; the more discoverable `global.nats.persistence.storageClass`-style keys do not.

## How validated

- Both scripts `bash -n` clean; `values.yaml` parses and carries exactly the intended deltas vs the upstream 1.3.0 chart (verified programmatically).
- The CRD pre-apply + JetStream storageClassName fixes are the exact remediations verified live on an EKS cluster on 2026-07-30: operator `Running` with **0 restarts**, all controllers report `Starting workers` (including `podsnapshot`), a `DynamoGraphDeployment` passes `kubectl apply --dry-run=server`, and `nats-0` PVC binds.
- Chart facts verified against the NGC helm index: `dynamo-platform-1.3.0.tgz` pulls cleanly; note `1.3.2` is listed in the index but the artifact 404s, and there is no `dynamo-crds` chart for 1.3.x (CRDs ship inside the platform chart).
- End-to-end deploy → serve → remove → redeploy validation on a clean cluster is in progress today and results will be posted on this PR.

Part of updating the published Dynamo deployment to match the validated 1.3.0 stack (Nemotron ultra disagg manifest fixes follow in a separate PR).