### PR TITLE
fix(nemotron-ultra-agg): non-root NVFP4 flashinfer cubin fix (initContainer overlay)

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/deployment.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/deployment.yaml-template
@@ -90,7 +90,14 @@ spec:
         - name: vllm
           image: ${REGISTRY}${IMAGE}${TAG}
           imagePullPolicy: Always
-          securityContext: { capabilities: { add: ["IPC_LOCK"] } }
+          # NVFP4 MoE on Blackwell makes flashinfer symlink its trtllm cubins INTO the installed
+          # flashinfer_cubin package tree (ensure_symlink -> link.parent.mkdir, jit/cubin_loader.py),
+          # which is root-owned. flashinfer's _get_cubin_dir() (jit/env.py) prefers the installed
+          # flashinfer_cubin package over the FLASHINFER_CUBIN_DIR env var, so that env var (below) is
+          # INERT whenever the package is present in the image (as it is in 1.3.1-efa) -> the non-root
+          # worker hits PermissionError [Errno 13] in profile_run. Run the worker as root so it can write
+          # its own package dir. BF16 is unaffected (Unquantized MoE doesn't fetch these cubins).
+          securityContext: { runAsUser: 0, runAsGroup: 0, capabilities: { add: ["IPC_LOCK"] } }
           command: ["/bin/bash","-c"]
           args:
             - |-
@@ -118,11 +125,13 @@ spec:
             - { name: DYN_SYSTEM_PORT, value: "9090" }
             - { name: HF_HOME, value: /tmp/hf_cache }
             - { name: HF_MODULES_CACHE, value: /tmp/hf_cache/modules }
-            # NVFP4 MoE on Blackwell pulls FlashInfer TRTLLM cubins at runtime and symlinks them
-            # into its cubin dir; the default (installed flashinfer_cubin pkg) is under root-owned
-            # site-packages, so the non-root worker hits PermissionError [Errno 13] during
-            # profile_run. Point it at a writable path (same reason HF_HOME → /tmp above). BF16
-            # is unaffected (Unquantized MoE doesn't use these cubins), so this is inert for BF16.
+            # FLASHINFER_CUBIN_DIR points flashinfer's cubin DOWNLOAD cache at a writable path. NOTE:
+            # this env var is only honored when the flashinfer_cubin package is NOT installed —
+            # _get_cubin_dir() (jit/env.py) prefers the installed package over this var. The 1.3.1-efa
+            # image ships flashinfer_cubin, so for NVFP4 the real write (a cubin symlink into the
+            # root-owned package tree) is NOT redirected by this var; the worker securityContext
+            # runAsUser:0 above is what actually prevents the profile_run PermissionError. Kept as a
+            # correct-and-harmless fallback for images without the package. Inert for BF16 either way.
             - { name: FLASHINFER_CUBIN_DIR, value: /tmp/flashinfer_cubins }
             - { name: VLLM_LOGGING_LEVEL, value: INFO }
           ports: [ { containerPort: 9090, name: dyn-system } ]

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/deployment.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/deployment.yaml-template
@@ -86,18 +86,36 @@ spec:
           emptyDir: { medium: Memory, sizeLimit: 64Gi }
         - name: shared
           persistentVolumeClaim: { claimName: fsx-pvc }
+        # Writable overlay for flashinfer's cubin package dir (NVFP4 fix — see initContainer).
+        - name: flashinfer-cubins
+          emptyDir: {}
+      # initContainer seeds the writable overlay with the image's baked cubins so the (non-root)
+      # worker can create the NVFP4 trtllm-cubin symlink that flashinfer writes into the package
+      # tree. Runs as root ONLY here (setup), NOT the serving worker; keeps the worker as `dynamo`.
+      initContainers:
+        - name: seed-flashinfer-cubins
+          image: ${REGISTRY}${IMAGE}${TAG}
+          imagePullPolicy: Always
+          securityContext: { runAsUser: 0 }
+          command: ["/bin/bash","-c"]
+          args:
+            - |-
+              set -eu
+              PKG_CUBINS="$(python3 -c 'import os,flashinfer_cubin; print(os.path.join(os.path.dirname(flashinfer_cubin.__file__), "cubins"))')"
+              echo "seeding from ${PKG_CUBINS} -> /seed"
+              if [ -d "${PKG_CUBINS}" ]; then cp -a "${PKG_CUBINS}/." /seed/ 2>/dev/null || true; fi
+              chmod -R a+rwX /seed
+              echo "seed done: $(find /seed -mindepth 1 | wc -l) entries"
+          volumeMounts:
+            - { name: flashinfer-cubins, mountPath: /seed }
       containers:
         - name: vllm
           image: ${REGISTRY}${IMAGE}${TAG}
           imagePullPolicy: Always
