### PR TITLE
nemotron/ultra/disagg: Dynamo 1.3.x manifests — venv fix, PP>1 LWS + DGD + EP16 options, zero-residue teardown

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/.env
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/.env
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-export REGISTRY=public.ecr.aws/hpc-cloud/
-export IMAGE=dynamo-vllm-efa
-export TAG=":1.3.0-patched"
+export REGISTRY=${REGISTRY:-public.ecr.aws/hpc-cloud/}
+export IMAGE=${IMAGE:-dynamo-vllm-efa}
+export TAG=${TAG:-":1.3.1-patched"}
 
 export DOLLAR='$'
 # ${VAR:-default} everywhere: an unconditional export here would silently clobber a

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/.env
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/.env
@@ -5,14 +5,22 @@ export IMAGE=dynamo-vllm-efa
 export TAG=":1.3.0-patched"
 
 export DOLLAR='$'
-export NAMESPACE=iankouls
-export DEPLOYMENT_NAME=nemotron3-ultra-550b-disagg
-# MANIFEST_TYPE=deployment|lws|lws-pp|dgd
+# ${VAR:-default} everywhere: an unconditional export here would silently clobber a
+# caller's environment override (run.sh/stop.sh source this file) - for NAMESPACE that
+# means stop.sh could render its deletes into somebody ELSE's namespace.
+export NAMESPACE=${NAMESPACE:-iankouls}
+export DEPLOYMENT_NAME=${DEPLOYMENT_NAME:-nemotron3-ultra-550b-disagg}
+# MANIFEST_TYPE=deployment|lws|lws-pp|dgd|ep
 #   deployment : plain Deployments, 1 prefill + 1 decode node, TP8/PP1 each (simplest)
 #   lws        : LeaderWorkerSet, prefill+decode TP8/PP2 across 2 nodes each (experimental, see header)
 #   lws-pp     : LeaderWorkerSet, prefill TP8/PP2 (2 nodes) + decode 2x TP8/PP1 (validated PP>1 shape)
 #   dgd        : DynamoGraphDeployment via the Dynamo operator (requires the platform from ../../../nvidia-dynamo)
+#   ep         : EP16 aggregated - LWS DP2 x TP8 with --enable-expert-parallel (expert-parallel degree 16)
 export MANIFEST_TYPE=${MANIFEST_TYPE:-deployment}
+# EP16 (MANIFEST_TYPE=ep) only: data-parallel group size; EP degree = EP_DP_SIZE * GPU_PER_WORKER.
+# The model's expert count must be divisible by the EP degree (Nemotron-3-Ultra + Qwen3-235B: yes;
+# Mixtral's 8 experts: no - it cannot run EP16).
+export EP_DP_SIZE=${EP_DP_SIZE:-2}
 export INSTANCE_TYPE_FRONTEND=m5.8xlarge
 export INSTANCE_TYPE_WORKER=p5en.48xlarge
 export GPU_PER_WORKER=8
@@ -31,8 +39,11 @@ case "${MODEL_VARIANT}" in
   nvfp4|NVFP4|fp4) _PREC_SUFFIX="NVFP4" ;;
   bf16|BF16|*)     _PREC_SUFFIX="BF16"  ;;
 esac
-export MODEL_NAME="${MODEL_REPO}-${_PREC_SUFFIX}"
-export MODEL_PATH="/shared/models/hf/${MODEL_NAME}"
+# MODEL_NAME override escape hatch: models outside the -BF16/-NVFP4 suffix convention
+# (e.g. MODEL_NAME=meta-llama/Llama-3.1-8B-Instruct for a fast smoke test) skip the
+# suffix derivation entirely. Default stays the Nemotron variant logic above.
+export MODEL_NAME="${MODEL_NAME:-${MODEL_REPO}-${_PREC_SUFFIX}}"
+export MODEL_PATH="${MODEL_PATH:-/shared/models/hf/${MODEL_NAME}}"
 
 export ETCD_URL=http://dynamo-platform-etcd.dynamo-system.svc.cluster.local:2379
 export NATS_URL=nats://dynamo-platform-nats.dynamo-system.svc.cluster.local:4222

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/.env
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/.env
@@ -44,6 +44,15 @@ esac
 # suffix derivation entirely. Default stays the Nemotron variant logic above.
 export MODEL_NAME="${MODEL_NAME:-${MODEL_REPO}-${_PREC_SUFFIX}}"
 export MODEL_PATH="${MODEL_PATH:-/shared/models/hf/${MODEL_NAME}}"
+# Hybrid-Mamba flags are MODEL-CONDITIONAL, not universal: on a pure-transformer model
+# (Qwen3, Llama, Mixtral) `--mamba-cache-mode align` makes the vLLM 0.23 model runner call
+# model.get_mamba_state_copy_func() at FIRST INFERENCE (not startup!) -> AttributeError ->
+# EngineCore dies -> HTTP 500. Auto-derived from MODEL_NAME; override MAMBA_FLAGS='' to force.
+case "${MODEL_NAME}" in
+  *Nemotron*|*nemotron*) _MAMBA_DEFAULT="--mamba-cache-mode align --no-disable-hybrid-kv-cache-manager" ;;
+  *)                     _MAMBA_DEFAULT="" ;;
+esac
+export MAMBA_FLAGS="${MAMBA_FLAGS-${_MAMBA_DEFAULT}}"
 
 export ETCD_URL=http://dynamo-platform-etcd.dynamo-system.svc.cluster.local:2379
 export NATS_URL=nats://dynamo-platform-nats.dynamo-system.svc.cluster.local:4222

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/.env
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/.env
@@ -12,7 +12,7 @@ export DEPLOYMENT_NAME=nemotron3-ultra-550b-disagg
 #   lws        : LeaderWorkerSet, prefill+decode TP8/PP2 across 2 nodes each (experimental, see header)
 #   lws-pp     : LeaderWorkerSet, prefill TP8/PP2 (2 nodes) + decode 2x TP8/PP1 (validated PP>1 shape)
 #   dgd        : DynamoGraphDeployment via the Dynamo operator (requires the platform from ../../../nvidia-dynamo)
-export MANIFEST_TYPE=deployment
+export MANIFEST_TYPE=${MANIFEST_TYPE:-deployment}
 export INSTANCE_TYPE_FRONTEND=m5.8xlarge
 export INSTANCE_TYPE_WORKER=p5en.48xlarge
 export GPU_PER_WORKER=8

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/.env
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/.env
@@ -2,12 +2,16 @@
 
 export REGISTRY=public.ecr.aws/hpc-cloud/
 export IMAGE=dynamo-vllm-efa
-export TAG=":disagg-1.2.0"
+export TAG=":1.3.0-patched"
 
 export DOLLAR='$'
 export NAMESPACE=iankouls
 export DEPLOYMENT_NAME=nemotron3-ultra-550b-disagg
-# MANIFEST_TYPE=deployment|lws
+# MANIFEST_TYPE=deployment|lws|lws-pp|dgd
+#   deployment : plain Deployments, 1 prefill + 1 decode node, TP8/PP1 each (simplest)
+#   lws        : LeaderWorkerSet, prefill+decode TP8/PP2 across 2 nodes each (experimental, see header)
+#   lws-pp     : LeaderWorkerSet, prefill TP8/PP2 (2 nodes) + decode 2x TP8/PP1 (validated PP>1 shape)
+#   dgd        : DynamoGraphDeployment via the Dynamo operator (requires the platform from ../../../nvidia-dynamo)
 export MANIFEST_TYPE=deployment
 export INSTANCE_TYPE_FRONTEND=m5.8xlarge
 export INSTANCE_TYPE_WORKER=p5en.48xlarge

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/deployment.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/deployment.yaml-template
@@ -52,9 +52,8 @@ spec:
                 --served-model-name ${MODEL_NAME} \
                 --tensor-parallel-size ${GPU_PER_WORKER} --pipeline-parallel-size 1 \
                 --max-model-len 4096 --gpu-memory-utilization 0.97 --enforce-eager \
-                --trust-remote-code --mamba-cache-mode align \
+                --trust-remote-code ${MAMBA_FLAGS} \
                 --load-format runai_streamer \
-                --no-disable-hybrid-kv-cache-manager \
                 --disaggregation-mode prefill \
                 --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}'
           env:
@@ -128,9 +127,8 @@ spec:
                 --served-model-name ${MODEL_NAME} \
                 --tensor-parallel-size ${GPU_PER_WORKER} --pipeline-parallel-size 1 \
                 --max-model-len 4096 --gpu-memory-utilization 0.97 --enforce-eager \
-                --trust-remote-code --mamba-cache-mode align \
+                --trust-remote-code ${MAMBA_FLAGS} \
                 --load-format runai_streamer \
-                --no-disable-hybrid-kv-cache-manager \
                 --disaggregation-mode decode \
                 --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}'
           env:

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/deployment.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/deployment.yaml-template
@@ -53,6 +53,8 @@ spec:
                 --tensor-parallel-size ${GPU_PER_WORKER} --pipeline-parallel-size 1 \
                 --max-model-len 4096 --gpu-memory-utilization 0.97 --enforce-eager \
                 --trust-remote-code --mamba-cache-mode align \
+                --load-format runai_streamer \
+                --no-disable-hybrid-kv-cache-manager \
                 --disaggregation-mode prefill \
                 --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}'
           env:
@@ -127,6 +129,8 @@ spec:
                 --tensor-parallel-size ${GPU_PER_WORKER} --pipeline-parallel-size 1 \
                 --max-model-len 4096 --gpu-memory-utilization 0.97 --enforce-eager \
                 --trust-remote-code --mamba-cache-mode align \
+                --load-format runai_streamer \
+                --no-disable-hybrid-kv-cache-manager \
                 --disaggregation-mode decode \
                 --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}'
           env:

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/deployment.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/deployment.yaml-template
@@ -3,7 +3,7 @@
 #
 # Author: Anton Alexander
 #
-# Image = NGC 1.2.0-efa + 5 vLLM disagg patches (PR#42522/#43935) - the patches remove the
+# Image = Dynamo 1.3.0 based (see dynamo-vllm-efa/Dockerfile) + 5 vLLM disagg patches (PR#42522/#43935) - the patches remove the
 # Mamba "External KV connector not verified yet" assertion that blocked the unpatched build.
 # KV transferred prefill->decode over EFA RDMA via NIXL LIBFABRIC. Single-node-per-role uses the
 # same OOM-avoidance recipe as agg (gpu-util 0.97, max-model-len 4096, enforce-eager).
@@ -43,7 +43,10 @@ spec:
             - |-
               set -u
               unset HPCX_DIR HPCX_MPI_DIR HPCX_HOME HPCX_UCX_DIR HPCX_SHARP_DIR HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
