### PR TITLE
fix(nemotron/ultra/agg): raise startup probe for full 550B load + add LOAD_FORMAT knob

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/.env
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/.env
@@ -30,6 +30,14 @@ esac
 export MODEL_NAME="${MODEL_REPO}-${_PREC_SUFFIX}"
 export MODEL_PATH="/shared/models/hf/${MODEL_NAME}"
 
+# Weight loader. Default "auto" = vLLM's HF safetensors path (works everywhere, but a cold
+# ~1 TB BF16 load over Lustre is slow — mostly why the startup probe had to be raised).
+# Faster options when the image provides them (the 1.3.x vllm-runtime registers both):
+#   runai_streamer  - streams shards, overlaps download+load
+#   mx              - modelexpress MxModelLoader
+# Override per deployment, e.g. export LOAD_FORMAT=runai_streamer
+export LOAD_FORMAT="${LOAD_FORMAT:-auto}"
+
 export ETCD_URL=http://dynamo-platform-etcd.dynamo-system.svc.cluster.local:2379
 export NATS_URL=nats://dynamo-platform-nats.dynamo-system.svc.cluster.local:4222
 

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/deployment.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/deployment.yaml-template
@@ -101,6 +101,7 @@ spec:
               exec python3 -m dynamo.vllm \
                 --model ${MODEL_PATH} \
                 --served-model-name ${MODEL_NAME} \
+                --load-format ${LOAD_FORMAT} \
                 --tensor-parallel-size ${GPU_PER_WORKER} \
                 --pipeline-parallel-size 1 \
                 --max-model-len 4096 \
@@ -123,7 +124,12 @@ spec:
             httpGet: { path: /health, port: 9090 }
             periodSeconds: 30
             timeoutSeconds: 10
-            failureThreshold: 150
+            # 550B BF16 is a ~1 TB checkpoint; a cold Lustre load can take well over an hour
+            # (safetensors shards start ~40-48s each, accelerating as page cache warms), so the
+            # probe must cover the full cold load or the container is killed mid-load with no
+            # error. 240 x 30s = 120 min. NVFP4 (~41 GiB/GPU via MODEL_VARIANT=NVFP4) loads far
+            # faster; the higher ceiling is harmless once ready (probe stops on first success).
+            failureThreshold: 240
           resources:
             requests: { cpu: "48", memory: 800Gi, nvidia.com/gpu: "${GPU_PER_WORKER}" }
             limits:   { cpu: "48", memory: 800Gi, nvidia.com/gpu: "${GPU_PER_WORKER}" }


### PR DESCRIPTION
## Problem

The Nemotron-3 Ultra 550B **agg** worker fails to start on the BF16 checkpoint — but not from a crash. From the events + logs:

- Checkpoint is **~1044 GiB** over Lustre, loading **225 safetensors shards** (first shard ~47.9s, accelerating as the page cache warms).
- The container's `startupProbe` (`150 × 30s = 75 min`) is **overrun** before the load finishes, so kubelet reports `Startup probe failed: 503` and **kills the container mid-load** — no OOM, no traceback, no kernel error. It simply never became ready.

(Note: a run that *looks* like "NVFP4 failed" is actually BF16 unless `MODEL_VARIANT=NVFP4` is set — vLLM logs `quantization=None`, `dtype=torch.bfloat16`, Unquantized MoE — so this probe timeout is the real failure, independent of precision.)

## Fix

**1. Raise the startup probe to cover a full cold load** — `failureThreshold: 150 → 240` (75 → 120 min), with a comment explaining why. The higher ceiling is harmless once the engine is ready (the probe stops on first success), and NVFP4 (`MODEL_VARIANT=NVFP4`, ~41 GiB/GPU) loads far faster and won't need the headroom. This is the root-cause fix and applies regardless of precision.

**2. Add a `LOAD_FORMAT` knob** (default `auto` = current behavior, **zero regression**) wired to `--load-format`, so operators can select a faster loader that the 1.3.x `vllm-runtime` image already registers — `runai_streamer` (streams shards, overlaps download+load) or `mx` (modelexpress) — without editing the template. Set e.g. `export LOAD_FORMAT=runai_streamer` in `agg/.env`.

## Files

- `nemotron/ultra/agg/deployment.yaml-template` — probe `failureThreshold` 150→240 (+ comment); `--load-format ${LOAD_FORMAT}` on the vllm worker.
- `nemotron/ultra/agg/.env` — `export LOAD_FORMAT="${LOAD_FORMAT:-auto}"` (+ doc comment).

## Testing

- Template renders + parses as valid YAML (3 docs) after `${VAR}` substitution.
- `LOAD_FORMAT` defined in `.env` and consumed in the template; default `auto` preserves existing behavior exactly.
- Backward-compatible: no change to a deployment that doesn't set `LOAD_FORMAT`, other than the larger probe ceiling.

Signed-off-by: DCO on the commit.
