### PR TITLE
fix(nemotron-agg): point agg at the golden image so NVFP4 works (not stock 1.3.1-efa)

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/.env
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/.env
@@ -1,8 +1,15 @@
 #!/bin/bash
 
-export REGISTRY=nvcr.io/nvidia/ai-dynamo/
-export IMAGE=vllm-runtime
-export TAG=":1.3.1-efa"
+# Use the golden image (built from ../disagg/dynamo-vllm-efa/Dockerfile — "covers every
+# scenario: aggregated, EP16, PP>1"), NOT the stock nvcr.io vllm-runtime. The stock 1.3.1-efa
+# ships flashinfer_cubin root-owned, so NVFP4 profile_run crashes on the non-root worker with
+# PermissionError[13] (FLASHINFER_CUBIN_DIR is inert — flashinfer prefers the installed package
+# over the env var). The golden image carries the build-time cubin chmod fix, so NVFP4 agg works
+# out of the box with no initContainer / runAsUser. BF16 works on either image. Override per
+# deployment if you host the golden image elsewhere.
+export REGISTRY=${REGISTRY:-public.ecr.aws/hpc-cloud/}
+export IMAGE=${IMAGE:-dynamo-vllm-efa}
+export TAG=${TAG:-":1.3.1-patched"}
 
 export DOLLAR='$'
 export NAMESPACE=default

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/deployment.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/deployment.yaml-template
@@ -118,11 +118,13 @@ spec:
             - { name: DYN_SYSTEM_PORT, value: "9090" }
             - { name: HF_HOME, value: /tmp/hf_cache }
             - { name: HF_MODULES_CACHE, value: /tmp/hf_cache/modules }
-            # NVFP4 MoE on Blackwell pulls FlashInfer TRTLLM cubins at runtime and symlinks them
-            # into its cubin dir; the default (installed flashinfer_cubin pkg) is under root-owned
-            # site-packages, so the non-root worker hits PermissionError [Errno 13] during
-            # profile_run. Point it at a writable path (same reason HF_HOME → /tmp above). BF16
-            # is unaffected (Unquantized MoE doesn't use these cubins), so this is inert for BF16.
+            # FLASHINFER_CUBIN_DIR only points flashinfer's cubin DOWNLOAD cache at a writable path.
+            # NOTE: it does NOT fix the NVFP4 profile_run crash on the stock image — flashinfer's
+            # _get_cubin_dir() (jit/env.py) prefers the installed flashinfer_cubin PACKAGE over this
+            # var, and NVFP4 symlinks cubins into that root-owned package dir → non-root worker
+            # PermissionError[13]. That is fixed in the GOLDEN image (see ../.env / the disagg
+            # Dockerfile's build-time chmod), which this .env now points at. Kept here as a harmless
+            # cache hint. BF16 never touches these cubins.
             - { name: FLASHINFER_CUBIN_DIR, value: /tmp/flashinfer_cubins }
             - { name: VLLM_LOGGING_LEVEL, value: INFO }
           ports: [ { containerPort: 9090, name: dyn-system } ]


### PR DESCRIPTION
## Gap

The NVFP4 cubin fix merged in #43 lives in the **golden** `dynamo-vllm-efa` Dockerfile, which the **disagg** path builds and uses. But the **agg** path — which is where the original crash happened (`nemotron3-ultra-550b-agg-worker`) — still points `agg/.env` at the **stock** `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.1-efa`. So NVFP4 agg still crashes:

```
PermissionError: [Errno 13] ... /flashinfer_cubin/cubins/flashinfer   (profile_run)
```

`FLASHINFER_CUBIN_DIR` (set in the agg template) does **not** fix it — flashinfer's `_get_cubin_dir()` (`jit/env.py`) prefers the installed `flashinfer_cubin` package over the env var, and NVFP4 symlinks cubins into that root-owned package dir.

## Fix

The golden image already states it *"covers every scenario: aggregated, EP16, PP>1"* and now carries the build-time cubin chmod (from #43). Point `agg/.env` at it — `public.ecr.aws/hpc-cloud/dynamo-vllm-efa:1.3.1-patched` (overridable), exactly how `disagg/.env` already works — so NVFP4 agg works out of the box with the worker still non-root, no initContainer, no `runAsUser`. Also corrects the now-misleading `FLASHINFER_CUBIN_DIR` comment. BF16 works on either image.

Aligns with the maintainer's stated preference ("we don't need to use the nvidia stock image until they fix it").

## Verification

- `agg/.env` sources cleanly and resolves to `public.ecr.aws/hpc-cloud/dynamo-vllm-efa:1.3.1-patched`; MODEL_VARIANT BF16/NVFP4 toggle intact.
- `deployment.yaml-template` still parses (3 docs); agg worker unchanged otherwise (non-root, no initContainer — the fix is in the image).
- Same fix verified end-to-end on B200 for the golden image (NVFP4 profile_run passes); see #43.

Related: #43 (build-time cubin fix in the golden Dockerfile, merged); #42 (initContainer variant, closed as superseded).