-              source /opt/dynamo/venv/bin/activate
+              # Dynamo images differ in python layout: 1.2.0-era images ship /opt/dynamo/venv,
+              # 1.3.0-era images (NGC vllm-runtime:1.3.0 and derivatives) install into the system
+              # python and have NO venv. Activate only when present so one manifest serves both.
+              if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
               exec python3 -m dynamo.vllm \
                 --model ${MODEL_PATH} \
                 --served-model-name ${MODEL_NAME} \
@@ -114,7 +117,10 @@ spec:
             - |-
               set -u
               unset HPCX_DIR HPCX_MPI_DIR HPCX_HOME HPCX_UCX_DIR HPCX_SHARP_DIR HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
-              source /opt/dynamo/venv/bin/activate
+              # Dynamo images differ in python layout: 1.2.0-era images ship /opt/dynamo/venv,
+              # 1.3.0-era images (NGC vllm-runtime:1.3.0 and derivatives) install into the system
+              # python and have NO venv. Activate only when present so one manifest serves both.
+              if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
               exec python3 -m dynamo.vllm \
                 --model ${MODEL_PATH} \
                 --served-model-name ${MODEL_NAME} \
@@ -167,8 +173,13 @@ spec:
         - name: frontend
           image: ${REGISTRY}${IMAGE}${TAG}
           imagePullPolicy: Always
-          command: ["/opt/dynamo/venv/bin/python3","-m","dynamo.frontend"]
-          args: ["--http-port","8000","--http-host","0.0.0.0"]
+          command: ["/bin/bash","-c"]
+          # 1.3.0-era images have no /opt/dynamo/venv - exec of its python3 fails with
+          # "no such file or directory" and the pod CrashLoops. Activate only when present.
+          args:
+            - |-
+              if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+              exec python3 -m dynamo.frontend --http-port 8000 --http-host 0.0.0.0
           env:
             - { name: DYNAMO_BACKEND, value: vllm }
             - { name: DYN_NAMESPACE, value: dynamo-disagg }

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd.yaml-template
@@ -120,7 +120,10 @@ spec:
             - { name: NCCL_NET_PLUGIN, value: ofi }
             - { name: NCCL_TUNER_PLUGIN, value: ofi }
             - { name: OFI_NCCL_FORCE_NUM_RAILS, value: "4" }
-          ports: [{ containerPort: 9091, name: dyn-system }]
+          # Port MUST be named "system": the operator injects readiness/liveness probes
+          # that target the named port; any other name fails with
+          # 'strconv.Atoi: parsing "system"' and the worker never goes Ready.
+          ports: [{ containerPort: 9091, name: system }]
           startupProbe:
             httpGet: { path: /health, port: 9091 }
             periodSeconds: 30
@@ -192,7 +195,7 @@ spec:
             - { name: NCCL_NET_PLUGIN, value: ofi }
             - { name: NCCL_TUNER_PLUGIN, value: ofi }
             - { name: OFI_NCCL_FORCE_NUM_RAILS, value: "4" }
-          ports: [{ containerPort: 9092, name: dyn-system }]
+          ports: [{ containerPort: 9092, name: system }]
           startupProbe:
             httpGet: { path: /health, port: 9092 }
             periodSeconds: 30

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd.yaml-template
@@ -1,0 +1,200 @@
+# =============================================================================
+# Nemotron-3 Ultra disaggregated P/D — DynamoGraphDeployment (Dynamo operator)
+# =============================================================================
+#
+# Author: Anton Alexander
+#
+# Requires the Dynamo platform 1.3.0 (operator + etcd + NATS) from
+# eks/deployment/nvidia-dynamo. The operator turns this single resource into
+# the frontend + prefill + decode deployments and owns their lifecycle, so
+# `kubectl delete -f dgd.yaml` (or ./stop.sh) removes everything it created.
+#
+# Topology: 1 prefill node + 1 decode node, TP=${GPU_PER_WORKER}/PP=1 each -
+# the validated single-node-per-role serving shape. KV moves prefill->decode
+# over EFA RDMA via NIXL LIBFABRIC.
+#
+# API version: nvidia.com/v1alpha1 - on the 1.3.0 operator this is the storage
+# version and admits cleanly (with a deprecation warning). v1beta1 is a
+# DIFFERENT schema (spec.components array), not a rename of this one.
+# =============================================================================
+---
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: ${DEPLOYMENT_NAME}
+  namespace: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}
+spec:
+  backendFramework: vllm
+  pvcs:
+    - name: fsx-pvc
+      create: false
+  envs:
+    - { name: DYNAMO_BACKEND, value: vllm }
+    - { name: ETCD_ENDPOINTS, value: "${ETCD_URL}" }
+    - { name: NATS_SERVER,    value: "${NATS_URL}" }
+    - { name: HF_HOME,        value: /shared/hf_cache }
+  services:
+    # ---- Frontend (router, CPU-only) --------------------------------------
+    Frontend:
+      componentType: frontend
+      replicas: 1
+      resources:
+        requests: { cpu: "2", memory: 4Gi }
+        limits:   { cpu: "4", memory: 8Gi }
+      extraPodSpec:
+        nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_FRONTEND} }
+        mainContainer:
+          image: ${REGISTRY}${IMAGE}${TAG}
+          imagePullPolicy: Always
+          command: ["/bin/bash", "-c"]
+          # 1.3.0-era images have no /opt/dynamo/venv - activate only when present.
+          args:
+            - |-
+              if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+              exec python3 -m dynamo.frontend --http-port 8000 --http-host 0.0.0.0
+          ports: [{ containerPort: 8000, name: http }]
+          # NOTE: no readinessProbe here - the operator injects its own frontend
+          # probe; adding ours makes the API server reject the generated pod
+          # ("may not specify more than 1 handler type").
+    # ---- Prefill worker (TP${GPU_PER_WORKER}/PP1, 1 node) -----------------
+    VllmPrefillWorker:
+      componentType: worker
+      subComponentType: prefill
+      replicas: 1
+      resources:
+        requests: { cpu: "96", memory: 1000Gi, gpu: "${GPU_PER_WORKER}", custom: { vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" } }
+        limits:   { cpu: "96", memory: 1000Gi, gpu: "${GPU_PER_WORKER}", custom: { vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" } }
+      volumeMounts:
+        - { name: fsx-pvc, mountPoint: /shared }
+      extraPodSpec:
+        nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_WORKER} }
+        tolerations:
+          - { key: nvidia.com/gpu, operator: Exists, effect: NoSchedule }
+          - { key: vpc.amazonaws.com/efa, operator: Exists, effect: NoSchedule }
+        affinity:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector: { matchLabels: { app.kubernetes.io/part-of: ${DEPLOYMENT_NAME} } }
+                topologyKey: kubernetes.io/hostname
+        volumes:
+          - { name: dshm,       emptyDir: { medium: Memory, sizeLimit: 64Gi } }
+          - { name: infiniband, hostPath: { path: /dev/infiniband, type: DirectoryOrCreate } }
+          - { name: gdrdrv,     hostPath: { path: /dev/gdrdrv, type: CharDevice } }
+        mainContainer:
+          image: ${REGISTRY}${IMAGE}${TAG}
+          imagePullPolicy: Always
+          securityContext: { capabilities: { add: ["IPC_LOCK"] } }
+          command: ["/bin/bash", "-c"]
+          args:
+            - |-
+              set -u
+              unset HPCX_DIR HPCX_MPI_DIR HPCX_HOME HPCX_UCX_DIR HPCX_SHARP_DIR \
+                    HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
+              if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+              exec python3 -m dynamo.vllm \
+                --model ${MODEL_PATH} \
+                --served-model-name ${MODEL_NAME} \
+                --tensor-parallel-size ${GPU_PER_WORKER} --pipeline-parallel-size 1 \
+                --max-model-len 4096 --gpu-memory-utilization 0.97 --enforce-eager \
+                --trust-remote-code --mamba-cache-mode align \
+                --disaggregation-mode prefill \
+                --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}'
+          env:
+            - { name: DYN_SYSTEM_ENABLED, value: "true" }
+            - { name: DYN_SYSTEM_PORT, value: "9091" }
+            - { name: VLLM_LOGGING_LEVEL, value: INFO }
+            - { name: VLLM_SSM_CONV_STATE_LAYOUT, value: DS }
+            - { name: FLASHINFER_DISABLE_VERSION_CHECK, value: "1" }
+            - { name: FI_PROVIDER, value: efa }
+            - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
+            - { name: FI_EFA_FORK_SAFE, value: "1" }
+            - { name: FI_HMEM_CUDA_USE_DMABUF, value: "1" }
+            - { name: FI_EFA_ENABLE_SHM, value: "0" }
+            - { name: FI_EFA_ENABLE_SHM_TRANSFER, value: "0" }
+            - { name: NIXL_LIBFABRIC_MAX_RAILS, value: "1" }
+            - { name: NIXL_SKIP_TOPOLOGY_CHECK, value: "1" }
+            - { name: NCCL_NET_PLUGIN, value: ofi }
+            - { name: NCCL_TUNER_PLUGIN, value: ofi }
+            - { name: OFI_NCCL_FORCE_NUM_RAILS, value: "4" }
+          ports: [{ containerPort: 9091, name: dyn-system }]
+          startupProbe:
+            httpGet: { path: /health, port: 9091 }
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 240
+          volumeMounts:
+            - { name: dshm,       mountPath: /dev/shm }
+            - { name: infiniband, mountPath: /dev/infiniband }
+            - { name: gdrdrv,     mountPath: /dev/gdrdrv }
+    # ---- Decode worker (TP${GPU_PER_WORKER}/PP1, 1 node) ------------------
+    VllmDecodeWorker:
+      componentType: worker
+      subComponentType: decode
+      replicas: 1
+      resources:
+        requests: { cpu: "96", memory: 1000Gi, gpu: "${GPU_PER_WORKER}", custom: { vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" } }
+        limits:   { cpu: "96", memory: 1000Gi, gpu: "${GPU_PER_WORKER}", custom: { vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" } }
+      volumeMounts:
+        - { name: fsx-pvc, mountPoint: /shared }
+      extraPodSpec:
+        nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_WORKER} }
+        tolerations:
+          - { key: nvidia.com/gpu, operator: Exists, effect: NoSchedule }
+          - { key: vpc.amazonaws.com/efa, operator: Exists, effect: NoSchedule }
+        affinity:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector: { matchLabels: { app.kubernetes.io/part-of: ${DEPLOYMENT_NAME} } }
+                topologyKey: kubernetes.io/hostname
+        volumes:
+          - { name: dshm,       emptyDir: { medium: Memory, sizeLimit: 64Gi } }
+          - { name: infiniband, hostPath: { path: /dev/infiniband, type: DirectoryOrCreate } }
+          - { name: gdrdrv,     hostPath: { path: /dev/gdrdrv, type: CharDevice } }
+        mainContainer:
+          image: ${REGISTRY}${IMAGE}${TAG}
+          imagePullPolicy: Always
+          securityContext: { capabilities: { add: ["IPC_LOCK"] } }
+          command: ["/bin/bash", "-c"]
+          args:
+            - |-
+              set -u
+              unset HPCX_DIR HPCX_MPI_DIR HPCX_HOME HPCX_UCX_DIR HPCX_SHARP_DIR \
+                    HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
+              if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+              exec python3 -m dynamo.vllm \
+                --model ${MODEL_PATH} \
+                --served-model-name ${MODEL_NAME} \
+                --tensor-parallel-size ${GPU_PER_WORKER} --pipeline-parallel-size 1 \
+                --max-model-len 4096 --gpu-memory-utilization 0.97 --enforce-eager \
+                --trust-remote-code --mamba-cache-mode align \
+                --disaggregation-mode decode \
+                --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}'
+          env:
+            - { name: DYN_SYSTEM_ENABLED, value: "true" }
+            - { name: DYN_SYSTEM_PORT, value: "9092" }
+            - { name: VLLM_LOGGING_LEVEL, value: INFO }
+            - { name: VLLM_SSM_CONV_STATE_LAYOUT, value: DS }
+            - { name: FLASHINFER_DISABLE_VERSION_CHECK, value: "1" }
+            - { name: FI_PROVIDER, value: efa }
+            - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
+            - { name: FI_EFA_FORK_SAFE, value: "1" }
+            - { name: FI_HMEM_CUDA_USE_DMABUF, value: "1" }
+            - { name: FI_EFA_ENABLE_SHM, value: "0" }
+            - { name: FI_EFA_ENABLE_SHM_TRANSFER, value: "0" }
+            - { name: NIXL_LIBFABRIC_MAX_RAILS, value: "1" }
+            - { name: NIXL_SKIP_TOPOLOGY_CHECK, value: "1" }
+            - { name: NCCL_NET_PLUGIN, value: ofi }
+            - { name: NCCL_TUNER_PLUGIN, value: ofi }
+            - { name: OFI_NCCL_FORCE_NUM_RAILS, value: "4" }
+          ports: [{ containerPort: 9092, name: dyn-system }]
+          startupProbe:
+            httpGet: { path: /health, port: 9092 }
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 240
+          volumeMounts:
+            - { name: dshm,       mountPath: /dev/shm }
+            - { name: infiniband, mountPath: /dev/infiniband }
+            - { name: gdrdrv,     mountPath: /dev/gdrdrv }

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd.yaml-template
@@ -106,9 +106,8 @@ spec:
                 --served-model-name ${MODEL_NAME} \
                 --tensor-parallel-size ${GPU_PER_WORKER} --pipeline-parallel-size 1 \
                 --max-model-len 4096 --gpu-memory-utilization 0.97 --enforce-eager \
-                --trust-remote-code --mamba-cache-mode align \
+                --trust-remote-code ${MAMBA_FLAGS} \
                 --load-format runai_streamer \
-                --no-disable-hybrid-kv-cache-manager \
                 --disaggregation-mode prefill \
                 --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}'
           env:
@@ -181,9 +180,8 @@ spec:
                 --served-model-name ${MODEL_NAME} \
                 --tensor-parallel-size ${GPU_PER_WORKER} --pipeline-parallel-size 1 \
                 --max-model-len 4096 --gpu-memory-utilization 0.97 --enforce-eager \
-                --trust-remote-code --mamba-cache-mode align \
+                --trust-remote-code ${MAMBA_FLAGS} \
                 --load-format runai_streamer \
-                --no-disable-hybrid-kv-cache-manager \
                 --disaggregation-mode decode \
                 --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}'
           env:

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd.yaml-template
@@ -99,6 +99,8 @@ spec:
                 --tensor-parallel-size ${GPU_PER_WORKER} --pipeline-parallel-size 1 \
                 --max-model-len 4096 --gpu-memory-utilization 0.97 --enforce-eager \
                 --trust-remote-code --mamba-cache-mode align \