-          # NVFP4 MoE on Blackwell makes flashinfer symlink its trtllm cubins INTO the installed
-          # flashinfer_cubin package tree (ensure_symlink -> link.parent.mkdir, jit/cubin_loader.py),
-          # which is root-owned. flashinfer's _get_cubin_dir() (jit/env.py) prefers the installed
-          # flashinfer_cubin package over the FLASHINFER_CUBIN_DIR env var, so that env var (below) is
-          # INERT whenever the package is present in the image (as it is in 1.3.1-efa) -> the non-root
-          # worker hits PermissionError [Errno 13] in profile_run. Run the worker as root so it can write
-          # its own package dir. BF16 is unaffected (Unquantized MoE doesn't fetch these cubins).
-          securityContext: { runAsUser: 0, runAsGroup: 0, capabilities: { add: ["IPC_LOCK"] } }
+          # Keep the image's default (non-root `dynamo`) user. The NVFP4 cubin-write problem is fixed
+          # by the seed-flashinfer-cubins initContainer below (writable overlay over the package's
+          # cubins dir), NOT by running as root. See that initContainer for the full explanation.
+          securityContext: { capabilities: { add: ["IPC_LOCK"] } }
           command: ["/bin/bash","-c"]
           args:
             - |-
@@ -151,3 +169,6 @@ spec:
           volumeMounts:
             - { name: dshm, mountPath: /dev/shm }
             - { name: shared, mountPath: /shared }
+            # Writable overlay over flashinfer_cubin's package cubins dir so the non-root worker can
+            # create the NVFP4 trtllm-cubin symlink (fixes the profile_run PermissionError[13]).
+            - { name: flashinfer-cubins, mountPath: /usr/local/lib/python3.12/dist-packages/flashinfer_cubin/cubins }


### PR DESCRIPTION
## Problem

Following #41, the Nemotron-3 Ultra **NVFP4** agg worker still crashes in `profile_run` on `1.3.1-efa`, even with `FLASHINFER_CUBIN_DIR=/tmp/flashinfer_cubins` set:

```
File ".../flashinfer/jit/cubin_loader.py", line 252, in ensure_symlink
    link.parent.mkdir(parents=True, exist_ok=True)
PermissionError: [Errno 13] Permission denied:
    '/usr/local/lib/python3.12/dist-packages/flashinfer_cubin/cubins/flashinfer'
```

## Root cause (verified vs flashinfer v0.6.12 source)

`FLASHINFER_CUBIN_DIR` is **inert** on this image. flashinfer's `_get_cubin_dir()` (`jit/env.py:59-97`) resolves the cubin dir by priority:

1. the installed `flashinfer_cubin` package (if present) ← **the `1.3.1-efa` image ships it, so this wins** (`flashinfer_cubin.get_cubin_dir()` hardcodes its own package dir, no env override)
2. `FLASHINFER_CUBIN_DIR` env var ← never reached
3. default cache

For NVFP4 MoE, flashinfer symlinks its trtllm cubins **into its own package tree** (`ensure_symlink` → `link.parent.mkdir`, `jit/cubin_loader.py:252`) — a root-owned path — and the non-root `dynamo` worker cannot create it → `PermissionError [Errno 13]`. BF16 is unaffected (Unquantized MoE never fetches these cubins).

## Fix (non-root)

Keep the image's default `dynamo` user. Add an **initContainer** (root, setup-only) that seeds a writable `emptyDir` with the image's baked `flashinfer_cubin/cubins`, mounted over the package cubins dir. The serving worker stays non-root and can now create the cubin symlink.

Deploy-only, no image rebuild. (Earlier revision used `runAsUser:0`; changed to this non-root approach per review — the serving container keeps its default user; only the throwaway initContainer runs as root.)

## Note

This is a workaround for a **Dynamo/NVIDIA image packaging issue** — `flashinfer_cubin` is shipped root-owned and flashinfer prefers the package dir over `FLASHINFER_CUBIN_DIR`. An upstream report to NVIDIA/ai-dynamo will follow so the base image can fix it at the source (e.g. ship the cubin dir group-writable, or make it honor the env var).

## Verification

- Template renders (3 docs parse); worker `securityContext` = non-root (`{capabilities:{add:[IPC_LOCK]}}`); initContainer `seed-flashinfer-cubins` runs as root and seeds `/seed`; worker overlay-mounts `flashinfer-cubins` at `/usr/local/lib/python3.12/dist-packages/flashinfer_cubin/cubins`.
- Root cause traced to exact flashinfer v0.6.12 lines (`jit/env.py:59-97`, `flashinfer-cubin/flashinfer_cubin/__init__.py:21-26`, `jit/cubin_loader.py:240-252`, `jit/fused_moe.py:279`) against the crash log from a live `ml.p6-b200.48xlarge` worker.