### PR TITLE
fix(nemotron/ultra/agg): guard /opt/dynamo/venv activation for Dynamo 1.3.x images

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/deployment.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/deployment.yaml-template
@@ -37,8 +37,12 @@ spec:
         - name: frontend
           image: ${REGISTRY}${IMAGE}${TAG}
           imagePullPolicy: Always
-          command: ["/opt/dynamo/venv/bin/python3","-m","dynamo.frontend"]
-          args: ["--http-port","8000","--http-host","0.0.0.0"]
+          command: ["/bin/bash","-c"]
+          # 1.3.x images ship plain python3 and have NO /opt/dynamo/venv - activate only when present.
+          args:
+            - |-
+              if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+              exec python3 -m dynamo.frontend --http-port 8000 --http-host 0.0.0.0
           env:
             - { name: DYNAMO_BACKEND, value: vllm }
             - { name: DYN_NAMESPACE, value: dynamo-agg }
@@ -93,7 +97,7 @@ spec:
               set -eu
               unset HPCX_DIR HPCX_MPI_DIR HPCX_HOME HPCX_UCX_DIR HPCX_SHARP_DIR \
                     HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
-              source /opt/dynamo/venv/bin/activate
+              if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
               exec python3 -m dynamo.vllm \
                 --model ${MODEL_PATH} \
                 --served-model-name ${MODEL_NAME} \

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws.yaml-template
@@ -62,7 +62,7 @@ spec:
                 # The dynamo-efa image preset HPCX_* env breaks libfabric - must clear.
                 unset HPCX_DIR HPCX_MPI_DIR HPCX_HOME HPCX_UCX_DIR HPCX_SHARP_DIR \
                       HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
-                source /opt/dynamo/venv/bin/activate
+                if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
                 # Wait for own DNS to be resolvable (LWS pods come up simultaneously)
                 for i in ${DOLLAR}(seq 1 60); do
                   if getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" >/dev/null 2>&1; then break; fi
@@ -178,7 +178,7 @@ spec:
                 set -eu
                 unset HPCX_DIR HPCX_MPI_DIR HPCX_HOME HPCX_UCX_DIR HPCX_SHARP_DIR \
                       HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
-                source /opt/dynamo/venv/bin/activate
+                if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
                 for i in ${DOLLAR}(seq 1 60); do
                   if getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" >/dev/null 2>&1; then break; fi
                   echo "[worker] waiting for DNS LWS_LEADER_ADDRESS=$LWS_LEADER_ADDRESS (${DOLLAR}i)"
@@ -254,12 +254,12 @@ spec:
         - name: frontend
           image: ${REGISTRY}${IMAGE}${TAG}
           imagePullPolicy: Always
-          command: ["/opt/dynamo/venv/bin/python3", "-m", "dynamo.frontend"]
+          command: ["/bin/bash", "-c"]
+          # 1.3.x images ship plain python3 and have NO /opt/dynamo/venv - activate only when present.
           args:
-            - --http-port
-            - "8000"
-            - --http-host
-            - "0.0.0.0"
+            - |-
+              if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+              exec python3 -m dynamo.frontend --http-port 8000 --http-host 0.0.0.0
           env:
             - { name: DYNAMO_BACKEND, value: vllm }
             - { name: DYN_NAMESPACE, value: dynamo }


### PR DESCRIPTION
## Problem

The Nemotron-3 Ultra 550B **agg** deployment crash-loops on Dynamo 1.3.x images. Both roles fail at startup:

- **frontend**: `exec /opt/dynamo/venv/bin/python3: no such file or directory`
- **worker**: `/bin/bash: line 4: /opt/dynamo/venv/bin/activate: No such file or directory`

## Root cause

The `nemotron/ultra/agg` templates hardcode the `/opt/dynamo/venv` path (activate the venv, then call `/opt/dynamo/venv/bin/python3`). The **1.3.x** `vllm-runtime` images ship a plain system `python3` and have **no** `/opt/dynamo/venv`, so both the frontend and worker containers die before serving. The sibling `nemotron/ultra/disagg/` templates already guard this; agg was missed.

## Fix

Guard the venv activation so it is used only when present, and invoke `python3` from `PATH` — the same idiom already used in `disagg/`:

```bash
command: ["/bin/bash", "-c"]
args:
  - |-
    if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
    exec python3 -m dynamo.{frontend,vllm} ...
```

Applied to all 5 hardcoded sites across `agg/deployment.yaml-template` and `agg/lws.yaml-template` (frontend + worker, single-node and LWS multi-node). Backward-compatible: on an image that *does* ship the venv, the guard still sources it.

## Testing

- Matches the working `disagg/` pattern already in this repo.
- Verified against the 1.3.x `vllm-runtime` image (plain `python3`, no `/opt/dynamo/venv`).

Signed-off-by: DCO on the commit.