+                --load-format runai_streamer \
+                --no-disable-hybrid-kv-cache-manager \
                 --disaggregation-mode prefill \
                 --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}'
           env:
@@ -169,6 +171,8 @@ spec:
                 --tensor-parallel-size ${GPU_PER_WORKER} --pipeline-parallel-size 1 \
                 --max-model-len 4096 --gpu-memory-utilization 0.97 --enforce-eager \
                 --trust-remote-code --mamba-cache-mode align \
+                --load-format runai_streamer \
+                --no-disable-hybrid-kv-cache-manager \
                 --disaggregation-mode decode \
                 --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}'
           env:

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd.yaml-template
@@ -34,7 +34,10 @@ spec:
     - { name: DYNAMO_BACKEND, value: vllm }
     - { name: ETCD_ENDPOINTS, value: "${ETCD_URL}" }
     - { name: NATS_SERVER,    value: "${NATS_URL}" }
-    - { name: HF_HOME,        value: /shared/hf_cache }
+    # /tmp, NOT /shared: pods run uid 1000 and /shared is root-owned - the frontend
+    # dies registering the model ("Failed to create cache directory /shared/hf_cache/hub:
+    # Permission denied") and /v1/models stays empty -> every request 404s.
+    - { name: HF_HOME,        value: /tmp/hf_cache }
   services:
     # ---- Frontend (router, CPU-only) --------------------------------------
     Frontend:
@@ -43,6 +46,11 @@ spec:
       resources:
         requests: { cpu: "2", memory: 4Gi }
         limits:   { cpu: "4", memory: 8Gi }
+      # The frontend reads the model dir (config/tokenizer, not weights) to build the
+      # preprocessor when workers register a local path - without this mount the model
+      # never appears in /v1/models.
+      volumeMounts:
+        - { name: fsx-pvc, mountPoint: /shared }
       extraPodSpec:
         nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_FRONTEND} }
         mainContainer:

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dynamo-vllm-efa/Dockerfile
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dynamo-vllm-efa/Dockerfile
@@ -1,4 +1,4 @@
-# Nemotron-550B disagg on Dynamo 1.3.0 GA + vLLM 0.23 + EFA 1.49 — ONE GOLDEN IMAGE.
+# Nemotron-550B disagg on Dynamo 1.3.1 (-efa base) + vLLM 0.23 — ONE GOLDEN IMAGE.
 #
 # Author: Anton Alexander
 #
@@ -7,7 +7,7 @@
 # FULLY PUBLIC, DOCKERFILE-ONLY REPRODUCIBLE: no gist, no external files, no patch step,
 # no fork refs. Anyone can `docker build` this with only public network access.
 #
-#   docker build -t $REGISTRY/nemotron-disagg:dynamo13-golden .
+#   docker build -t $REGISTRY/nemotron-disagg:dynamo131-golden .
 #   ./build-sbom-scan.sh          # SBOM (SPDX + CycloneDX) + CVE gate, pipeline-ready
 #
 # The PP>1 fix is fetched at build time from vLLM PR #48263's own pull-ref on UPSTREAM
@@ -15,17 +15,21 @@
 # When #48263 merges into the Dynamo-pinned vLLM, delete the OVERLAY stage entirely.
 #
 # ---------------------------------------------------------------------------------------
-# BASE: 1.3.0 GA. Verified contents (docker run --rm, 2026-07-30) — this drove which
-# layers below survived and which were deleted as redundant:
+# BASE: 1.3.1-efa. Verified contents (docker run --rm, 2026-08-06) — this drove which
+# layers below survived and which were retired:
 #
-#     vllm 0.23.0 | ai-dynamo 1.3.0 | transformers 5.12.0 | runai-model-streamer 0.16.0
+#     vllm 0.23.0 (build commit IDENTICAL to 1.3.0) | ai-dynamo 1.3.1
+#     transformers 5.12.0 | runai-model-streamer 0.16.0
 #     flashinfer-jit-cache 0.6.12+cu130 | flashinfer-python 0.6.12
-#     ray ABSENT | /opt/amazon/efa ABSENT | default USER dynamo | nats-server 16MB baked
+#     EFA installer 1.49.0 BAKED (+ libfabric 2.4.0amzn + /opt/amazon/ofi-nccl) -> our
+#       EFA install layer RETIRED, replaced by an assert (#12105 retire condition met)
+#     ray ABSENT | no /opt/dynamo/venv | default USER dynamo | nats-server 16MB STILL baked
+#     nixl NIXL_CONNECTOR_VERSION 4 -> PR#48263 overlay (v8) STILL REQUIRED
 #
 # Do NOT assume a newer base fixes a layer — measure it. Three separate GA layers were
 # each assumed-fixed and were not (transformers, flashinfer, nats-server).
 # ---------------------------------------------------------------------------------------
-ARG BASE=nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0
+ARG BASE=nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.1-efa
 FROM ${BASE}
 
 USER root
@@ -43,20 +47,21 @@ d = m.version("ai-dynamo"); assert d.startswith("1.3"),  f"base ai-dynamo {d} !=
 print(f"[base] vllm={v} ai-dynamo={d} OK")
 PY
 
-# ---- 1) AWS EFA 1.49 userspace (public installer, no kmod) --------------------------
-#    Still required: GA has NO /opt/amazon/efa. The `1.3.0-efa` tag bakes EFA 1.47, not
-#    1.49, so this layer's retire condition is still unmet (ai-dynamo/dynamo#12105).
-ARG EFA_INSTALLER_VER=1.49.0
+# ---- 1) AWS EFA userspace: NOW FROM THE BASE (install layer RETIRED at 1.3.1) --------
+#    History: GA 1.3.0 had NO /opt/amazon/efa and 1.3.0-efa baked 1.47, so this used to
+#    be a full efa_installer.sh layer (ai-dynamo/dynamo#12105). The 1.3.1-efa tag bakes
+#    EFA installer 1.49.0 + libfabric 2.4.0amzn + /opt/amazon/ofi-nccl (measured in-image
+#    2026-08-06), which meets the retire condition. Keep a build-time assert so a future
+#    BASE bump that regresses EFA fails here, not on a p5en at serve time.
+ARG EFA_INSTALLER_MIN=1.49.0
 RUN set -eux; \
