### PR TITLE
fix(nemotron/ultra/agg): image tag 1.3.1-efa + FLASHINFER_CUBIN_DIR for NVFP4 worker

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/.env
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/.env
@@ -2,7 +2,7 @@
 
 export REGISTRY=nvcr.io/nvidia/ai-dynamo/
 export IMAGE=vllm-runtime
-export TAG=":1.2.0-efa"
+export TAG=":1.3.1-efa"
 
 export DOLLAR='$'
 export NAMESPACE=default

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/deployment.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/deployment.yaml-template
@@ -118,6 +118,12 @@ spec:
             - { name: DYN_SYSTEM_PORT, value: "9090" }
             - { name: HF_HOME, value: /tmp/hf_cache }
             - { name: HF_MODULES_CACHE, value: /tmp/hf_cache/modules }
+            # NVFP4 MoE on Blackwell pulls FlashInfer TRTLLM cubins at runtime and symlinks them
+            # into its cubin dir; the default (installed flashinfer_cubin pkg) is under root-owned
+            # site-packages, so the non-root worker hits PermissionError [Errno 13] during
+            # profile_run. Point it at a writable path (same reason HF_HOME → /tmp above). BF16
+            # is unaffected (Unquantized MoE doesn't use these cubins), so this is inert for BF16.
+            - { name: FLASHINFER_CUBIN_DIR, value: /tmp/flashinfer_cubins }
             - { name: VLLM_LOGGING_LEVEL, value: INFO }
           ports: [ { containerPort: 9090, name: dyn-system } ]
           startupProbe:


### PR DESCRIPTION
Follow-up to #40 (merged) — a fresh PR as requested, since #40's probe + LOAD_FORMAT changes already landed on main.

Two changes to `nemotron/ultra/agg`:

**1. `.env`: image tag `1.2.0-efa` → `1.3.1-efa`.** The `1.2.0` image predates the 0.23/1.3.1 runtime the agg deployment is being validated on; the `1.3.1-efa` vllm-runtime carries vLLM 0.23 + EFA.

**2. `deployment.yaml-template`: add `FLASHINFER_CUBIN_DIR=/tmp/flashinfer_cubins` to the worker env.** With #40's probe raised, the 550B NVFP4 worker now loads and engages the FlashInfer NVFP4 MoE backend — then crashes in `profile_run`:

```
PermissionError: [Errno 13] Permission denied:
/usr/local/lib/python3.12/dist-packages/flashinfer_cubin/cubins/flashinfer
```

Root cause: NVFP4 MoE on Blackwell (`trtllm_fp4_block_scale_moe` → `get_trtllm_moe_sm100_module`) fetches TRTLLM cubins at runtime and symlinks them into `FLASHINFER_CUBIN_DIR` (`flashinfer/jit/cubin_loader.py:216,252`). When that env var is unset, flashinfer defaults to the installed `flashinfer_cubin` package dir under **root-owned site-packages** (`flashinfer/jit/env.py:74-104`), which the non-root worker cannot write → EACCES during the mkdir/symlink. Pointing it at a writable path (same reason `HF_HOME` → `/tmp`) fixes it.

## Notes
- **BF16 is unaffected** (Unquantized MoE doesn't use these cubins), so `FLASHINFER_CUBIN_DIR` is inert outside NVFP4 — safe to bake into the shared template.
- Verified var name + default path against flashinfer source.
- Template renders + parses as valid YAML (3 docs) after `${VAR}` substitution.

Signed-off-by: DCO on the commit.
