### PR TITLE
fix(nemotron-disagg): cubin fix left a root-owned subtree — NVFP4 still crashed

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dynamo-vllm-efa/Dockerfile
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dynamo-vllm-efa/Dockerfile
@@ -146,22 +146,23 @@ PY
 #    PermissionError [Errno 13] in profile_run at the FIRST NVFP4 MoE call. Make the dir
 #    writable at build time so no runtime initContainer / runAsUser:0 is needed; the
 #    worker stays non-root. BF16 is unaffected (Unquantized MoE never fetches these
-#    cubins). Verified 2026-08-07: with only this line, the non-root user (uid 1000)
-#    can mkdir+symlink the exact crash path .../flashinfer_cubin/cubins/flashinfer/trtllm.
+#    cubins).
+#
+#    IMPORTANT (fixes a regression in the first cut of this step): do NOT pre-create
+#    the cubins/flashinfer/trtllm/batched_gemm subtree here. A build-time probe that
+#    did `os.makedirs(...batched_gemm)` left those subdirs ROOT-OWNED 0755, and a
+#    subsequent `chmod cubins 0777` only re-permed the TOP dir — so at runtime the
+#    non-root worker still hit PermissionError[13] symlinking INTO the root-owned
+#    batched_gemm. The correct fix is chmod -R the cubins dir and leave it EMPTY: the
+#    worker then creates the whole flashinfer/trtllm/... subtree itself (worker-owned).
+#    Verified as uid 1000: symlink into batched_gemm SUCCEEDS with this recipe, FAILS
+#    if the subtree is pre-created. Keep this a single chmod -R with no makedirs probe.
 RUN set -eux; \
     CUBINS="$(python3 -c 'import os,flashinfer_cubin; print(os.path.join(os.path.dirname(flashinfer_cubin.__file__),"cubins"))')"; \
     mkdir -p "${CUBINS}"; \
     chmod -R a+rwX "${CUBINS}"; \
-    python3 - "${CUBINS}" <<'PY'
-import os, sys, tempfile
-cubins = sys.argv[1]
-# assert the runtime user (uid 1000) can create the symlink parent that crashed
-probe = os.path.join(cubins, "flashinfer", "trtllm", "batched_gemm")
-os.makedirs(probe, exist_ok=True)
-t = os.path.join(probe, ".writeprobe"); open(t, "w").write("ok"); os.remove(t)
-os.chmod(cubins, 0o777)
-print(f"[nvfp4-cubin-fix] {cubins} writable (probe mkdir+write OK)")
-PY
+    test -w "${CUBINS}"; \
+    echo "[nvfp4-cubin-fix] ${CUBINS} made writable (chmod -R a+rwX; subtree left empty for the worker to own)"
 
 USER dynamo
 LABEL org.opencontainers.image.description="Golden image: Dynamo 1.3.1 (-efa base, EFA 1.49 baked) + vLLM 0.23 + ray 2.55.1 + vLLM PR#48263 overlay (agg + EP16 + PP>1, Dockerfile-only reproducible)"


### PR DESCRIPTION
## Symptom (reported by @iankouls-aws)

After merging #43 and rebuilding the golden image (`public.ecr.aws/hpc-cloud/dynamo-vllm-efa:1.3.1-patched`, `imagePullPolicy: Always`), NVFP4 **still** hit `PermissionError [Errno 13]` in `profile_run` — unlike the proof image, which worked.

## Root cause (a regression in #43's build step, reproduced empirically)

#43's step was:
```
chmod -R a+rwX "${CUBINS}"                 # ok: cubins dir writable
python3: os.makedirs(cubins/flashinfer/trtllm/batched_gemm)   # <-- creates subdirs ROOT-OWNED 0755
         os.chmod(cubins, 0o777)             # <-- re-perms only the TOP dir
```
So the pre-created `batched_gemm` subtree stayed **root-owned**. At runtime flashinfer's `ensure_symlink` does `link.symlink_to(...)` **into** that dir — as the non-root `dynamo` worker → EACCES, the exact crash #43 was meant to fix. The proof image passed only because it never pre-created the subtree, so the worker created (and owned) it.

**A/B on images built FROM `1.3.1-efa`, run as uid 1000:**
| recipe | symlink into batched_gemm |
|---|---|
| #43 (chmod -R **+ makedirs probe**) | ❌ PermissionError[13] |
| chmod -R, **empty dir** (this PR) | ✅ SYMLINK OK |

## Fix

Drop the `makedirs` probe. `chmod -R a+rwX` the cubins dir and leave it **empty** — the worker creates the whole `flashinfer/trtllm/...` subtree itself (worker-owned). Single `chmod -R`, no subtree pre-creation,  sanity only.

## Verification

- Built both recipes FROM `1.3.1-efa`; as uid 1000 the empty-dir recipe symlinks into `batched_gemm` successfully, the #43 recipe fails (shown above).
- Dockerfile heredoc balance intact; no other step touched.

Fixes the regression from #43; unblocks the maintainer's rebuilt-image NVFP4 run.