-    apt-get update && apt-get install -y --no-install-recommends \
-      curl ca-certificates git environment-modules tcl libhwloc-dev; \
-    curl -fsSL https://efa-installer.amazonaws.com/aws-efa-installer-${EFA_INSTALLER_VER}.tar.gz \
-      -o /tmp/efa.tar.gz; \
-    tar -xzf /tmp/efa.tar.gz -C /tmp; \
-    cd /tmp/aws-efa-installer && ./efa_installer.sh -y --skip-kmod --skip-limit-conf --no-verify; \
-    echo "${EFA_INSTALLER_VER}" > /opt/efa-installer.version; \
-    /opt/amazon/efa/bin/fi_info --version; \
-    rm -rf /tmp/efa.tar.gz /tmp/aws-efa-installer /var/lib/apt/lists/*
+    test -x /opt/amazon/efa/bin/fi_info || { echo "FAIL: base has no /opt/amazon/efa - use an -efa base tag or restore the efa_installer.sh layer (see #12105)"; exit 1; }; \
+    VER="$(grep -oE '[0-9]+\.[0-9]+\.[0-9]+' /opt/amazon/efa_installed_packages | head -1)"; \
+    printf '%s\n%s\n' "${EFA_INSTALLER_MIN}" "${VER}" | sort -V -C || { echo "FAIL: base EFA ${VER} < required ${EFA_INSTALLER_MIN}"; exit 1; }; \
+    test -f /opt/amazon/ofi-nccl/lib/libnccl-net-ofi.so || { echo "FAIL: aws-ofi-nccl plugin missing from base"; exit 1; }; \
+    echo "${VER}" > /opt/efa-installer.version; \
+    /opt/amazon/efa/bin/fi_info --version
+# The base bakes the bits but NOT the env contract - keep ours.
 ENV FI_PROVIDER=efa FI_EFA_USE_DEVICE_RDMA=1 \
     NCCL_NET_PLUGIN=ofi NCCL_NVLS_ENABLE=0
 # NOTE: FLASHINFER_DISABLE_VERSION_CHECK=1 was DELETED. It existed because the dev base
@@ -91,6 +96,9 @@ PY
 ARG VLLM_PR=48263
 ARG VLLM_FIX_SHA=c370902c1243bb09f5729310662aceb7c3dd3737
 RUN set -eux; \
+    # git used to arrive as a side-effect of the (now retired) efa_installer apt line; \
+    # the -efa base doesn't ship it. Self-supply so this stage owns its own deps. \
+    command -v git >/dev/null || { apt-get update && apt-get install -y --no-install-recommends git ca-certificates && rm -rf /var/lib/apt/lists/*; }; \
     NIXLSRC="vllm/distributed/kv_transfer/kv_connector/v1/nixl"; \
     mkdir /tmp/vllm-fix; cd /tmp/vllm-fix; \
     git init -q .; git remote add origin https://github.com/vllm-project/vllm.git; \
@@ -130,6 +138,6 @@ print("[golden] agg + EP16 + PP>1 prerequisites all present; EFA present; 0-CRIT
 PY
 
 USER dynamo
-LABEL org.opencontainers.image.description="Golden image: Dynamo 1.3.0 GA + vLLM 0.23 + ray 2.55.1 + EFA 1.49 + vLLM PR#48263 overlay (agg + EP16 + PP>1, Dockerfile-only reproducible)"
+LABEL org.opencontainers.image.description="Golden image: Dynamo 1.3.1 (-efa base, EFA 1.49 baked) + vLLM 0.23 + ray 2.55.1 + vLLM PR#48263 overlay (agg + EP16 + PP>1, Dockerfile-only reproducible)"
 LABEL org.opencontainers.image.source="https://github.com/vllm-project/vllm/pull/48263"
 

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dynamo-vllm-efa/build-sbom-scan.sh
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dynamo-vllm-efa/build-sbom-scan.sh
@@ -17,7 +17,7 @@
 set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-IMAGE="${IMAGE:-dynamo-vllm-efa:1.3.0-patched}"
+IMAGE="${IMAGE:-dynamo-vllm-efa:1.3.1-patched}"
 GATE_SEVERITY="${GATE_SEVERITY:-CRITICAL}"
 MAX_HIGH="${MAX_HIGH:-}"                       # empty = report HIGH, do not gate on it
 OUTDIR="${OUTDIR:-$HERE/sbom}"

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dynamo-vllm-efa/buildspec.yaml
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dynamo-vllm-efa/buildspec.yaml
@@ -6,26 +6,26 @@ version: 0.2
 # Author: Anton Alexander
 #
 # Reproducible build fromPUBLIC base: nvcr.io/nvidia/ai-dynamo/
-# vllm-runtime:1.3.0 (EFA + NIXL LIBFABRIC + vLLM 0.23.0 baked) + nixl patches
+# vllm-runtime:1.3.1-efa (EFA 1.49 baked + NIXL LIBFABRIC + vLLM 0.23.0 baked) + nixl patches
 #
 # Reuses build-sbom-scan.sh, so the CodeBuild path produces the SAME artifacts
 # as the local path: image + syft SBOM (SPDX+CycloneDX) + trivy CVE gate.
 #
 # Project env vars (PLAINTEXT unless noted):
 #   REGISTRY=public.ecr.aws/hpc-cloud/
-#   IMAGE=dynamo-vllm-efa:1.3.0-patched
+#   IMAGE=dynamo-vllm-efa:1.3.1-patched
 #   GATE_SEVERITY=CRITICAL,HIGH
 #   MAX_HIGH=65
-#   BASE=nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0
+#   BASE=nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.1-efa
 # =============================================================================
 
 env:
   variables:
-    BASE: "nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0"
+    BASE: "nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.1-efa"
     GATE_SEVERITY: "CRITICAL,HIGH"
     MAX_HIGH: "65"
     REGISTRY: "public.ecr.aws/hpc-cloud/"
-    IMAGE: "dynamo-vllm-efa:1.3.0-patched"
+    IMAGE: "dynamo-vllm-efa:1.3.1-patched"
 
 phases:
   install:

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/ep.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/ep.yaml-template
@@ -80,9 +80,8 @@ spec:
                   --gpu-memory-utilization 0.95 \
                   --enforce-eager \
                   --trust-remote-code \
-                  --mamba-cache-mode align \
                   --load-format runai_streamer \
-                  --no-disable-hybrid-kv-cache-manager \
+                  ${MAMBA_FLAGS} \
                   --host 0.0.0.0 --port 8000
             env:
               - { name: MY_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
@@ -181,9 +180,8 @@ spec:
                   --gpu-memory-utilization 0.95 \
                   --enforce-eager \
                   --trust-remote-code \
-                  --mamba-cache-mode align \
                   --load-format runai_streamer \
-                  --no-disable-hybrid-kv-cache-manager
+                  ${MAMBA_FLAGS}
             env:
               - { name: MY_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
               - { name: HF_HOME, value: /tmp/hf_cache }

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/ep.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/ep.yaml-template
@@ -1,0 +1,231 @@
+# =============================================================================
+# Nemotron-3 Ultra EP16 — expert-parallel aggregated serving (DP2 x TP8 = EP16)
+# =============================================================================
+#
+# Author: Anton Alexander
+#
+# The MoE expert layers are sharded 16 ways across 2 nodes (EFA NCCL all-to-all);
+# each data-parallel rank is one full TP8 node. vLLM's OpenAI server runs on the
+# DP rank-0 leader; the LWS worker joins headless. EP degree = EP_DP_SIZE x
+# GPU_PER_WORKER, and the model's expert count must be divisible by it
+# (Nemotron-3-Ultra and Qwen3-235B: yes; Mixtral's 8 experts: no).
+#
+# This is the AGGREGATED expert-parallel permutation - no prefill/decode split,
+# no Dynamo platform required (the vllm leader serves OpenAI API directly).
+# =============================================================================
+---
+apiVersion: leaderworkerset.x-k8s.io/v1
+kind: LeaderWorkerSet
+metadata:
+  name: ${DEPLOYMENT_NAME}-ep
+  namespace: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}
+    app.kubernetes.io/component: ep-agg
+spec:
+  replicas: 1
+  startupPolicy: LeaderCreated
+  leaderWorkerTemplate:
+    restartPolicy: None
+    size: ${EP_DP_SIZE}
+    leaderTemplate:
+      metadata:
+        labels:
+          app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}
+          app.kubernetes.io/component: ep-agg
+          dynamo-role: leader
+      spec:
+        nodeSelector:
+          node.kubernetes.io/instance-type: ${INSTANCE_TYPE_WORKER}
+        tolerations:
+          - { key: nvidia.com/gpu, operator: Exists, effect: NoSchedule }
+          - { key: vpc.amazonaws.com/efa, operator: Exists, effect: NoSchedule }
+        affinity:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}
+                topologyKey: kubernetes.io/hostname
+        volumes:
+          - { name: dshm,       emptyDir: { medium: Memory, sizeLimit: 64Gi } }
+          - { name: infiniband, hostPath: { path: /dev/infiniband, type: DirectoryOrCreate } }
+          - { name: gdrdrv,     hostPath: { path: /dev/gdrdrv, type: CharDevice } }
+          - { name: shared,     persistentVolumeClaim: { claimName: fsx-pvc } }
+        containers:
+          - name: vllm
+            image: ${REGISTRY}${IMAGE}${TAG}
+            imagePullPolicy: Always
+            securityContext: { capabilities: { add: ["IPC_LOCK"] } }
+            command: ["/bin/bash", "-c"]
+            args:
+              - |-
+                set -u
+                unset HPCX_DIR HPCX_MPI_DIR HPCX_HOME HPCX_UCX_DIR HPCX_SHARP_DIR \
+                      HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
+                if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+                mkdir -p /tmp/hf_cache
+                echo "[ep dp0/leader] MY_IP=${DOLLAR}MY_IP EP=$((${EP_DP_SIZE}*${GPU_PER_WORKER}))"
+                python3 -c "import vllm; print(f'vllm {vllm.__version__}')"
+                exec vllm serve ${MODEL_PATH} \
+                  --served-model-name ${MODEL_NAME} \
+                  --tensor-parallel-size ${GPU_PER_WORKER} \
+                  --data-parallel-size ${EP_DP_SIZE} \
+                  --data-parallel-size-local 1 \
+                  --data-parallel-address "${DOLLAR}MY_IP" \
+                  --data-parallel-rpc-port 29550 \
+                  --enable-expert-parallel \
+                  --pipeline-parallel-size 1 \
+                  --max-model-len 8192 \
+                  --gpu-memory-utilization 0.95 \
+                  --enforce-eager \
+                  --trust-remote-code \
+                  --mamba-cache-mode align \
+                  --load-format runai_streamer \
+                  --no-disable-hybrid-kv-cache-manager \
+                  --host 0.0.0.0 --port 8000
+            env:
+              - { name: MY_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+              - { name: HF_HOME, value: /tmp/hf_cache }
+              - { name: HF_HUB_OFFLINE, value: "1" }
+              - { name: TRANSFORMERS_OFFLINE, value: "1" }
+              - { name: VLLM_LOGGING_LEVEL, value: INFO }
+              - { name: VLLM_ENGINE_READY_TIMEOUT_S, value: "1200" }
+              - { name: VLLM_SSM_CONV_STATE_LAYOUT, value: DS }
+              - { name: FLASHINFER_DISABLE_VERSION_CHECK, value: "1" }
+              - { name: FI_PROVIDER, value: efa }
+              - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
+              - { name: FI_EFA_FORK_SAFE, value: "1" }
+              - { name: FI_HMEM_CUDA_USE_DMABUF, value: "1" }
+              - { name: NCCL_NET_PLUGIN, value: ofi }
+              - { name: NCCL_TUNER_PLUGIN, value: ofi }
+              - { name: OFI_NCCL_FORCE_NUM_RAILS, value: "4" }
+              - { name: NCCL_NVLS_ENABLE, value: "0" }
+              - { name: NCCL_CUMEM_ENABLE, value: "1" }
+              - { name: NCCL_SOCKET_IFNAME, value: "^lo,docker,veth,eni" }
+            ports:
+              - { containerPort: 8000, name: http }
+              - { containerPort: 29550, name: dp-rpc }
+            readinessProbe:
+              httpGet: { path: /health, port: 8000 }
+              periodSeconds: 30
+              timeoutSeconds: 10
+              failureThreshold: 120
+            resources:
+              requests: { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+              limits:   { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+            volumeMounts:
+              - { name: dshm,       mountPath: /dev/shm }
+              - { name: infiniband, mountPath: /dev/infiniband }
+              - { name: gdrdrv,     mountPath: /dev/gdrdrv }
+              - { name: shared,     mountPath: /shared }
+    workerTemplate:
+      metadata:
+        labels:
+          app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}
+          app.kubernetes.io/component: ep-agg
+          dynamo-role: worker
+      spec:
+        nodeSelector:
+          node.kubernetes.io/instance-type: ${INSTANCE_TYPE_WORKER}
+        tolerations:
+          - { key: nvidia.com/gpu, operator: Exists, effect: NoSchedule }
+          - { key: vpc.amazonaws.com/efa, operator: Exists, effect: NoSchedule }
+        affinity:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}
+                topologyKey: kubernetes.io/hostname
+        volumes:
+          - { name: dshm,       emptyDir: { medium: Memory, sizeLimit: 64Gi } }
+          - { name: infiniband, hostPath: { path: /dev/infiniband, type: DirectoryOrCreate } }
+          - { name: gdrdrv,     hostPath: { path: /dev/gdrdrv, type: CharDevice } }
+          - { name: shared,     persistentVolumeClaim: { claimName: fsx-pvc } }
+        containers:
+          - name: vllm
+            image: ${REGISTRY}${IMAGE}${TAG}
+            imagePullPolicy: Always
+            securityContext: { capabilities: { add: ["IPC_LOCK"] } }
+            command: ["/bin/bash", "-c"]
+            args:
+              - |-
+                set -u
+                unset HPCX_DIR HPCX_MPI_DIR HPCX_HOME HPCX_UCX_DIR HPCX_SHARP_DIR \
+                      HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
+                if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+                mkdir -p /tmp/hf_cache
+                for i in ${DOLLAR}(seq 1 60); do
+                  if getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" >/dev/null 2>&1; then break; fi
+                  sleep 2
+                done
+                LEADER_IP=${DOLLAR}(getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" | awk '{print ${DOLLAR}1}')
+                echo "[ep dp${DOLLAR}{LWS_WORKER_INDEX}/worker] LEADER_IP=${DOLLAR}LEADER_IP MY_IP=${DOLLAR}MY_IP"
+                for i in ${DOLLAR}(seq 1 120); do
+                  if (echo > /dev/tcp/${DOLLAR}LEADER_IP/29550) 2>/dev/null; then break; fi
+                  sleep 5
+                done
+                exec vllm serve ${MODEL_PATH} \
+                  --served-model-name ${MODEL_NAME} \
+                  --headless \
+                  --data-parallel-start-rank ${DOLLAR}{LWS_WORKER_INDEX} \
+                  --tensor-parallel-size ${GPU_PER_WORKER} \
+                  --data-parallel-size ${EP_DP_SIZE} \
+                  --data-parallel-size-local 1 \
+                  --data-parallel-address "${DOLLAR}LEADER_IP" \
+                  --data-parallel-rpc-port 29550 \
+                  --enable-expert-parallel \
+                  --pipeline-parallel-size 1 \
+                  --max-model-len 8192 \
+                  --gpu-memory-utilization 0.95 \
+                  --enforce-eager \
+                  --trust-remote-code \
+                  --mamba-cache-mode align \
+                  --load-format runai_streamer \
+                  --no-disable-hybrid-kv-cache-manager
+            env:
+              - { name: MY_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+              - { name: HF_HOME, value: /tmp/hf_cache }
+              - { name: HF_HUB_OFFLINE, value: "1" }
+              - { name: TRANSFORMERS_OFFLINE, value: "1" }
+              - { name: VLLM_LOGGING_LEVEL, value: INFO }
+              - { name: VLLM_ENGINE_READY_TIMEOUT_S, value: "1200" }
+              - { name: VLLM_SSM_CONV_STATE_LAYOUT, value: DS }
+              - { name: FLASHINFER_DISABLE_VERSION_CHECK, value: "1" }
+              - { name: FI_PROVIDER, value: efa }
+              - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
+              - { name: FI_EFA_FORK_SAFE, value: "1" }
+              - { name: FI_HMEM_CUDA_USE_DMABUF, value: "1" }
+              - { name: NCCL_NET_PLUGIN, value: ofi }
+              - { name: NCCL_TUNER_PLUGIN, value: ofi }
+              - { name: OFI_NCCL_FORCE_NUM_RAILS, value: "4" }
+              - { name: NCCL_NVLS_ENABLE, value: "0" }
+              - { name: NCCL_CUMEM_ENABLE, value: "1" }
+              - { name: NCCL_SOCKET_IFNAME, value: "^lo,docker,veth,eni" }
+            resources:
+              requests: { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+              limits:   { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+            volumeMounts:
+              - { name: dshm,       mountPath: /dev/shm }
+              - { name: infiniband, mountPath: /dev/infiniband }
+              - { name: gdrdrv,     mountPath: /dev/gdrdrv }
+              - { name: shared,     mountPath: /shared }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${DEPLOYMENT_NAME}-ep
+  namespace: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}
+    app.kubernetes.io/component: ep-agg
+spec:
+  selector:
+    app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}
+    app.kubernetes.io/component: ep-agg
+    dynamo-role: leader
+  ports:
+    - port: 8000
+      targetPort: 8000
+      name: http

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-pp.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-pp.yaml-template
@@ -95,9 +95,8 @@ spec:
                   --gpu-memory-utilization 0.92 \
                   --enforce-eager \
                   --trust-remote-code \
-                  --mamba-cache-mode align \
+                  ${MAMBA_FLAGS} \
                   --load-format runai_streamer \
-                  --no-disable-hybrid-kv-cache-manager \
                   --disaggregation-mode prefill \
                   --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}' 2>&1 | tee -a "${DOLLAR}LOG"
             env:
@@ -270,9 +269,8 @@ spec:
                   --gpu-memory-utilization 0.98 \
                   --enforce-eager \
                   --trust-remote-code \
-                  --mamba-cache-mode align \
+                  ${MAMBA_FLAGS} \
                   --load-format runai_streamer \
-                  --no-disable-hybrid-kv-cache-manager \
                   --disaggregation-mode decode \
                   --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}' 2>&1 | tee -a "${DOLLAR}LOG"
             env:

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-pp.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-pp.yaml-template
@@ -1,0 +1,374 @@
+# =============================================================================
+# Nemotron-3 Ultra disaggregated P/D with PP>1 prefill — LeaderWorkerSet manifest
+# =============================================================================
+#
+# Author: Anton Alexander
+#
+# Topology (4 GPU nodes + 1 CPU node):
+#   - prefill: 1 LWS group of size 2 -> TP=${GPU_PER_WORKER} PP=2 across 2 nodes
+#              (Ray distributed executor, Ray V2 executor backend)
+#   - decode:  1 LWS with 2 single-node groups -> 2x independent TP=${GPU_PER_WORKER} PP=1 workers
+#              (asymmetric BY DESIGN: PP>1 on the decode side of the hybrid-Mamba
+#              550B deadlocks the Ray static DAG; prefill-PP2 -> decode-PP1 is the
+#              upstream-aligned shape and is validated end-to-end on Dynamo 1.3.0)
+#   - frontend: CPU-only router Deployment + Service
+#
+# KV is transferred prefill->decode over EFA RDMA via NIXL LIBFABRIC.
+# etcd/NATS come from the Dynamo platform (see ../../../nvidia-dynamo): ${ETCD_URL} / ${NATS_URL}.
+# Scheduling uses resource requests + instance-type nodeSelector + podAntiAffinity
+# only - no node hostnames, so the manifest is portable across clusters.
+# =============================================================================
+---
+apiVersion: leaderworkerset.x-k8s.io/v1
+kind: LeaderWorkerSet
+metadata:
+  name: ${DEPLOYMENT_NAME}-prefill
+  namespace: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}
+    app.kubernetes.io/component: prefill
+spec:
+  replicas: 1
+  startupPolicy: LeaderCreated
+  rolloutStrategy:
+    type: RollingUpdate
+  leaderWorkerTemplate:
+    restartPolicy: RecreateGroupOnPodRestart
+    size: 2
+    leaderTemplate:
+      metadata:
+        labels:
+          app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}
+          app.kubernetes.io/component: prefill
+          dynamo-role: leader
+      spec:
+        nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_WORKER} }
+        tolerations:
+          - { key: nvidia.com/gpu, operator: Exists, effect: NoSchedule }
+          - { key: vpc.amazonaws.com/efa, operator: Exists, effect: NoSchedule }
+        affinity:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector: { matchLabels: { app.kubernetes.io/part-of: ${DEPLOYMENT_NAME} } }
+                topologyKey: kubernetes.io/hostname
+        volumes:
+          - { name: dshm,       emptyDir: { medium: Memory, sizeLimit: 64Gi } }
+          - { name: infiniband, hostPath: { path: /dev/infiniband, type: DirectoryOrCreate } }
+          - { name: gdrdrv,     hostPath: { path: /dev/gdrdrv, type: CharDevice } }
+          - { name: shared,     persistentVolumeClaim: { claimName: fsx-pvc } }
+        containers:
+          - name: vllm
+            image: ${REGISTRY}${IMAGE}${TAG}
+            imagePullPolicy: Always
+            securityContext: { capabilities: { add: ["IPC_LOCK"] } }
+            command: ["/bin/bash", "-c"]
+            args:
+              - |-
+                set -u
+                unset HPCX_DIR HPCX_MPI_DIR HPCX_HOME HPCX_UCX_DIR HPCX_SHARP_DIR \
+                      HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
+                # Dynamo images differ in python layout: 1.2.0-era images ship /opt/dynamo/venv,
+                # 1.3.0-era images install into the system python and have NO venv.
+                if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+                LOG=/shared/${DEPLOYMENT_NAME}-prefill-pp2-${DOLLAR}(date -u +%FT%TZ).log
+                echo "[prefill-leader] starting; piping to ${DOLLAR}LOG"
+                python3 -c "import vllm; print(f'vllm {vllm.__version__}')" 2>&1 | tee -a "${DOLLAR}LOG"
+                for i in ${DOLLAR}(seq 1 60); do
+                  if getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" >/dev/null 2>&1; then break; fi
+                  sleep 2
+                done
+                LEADER_IP=${DOLLAR}(getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" | awk '{print ${DOLLAR}1}')
+                echo "[prefill-leader] LEADER_IP=${DOLLAR}LEADER_IP MY_IP=${DOLLAR}MY_IP" | tee -a "${DOLLAR}LOG"
+                ray start --head --port=6379 --node-ip-address="${DOLLAR}LEADER_IP" --num-gpus=${GPU_PER_WORKER} 2>&1 | tee -a "${DOLLAR}LOG"
+                for i in ${DOLLAR}(seq 1 120); do
+                  N=${DOLLAR}(ray status 2>/dev/null | awk '/Active:/{flag=1; next} /Pending:|Recent failures:|Resources/{flag=0} flag' | grep -c node_ || true)
+                  if [ "${DOLLAR}{N:-0}" -ge 2 ]; then break; fi
+                  sleep 5
+                done
+                exec python3 -m dynamo.vllm \
+                  --model ${MODEL_PATH} \
+                  --served-model-name ${MODEL_NAME} \
+                  --tensor-parallel-size ${GPU_PER_WORKER} \
+                  --pipeline-parallel-size 2 \
+                  --distributed-executor-backend ray \
+                  --max-model-len 8192 \
+                  --gpu-memory-utilization 0.92 \
+                  --enforce-eager \
+                  --trust-remote-code \
+                  --mamba-cache-mode align \
+                  --load-format runai_streamer \
+                  --no-disable-hybrid-kv-cache-manager \
+                  --disaggregation-mode prefill \
+                  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}' 2>&1 | tee -a "${DOLLAR}LOG"
+            env:
+              - { name: MY_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+              - { name: DYNAMO_BACKEND, value: vllm }
+              - { name: DYN_NAMESPACE, value: dynamo-disagg }
+              - { name: ETCD_ENDPOINTS, value: "${ETCD_URL}" }
+              - { name: NATS_SERVER, value: "${NATS_URL}" }
+              - { name: HF_HOME, value: /shared/hf_cache }
+              - { name: DYN_SYSTEM_ENABLED, value: "true" }
+              - { name: DYN_SYSTEM_PORT, value: "9091" }
+              - { name: VLLM_LOGGING_LEVEL, value: INFO }
+              - { name: VLLM_USE_RAY_V2_EXECUTOR_BACKEND, value: "1" }
+              - { name: VLLM_SSM_CONV_STATE_LAYOUT, value: DS }
+              - { name: FLASHINFER_DISABLE_VERSION_CHECK, value: "1" }
+              - { name: FI_PROVIDER, value: efa }
+              - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
+              - { name: FI_EFA_FORK_SAFE, value: "1" }
+              - { name: FI_HMEM_CUDA_USE_DMABUF, value: "1" }
+              - { name: NIXL_LIBFABRIC_MAX_RAILS, value: "1" }
+              - { name: NIXL_SKIP_TOPOLOGY_CHECK, value: "1" }
+              - { name: NCCL_NET_PLUGIN, value: ofi }
+              - { name: NCCL_TUNER_PLUGIN, value: ofi }
+              - { name: OFI_NCCL_FORCE_NUM_RAILS, value: "4" }
+              - { name: NCCL_RUNTIME_CONNECT, value: "0" }
+              - { name: NCCL_NVLS_ENABLE, value: "1" }
+              - { name: NCCL_CUMEM_ENABLE, value: "1" }
+            ports: [{ containerPort: 9091, name: dyn-system }]
+            startupProbe:
+              httpGet: { path: /health, port: 9091 }
+              periodSeconds: 30
+              timeoutSeconds: 10
+              failureThreshold: 240
+            resources:
+              requests: { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+              limits:   { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+            volumeMounts:
+              - { name: dshm,       mountPath: /dev/shm }
+              - { name: infiniband, mountPath: /dev/infiniband }
+              - { name: gdrdrv,     mountPath: /dev/gdrdrv }
+              - { name: shared,     mountPath: /shared }
+    workerTemplate:
+      metadata:
+        labels:
+          app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}
+          app.kubernetes.io/component: prefill
+          dynamo-role: worker
+      spec:
+        nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_WORKER} }
+        tolerations:
+          - { key: nvidia.com/gpu, operator: Exists, effect: NoSchedule }
+          - { key: vpc.amazonaws.com/efa, operator: Exists, effect: NoSchedule }
+        affinity:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector: { matchLabels: { app.kubernetes.io/part-of: ${DEPLOYMENT_NAME} } }
+                topologyKey: kubernetes.io/hostname
+        volumes:
+          - { name: dshm,       emptyDir: { medium: Memory, sizeLimit: 64Gi } }
+          - { name: infiniband, hostPath: { path: /dev/infiniband, type: DirectoryOrCreate } }
+          - { name: gdrdrv,     hostPath: { path: /dev/gdrdrv, type: CharDevice } }
+          - { name: shared,     persistentVolumeClaim: { claimName: fsx-pvc } }
+        containers:
+          - name: vllm
+            image: ${REGISTRY}${IMAGE}${TAG}
+            imagePullPolicy: Always
+            securityContext: { capabilities: { add: ["IPC_LOCK"] } }
+            command: ["/bin/bash", "-c"]
+            args:
+              - |-
+                set -u
+                unset HPCX_DIR HPCX_MPI_DIR HPCX_HOME HPCX_UCX_DIR HPCX_SHARP_DIR \
+                      HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
+                if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+                for i in ${DOLLAR}(seq 1 60); do
+                  if getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" >/dev/null 2>&1; then break; fi
+                  sleep 2
+                done
+                LEADER_IP=${DOLLAR}(getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" | awk '{print ${DOLLAR}1}')
+                for i in ${DOLLAR}(seq 1 60); do
+                  if (echo > /dev/tcp/${DOLLAR}LEADER_IP/6379) 2>/dev/null; then break; fi
+                  sleep 5
+                done
+                exec ray start --address="${DOLLAR}LEADER_IP:6379" --node-ip-address="${DOLLAR}MY_IP" --num-gpus=${GPU_PER_WORKER} --block
+            env:
+              - { name: MY_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+              - { name: HF_HOME, value: /shared/hf_cache }
+              - { name: VLLM_SSM_CONV_STATE_LAYOUT, value: DS }
+              - { name: FLASHINFER_DISABLE_VERSION_CHECK, value: "1" }
+              - { name: FI_PROVIDER, value: efa }
+              - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
+              - { name: FI_EFA_FORK_SAFE, value: "1" }
+              - { name: FI_HMEM_CUDA_USE_DMABUF, value: "1" }
+              - { name: ETCD_ENDPOINTS, value: "${ETCD_URL}" }
+              - { name: NATS_SERVER, value: "${NATS_URL}" }
+              - { name: NIXL_LIBFABRIC_MAX_RAILS, value: "1" }
+              - { name: NIXL_SKIP_TOPOLOGY_CHECK, value: "1" }
+              - { name: NCCL_NET_PLUGIN, value: ofi }
+              - { name: NCCL_TUNER_PLUGIN, value: ofi }
+              - { name: OFI_NCCL_FORCE_NUM_RAILS, value: "4" }
+            resources:
+              requests: { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+              limits:   { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+            volumeMounts:
+              - { name: dshm,       mountPath: /dev/shm }
+              - { name: infiniband, mountPath: /dev/infiniband }
+              - { name: gdrdrv,     mountPath: /dev/gdrdrv }
+              - { name: shared,     mountPath: /shared }
+---
+# Decode: one LWS with 2 single-node groups (size: 1 => each group is just its
+# leader pod, built from workerTemplate). Each runs an independent TP8/PP1 decode
+# worker; the frontend round-robins across them via etcd/NATS registration.
+apiVersion: leaderworkerset.x-k8s.io/v1
+kind: LeaderWorkerSet
+metadata:
+  name: ${DEPLOYMENT_NAME}-decode
+  namespace: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}
+    app.kubernetes.io/component: decode
+spec:
+  replicas: 2
+  startupPolicy: LeaderCreated
+  rolloutStrategy:
+    type: RollingUpdate
+  leaderWorkerTemplate:
+    restartPolicy: RecreateGroupOnPodRestart
+    size: 1
+    workerTemplate:
+      metadata:
+        labels:
+          app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}
+          app.kubernetes.io/component: decode
+      spec:
+        nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_WORKER} }
+        tolerations:
+          - { key: nvidia.com/gpu, operator: Exists, effect: NoSchedule }
+          - { key: vpc.amazonaws.com/efa, operator: Exists, effect: NoSchedule }
+        affinity:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector: { matchLabels: { app.kubernetes.io/part-of: ${DEPLOYMENT_NAME} } }
+                topologyKey: kubernetes.io/hostname
+        volumes:
+          - { name: dshm,       emptyDir: { medium: Memory, sizeLimit: 64Gi } }
+          - { name: infiniband, hostPath: { path: /dev/infiniband, type: DirectoryOrCreate } }
+          - { name: gdrdrv,     hostPath: { path: /dev/gdrdrv, type: CharDevice } }
+          - { name: shared,     persistentVolumeClaim: { claimName: fsx-pvc } }
+        containers:
+          - name: vllm
+            image: ${REGISTRY}${IMAGE}${TAG}
+            imagePullPolicy: Always
+            securityContext: { capabilities: { add: ["IPC_LOCK"] } }
+            command: ["/bin/bash", "-c"]
+            args:
+              - |-
+                set -u
+                unset HPCX_DIR HPCX_MPI_DIR HPCX_HOME HPCX_UCX_DIR HPCX_SHARP_DIR \
+                      HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
+                if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+                LOG=/shared/${DEPLOYMENT_NAME}-decode-pp1-${DOLLAR}(date -u +%FT%TZ).log
+                python3 -c "import vllm; print(f'vllm {vllm.__version__}')" 2>&1 | tee -a "${DOLLAR}LOG"
+                # Single-node decode: TP8/PP1, no Ray - the validated decode shape for hybrid-Mamba.
+                exec python3 -m dynamo.vllm \
+                  --model ${MODEL_PATH} \
+                  --served-model-name ${MODEL_NAME} \
+                  --tensor-parallel-size ${GPU_PER_WORKER} \
+                  --pipeline-parallel-size 1 \
+                  --max-model-len 8192 \
+                  --gpu-memory-utilization 0.98 \
+                  --enforce-eager \
+                  --trust-remote-code \
+                  --mamba-cache-mode align \
+                  --load-format runai_streamer \
+                  --no-disable-hybrid-kv-cache-manager \
+                  --disaggregation-mode decode \
+                  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}' 2>&1 | tee -a "${DOLLAR}LOG"
+            env:
+              - { name: MY_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+              - { name: DYNAMO_BACKEND, value: vllm }
+              - { name: DYN_NAMESPACE, value: dynamo-disagg }
+              - { name: ETCD_ENDPOINTS, value: "${ETCD_URL}" }
+              - { name: NATS_SERVER, value: "${NATS_URL}" }
+              - { name: HF_HOME, value: /shared/hf_cache }
+              - { name: DYN_SYSTEM_ENABLED, value: "true" }
+              - { name: DYN_SYSTEM_PORT, value: "9092" }
+              - { name: VLLM_LOGGING_LEVEL, value: INFO }
+              - { name: VLLM_SSM_CONV_STATE_LAYOUT, value: DS }
+              - { name: FLASHINFER_DISABLE_VERSION_CHECK, value: "1" }
+              - { name: FI_PROVIDER, value: efa }
+              - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
+              - { name: FI_EFA_FORK_SAFE, value: "1" }
+              - { name: FI_HMEM_CUDA_USE_DMABUF, value: "1" }
+              - { name: NIXL_LIBFABRIC_MAX_RAILS, value: "1" }
+              - { name: NIXL_SKIP_TOPOLOGY_CHECK, value: "1" }
+              - { name: NCCL_NET_PLUGIN, value: ofi }
+              - { name: NCCL_TUNER_PLUGIN, value: ofi }
+              - { name: OFI_NCCL_FORCE_NUM_RAILS, value: "4" }
+              - { name: NCCL_NVLS_ENABLE, value: "1" }
+              - { name: NCCL_CUMEM_ENABLE, value: "1" }
+            ports: [{ containerPort: 9092, name: dyn-system }]
+            startupProbe:
+              httpGet: { path: /health, port: 9092 }
+              periodSeconds: 30
+              timeoutSeconds: 10
+              failureThreshold: 240
+            resources:
+              requests: { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+              limits:   { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+            volumeMounts:
+              - { name: dshm,       mountPath: /dev/shm }
+              - { name: infiniband, mountPath: /dev/infiniband }
+              - { name: gdrdrv,     mountPath: /dev/gdrdrv }
+              - { name: shared,     mountPath: /shared }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${DEPLOYMENT_NAME}-frontend
+  namespace: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}
+    app.kubernetes.io/component: frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}
+      app.kubernetes.io/component: frontend
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}
+        app.kubernetes.io/component: frontend
+    spec:
+      nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_FRONTEND} }
+      volumes:
+        - { name: shared, persistentVolumeClaim: { claimName: fsx-pvc } }
+      containers:
+        - name: frontend
+          image: ${REGISTRY}${IMAGE}${TAG}
+          imagePullPolicy: Always
+          command: ["/bin/bash", "-c"]
+          # 1.3.0-era images have no /opt/dynamo/venv - activate only when present.
+          args:
+            - |-
+              if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+              exec python3 -m dynamo.frontend --http-port 8000 --http-host 0.0.0.0
+          env:
+            - { name: DYNAMO_BACKEND, value: vllm }
+            - { name: DYN_NAMESPACE, value: dynamo-disagg }
+            - { name: ETCD_ENDPOINTS, value: "${ETCD_URL}" }
+            - { name: NATS_SERVER, value: "${NATS_URL}" }
+            - { name: HF_HOME, value: /tmp/hf_cache }
+          ports: [{ containerPort: 8000, name: http }]
+          readinessProbe: { tcpSocket: { port: 8000 }, periodSeconds: 10, failureThreshold: 30 }
+          resources:
+            requests: { cpu: "2", memory: 4Gi }
+            limits:   { cpu: "4", memory: 8Gi }
+          volumeMounts:
+            - { name: shared, mountPath: /shared, readOnly: true }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${DEPLOYMENT_NAME}-frontend
+  namespace: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}
+spec:
+  selector:
+    app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}
+    app.kubernetes.io/component: frontend
+  ports: [{ port: 8000, targetPort: 8000, name: http }]

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws.yaml-template
@@ -82,12 +82,16 @@ spec:
                 set -u
                 unset HPCX_DIR HPCX_MPI_DIR HPCX_HOME HPCX_UCX_DIR HPCX_SHARP_DIR \
                       HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
-                source /opt/dynamo/venv/bin/activate
+                # Dynamo images differ in python layout: 1.2.0-era images ship /opt/dynamo/venv,
+                # 1.3.0-era images (NGC vllm-runtime:1.3.0 and derivatives) install into the system
+                # python and have NO venv. Activate only when present so one manifest serves both.
+                if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
                 LOG=/shared/disagg-prefill-p5en-$(date -u +%FT%TZ).log
                 echo "[prefill-leader p5en] starting; piping to ${DOLLAR}LOG"
                 python3 -c "import vllm; print(f'vllm {vllm.__version__}')" 2>&1 | tee -a "${DOLLAR}LOG"
                 # Verify the PR #42522 patch is present
-                grep -A2 "is_kv_consumer" /opt/dynamo/venv/lib/python3.12/site-packages/vllm/model_executor/models/config.py 2>&1 | tee -a "${DOLLAR}LOG"
+                VLLM_DIR=${DOLLAR}(python3 -c "import vllm, os; print(os.path.dirname(vllm.__file__))")
+                grep -A2 "is_kv_consumer" "${DOLLAR}VLLM_DIR/model_executor/models/config.py" 2>&1 | tee -a "${DOLLAR}LOG"
                 for i in ${DOLLAR}(seq 1 60); do
                   if getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" >/dev/null 2>&1; then break; fi
                   sleep 2
@@ -194,7 +198,10 @@ spec:
                 set -u
                 unset HPCX_DIR HPCX_MPI_DIR HPCX_HOME HPCX_UCX_DIR HPCX_SHARP_DIR \
                       HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
-                source /opt/dynamo/venv/bin/activate
+                # Dynamo images differ in python layout: 1.2.0-era images ship /opt/dynamo/venv,
+                # 1.3.0-era images (NGC vllm-runtime:1.3.0 and derivatives) install into the system
+                # python and have NO venv. Activate only when present so one manifest serves both.
+                if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
                 for i in ${DOLLAR}(seq 1 60); do
                   if getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" >/dev/null 2>&1; then break; fi
                   sleep 2
@@ -280,10 +287,14 @@ spec:
                 set -u
                 unset HPCX_DIR HPCX_MPI_DIR HPCX_HOME HPCX_UCX_DIR HPCX_SHARP_DIR \
                       HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
-                source /opt/dynamo/venv/bin/activate
+                # Dynamo images differ in python layout: 1.2.0-era images ship /opt/dynamo/venv,
+                # 1.3.0-era images (NGC vllm-runtime:1.3.0 and derivatives) install into the system
+                # python and have NO venv. Activate only when present so one manifest serves both.
+                if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
                 LOG=/shared/disagg-decode-p5en-$(date -u +%FT%TZ).log
                 python3 -c "import vllm; print(f'vllm {vllm.__version__}')" 2>&1 | tee -a "${DOLLAR}LOG"
-                grep -A2 "is_kv_consumer" /opt/dynamo/venv/lib/python3.12/site-packages/vllm/model_executor/models/config.py 2>&1 | tee -a "${DOLLAR}LOG"
+                VLLM_DIR=${DOLLAR}(python3 -c "import vllm, os; print(os.path.dirname(vllm.__file__))")
+                grep -A2 "is_kv_consumer" "${DOLLAR}VLLM_DIR/model_executor/models/config.py" 2>&1 | tee -a "${DOLLAR}LOG"
                 for i in ${DOLLAR}(seq 1 60); do
                   if getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" >/dev/null 2>&1; then break; fi
                   sleep 2
@@ -383,7 +394,10 @@ spec:
                 set -u
                 unset HPCX_DIR HPCX_MPI_DIR HPCX_HOME HPCX_UCX_DIR HPCX_SHARP_DIR \
                       HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
-                source /opt/dynamo/venv/bin/activate
+                # Dynamo images differ in python layout: 1.2.0-era images ship /opt/dynamo/venv,
+                # 1.3.0-era images (NGC vllm-runtime:1.3.0 and derivatives) install into the system
+                # python and have NO venv. Activate only when present so one manifest serves both.
+                if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
                 for i in ${DOLLAR}(seq 1 60); do
                   if getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" >/dev/null 2>&1; then break; fi
                   sleep 2
@@ -449,12 +463,13 @@ spec:
         - name: frontend
           image: ${REGISTRY}${IMAGE}${TAG}
           imagePullPolicy: Always
-          command: ["/opt/dynamo/venv/bin/python3", "-m", "dynamo.frontend"]
+          command: ["/bin/bash", "-c"]
+          # 1.3.0-era images have no /opt/dynamo/venv - exec of its python3 fails with
+          # "no such file or directory" and the pod CrashLoops. Activate only when present.
           args:
-            - --http-port
-            - "8000"
-            - --http-host
-            - "0.0.0.0"
+            - |-
+              if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+              exec python3 -m dynamo.frontend --http-port 8000 --http-host 0.0.0.0
           env:
             - { name: DYNAMO_BACKEND, value: vllm }
             - { name: DYN_NAMESPACE, value: dynamo-disagg }

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws.yaml-template
@@ -32,6 +32,7 @@ apiVersion: leaderworkerset.x-k8s.io/v1
 kind: LeaderWorkerSet
 metadata:
   name: ${DEPLOYMENT_NAME}-prefill
+  namespace: ${NAMESPACE}
   labels:
     app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}
     app.kubernetes.io/component: prefill
@@ -241,6 +242,7 @@ apiVersion: leaderworkerset.x-k8s.io/v1
 kind: LeaderWorkerSet
 metadata:
   name: ${DEPLOYMENT_NAME}-decode
+  namespace: ${NAMESPACE}
   labels:
     app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}
     app.kubernetes.io/component: decode
@@ -491,7 +493,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ${DEPLOYMENT_NAME}-frontend
-  namespace: $NAMESPACE
+  namespace: ${NAMESPACE}
   labels:
     app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}
     app.kubernetes.io/component: frontend

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws.yaml-template
@@ -10,7 +10,7 @@
 #   - kv_role: kv_both             (BOTH sides; producer/consumer split broken in 1.1.0)
 #   - kv_connector_extra_config:
 #       backends: ["LIBFABRIC"]    (NIXL on EFA, NOT UCX)
-#   - mamba-cache-mode align       (paired with vLLM PR #42522 patch in image)
+#   - ${MAMBA_FLAGS} (hybrid-Mamba only; derived from MODEL_NAME in .env - empty on pure transformers)
 #
 # -----------------------------------------------------------------------------
 # FIXED here vs the upstream aws-do-eks copy (2026-06-07):
@@ -115,9 +115,8 @@ spec:
                   --gpu-memory-utilization 0.92 \
                   --enforce-eager \
                   --trust-remote-code \
-                  --mamba-cache-mode align \
+                  ${MAMBA_FLAGS} \
                   --load-format runai_streamer \
-                  --no-disable-hybrid-kv-cache-manager \
                   --disaggregation-mode prefill \
                   --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}' 2>&1 | tee -a "${DOLLAR}LOG"
             env:
@@ -318,9 +317,8 @@ spec:
                   --gpu-memory-utilization 0.92 \
                   --enforce-eager \
                   --trust-remote-code \
-                  --mamba-cache-mode align \
+                  ${MAMBA_FLAGS} \
                   --load-format runai_streamer \
-                  --no-disable-hybrid-kv-cache-manager \
                   --disaggregation-mode decode \
                   --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}' 2>&1 | tee -a "${DOLLAR}LOG"
             env:

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/run.sh
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/run.sh
@@ -9,7 +9,7 @@ fi
 export CMD=""
 
 case "${MANIFEST_TYPE}" in
-	deployment|lws|lws-pp|dgd)
+	deployment|lws|lws-pp|dgd|ep)
 		cat ${MANIFEST_TYPE}.yaml-template | envsubst > ${MANIFEST_TYPE}.yaml
 		export CMD="kubectl apply -f ./${MANIFEST_TYPE}.yaml"
 		;;

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/run.sh
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/run.sh
@@ -8,22 +8,18 @@ fi
 
 export CMD=""
 
-if [ "${MANIFEST_TYPE}" == "deployment" ]; then
-
-	cat deployment.yaml-template | envsubst > deployment.yaml
-	export CMD="kubectl apply -f ./deployment.yaml"
-
-elif [ "${MANIFEST_TYPE}" == "lws" ]; then
-
-	cat lws.yaml-template | envsubst > lws.yaml
-	export CMD="kubectl apply -f ./lws.yaml"
-
-else
-
-	echo "Unknown MANIFEST_TYPE ${MANIFEST_TYPE}"
-
-fi
-
+case "${MANIFEST_TYPE}" in
+	deployment|lws|lws-pp|dgd)
+		cat ${MANIFEST_TYPE}.yaml-template | envsubst > ${MANIFEST_TYPE}.yaml
+		export CMD="kubectl apply -f ./${MANIFEST_TYPE}.yaml"
+		;;
+	*)
+		echo "Unknown MANIFEST_TYPE ${MANIFEST_TYPE}"
+		;;
+esac
 
 if [ ! "$VERBOSE" == "false" ]; then echo -e "\n${CMD}\n"; fi
 eval "$CMD"
+
+# Verify: list everything this deployment created (empty until pods schedule)
+kubectl -n ${NAMESPACE} get deploy,lws,dgd,svc,pods -l app.kubernetes.io/part-of=${DEPLOYMENT_NAME} 2>/dev/null

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/stop.sh
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/stop.sh
@@ -8,7 +8,7 @@ fi
 
 # 1. Delete the declared resources for the selected manifest type.
 case "${MANIFEST_TYPE}" in
-	deployment|lws|lws-pp|dgd)
+	deployment|lws|lws-pp|dgd|ep)
 		cat ${MANIFEST_TYPE}.yaml-template | envsubst > ${MANIFEST_TYPE}.yaml
 		export CMD="kubectl delete -f ./${MANIFEST_TYPE}.yaml --ignore-not-found"
 		;;

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/stop.sh
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/stop.sh
@@ -6,27 +6,31 @@ if [ "${MANIFEST_TYPE}" == "" ]; then
 	export MANIFEST_TYPE=deployment
 fi
 
-export CMD=""
-
-if [ "${MANIFEST_TYPE}" == "deployment" ]; then
-
-	cat deployment.yaml-template | envsubst > deployment.yaml
-	export CMD="kubectl delete -f ./deployment.yaml"
-
-elif [ "${MANIFEST_TYPE}" == "lws" ]; then
-
-	cat lws.yaml-template | envsubst > lws.yaml
-	export CMD="kubectl delete -f ./lws.yaml"
-
-else
-
-	echo "Unknown MANIFEST_TYPE ${MANIFEST_TYPE}"
-
-fi
+# 1. Delete the declared resources for the selected manifest type.
+case "${MANIFEST_TYPE}" in
+	deployment|lws|lws-pp|dgd)
+		cat ${MANIFEST_TYPE}.yaml-template | envsubst > ${MANIFEST_TYPE}.yaml
+		export CMD="kubectl delete -f ./${MANIFEST_TYPE}.yaml --ignore-not-found"
+		;;
+	*)
+		echo "Unknown MANIFEST_TYPE ${MANIFEST_TYPE}"
+		export CMD=""
+		;;
+esac
 
 if [ ! "$VERBOSE" == "false" ]; then echo -e "\n${CMD}\n"; fi
 eval "$CMD"
 
-export CMD="kubectl delete pods \$(kubectl get pods | grep ${DEPLOYMENT_NAME} | cut -d ' ' -f 1)"
+# 2. Sweep by label: catches resources from a previous MANIFEST_TYPE, edited yamls,
+#    or operator-generated children - kubectl delete -f alone leaves those behind.
+#    Everything this stack creates carries app.kubernetes.io/part-of=${DEPLOYMENT_NAME}.
+export CMD="kubectl -n ${NAMESPACE} delete dgd,lws,deploy,sts,svc,pods --selector app.kubernetes.io/part-of=${DEPLOYMENT_NAME} --ignore-not-found"
 if [ ! "$VERBOSE" == "false" ]; then echo -e "\n${CMD}\n"; fi
 eval "$CMD"
+
+# 3. Wait for pod termination, then verify zero residue (should print nothing).
+kubectl -n ${NAMESPACE} wait --for=delete pods --selector app.kubernetes.io/part-of=${DEPLOYMENT_NAME} --timeout=180s 2>/dev/null
+echo ""
+echo "Verifying teardown (the following should be empty):"
+kubectl -n ${NAMESPACE} get dgd,lws,deploy,sts,svc,pods --selector app.kubernetes.io/part-of=${DEPLOYMENT_NAME} 2>/dev/null
+echo "Done."


### PR DESCRIPTION
## What

Brings `Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/` in line with the validated Dynamo **1.3.0** stack (pairs with #37, which updates the platform deploy scripts):

1. **venv-not-found fix (deployment + lws + all new templates).** 1.2.0-era images ship `/opt/dynamo/venv`; 1.3.0-era images (NGC `vllm-runtime:1.3.0` and derivatives) install into the **system python and have no venv** — verified in-pod (`/opt/dynamo/venv` absent, `dynamo`+`vllm 0.23.0` import from `/usr/bin/python3`). The unconditional `source /opt/dynamo/venv/bin/activate` and the frontend's exec of `/opt/dynamo/venv/bin/python3` crash on 1.3.0 images. Fix: guard the activate (`if [ -f ... ]`), exec plain `python3`, derive diagnostic paths from the live interpreter. One manifest now serves both image generations.
2. **`.env`**: default image tag → `:1.3.0-patched` (public ECR `hpc-cloud/dynamo-vllm-efa`, built from this directory's `dynamo-vllm-efa/Dockerfile`); documents the four `MANIFEST_TYPE`s.
3. **New `lws-pp.yaml-template` — the validated PP>1 disagg option**: prefill = LWS group of size 2 (TP8/**PP2** across 2 nodes, Ray executor); decode = LWS with **2 single-node groups** (independent TP8/PP1) — 2 prefill + 2 decode nodes. Asymmetric by design: PP>1 on decode deadlocks the hybrid-Mamba 550B in the Ray static DAG; prefill-PP2 → decode-PP1 is the upstream-aligned shape and is the one validated E2E (both PP stages on separate nodes, NIXL compatible on all ranks, coherent completion). **No hostname affinity anywhere** — resource requests + instance-type nodeSelector + podAntiAffinity only, so the file is publishable and portable.
4. **New `dgd.yaml-template` — Dynamo-operator option**: one `DynamoGraphDeployment` (v1alpha1, the 1.3.0 storage version) owns frontend/prefill/decode; teardown is a single delete via ownerReferences. Requires the platform from `eks/deployment/nvidia-dynamo` (#37).
5. **`run.sh`/`stop.sh`**: support `deployment|lws|lws-pp|dgd`. `stop.sh` previously left Services (and operator-generated StatefulSets) behind; it now deletes the declared yaml, sweeps **all** resource kinds by the `app.kubernetes.io/part-of` label, waits for pod deletion, and prints an explicit should-be-empty residue check.
6. **`lws.yaml-template`**: LWS objects now carry explicit `metadata.namespace: ${NAMESPACE}` (previously only the frontend did, so the LWS landed in the kubeconfig default namespace and teardown missed it).

etcd/NATS remain pointed at the platform namespace (`dynamo-platform-{etcd,nats}.dynamo-system.svc.cluster.local`) via `${ETCD_URL}`/`${NATS_URL}` — no throwaway etcd/NATS in these manifests.

## How validated

- All four templates render with `envsubst` to **zero** unsubstituted tokens and pass `kubectl apply --dry-run=server` on an EKS cluster running the 1.3.0 platform (deployment: 4 objects; lws: 4; lws-pp: 4; dgd admits with only the documented v1alpha1 deprecation warning).
- venv layout verified live in the official NGC 1.3.0 image on-cluster.
- Hostname-pin gate: `grep -rn "compute.internal\|kubernetes.io/hostname" ultra/` returns **only** `podAntiAffinity topologyKey` lines.
- EFA surface preserved throughout: `vpc.amazonaws.com/efa` requests/limits, `/dev/infiniband` + `/dev/gdrdrv` mounts, `dshm`, `IPC_LOCK`, `fsx-pvc`, `OFI_NCCL_FORCE_NUM_RAILS`.
- Full serve validation (chat completion per option + PP=1/PP>1 disagg) running today on p5en; results will be posted here.