### PR TITLE
feat(nemotron-agg): add aggregated DynamoGraphDeployment (DGD) CRD

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/dgd.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/dgd.yaml-template
@@ -1,0 +1,126 @@
+# =============================================================================
+# Nemotron-3 Ultra 550B AGGREGATED — DynamoGraphDeployment (Dynamo operator)
+# =============================================================================
+#
+# Author: Anton Alexander
+#
+# Requires the Dynamo platform 1.3.0 (operator + etcd + NATS) from
+# eks/deployment/nvidia-dynamo. The operator turns this single resource into
+# the frontend + worker deployments and owns their lifecycle, so
+# `kubectl delete -f dgd.yaml` (or ./stop.sh) removes everything it created.
+#
+# Aggregated (prefill+decode co-located) single-node worker: TP=${GPU_PER_WORKER}/PP=1,
+# intra-node NVLink. NO P/D disaggregation, so NO NIXL / KV-transfer / EFA needed
+# for the model itself (contrast ../disagg/dgd.yaml-template). This is the DGD
+# equivalent of ../agg/deployment.yaml-template — same serving shape, but managed
+# by the operator as one CRD.
+#
+# API version: nvidia.com/v1alpha1 — on the 1.3.0 operator this is the storage
+# version and admits cleanly (with a deprecation warning). v1beta1 is a DIFFERENT
+# schema (spec.components array), not a rename of this one.
+#
+# Uses the golden image via ../.env (covers agg/EP16/PP>1 + the NVFP4 cubin fix);
+# MODEL_VARIANT=NVFP4 switches the checkpoint. Worker stays non-root (dynamo).
+# =============================================================================
+---
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: ${DEPLOYMENT_NAME}
+  namespace: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}
+spec:
+  backendFramework: vllm
+  pvcs:
+    - name: fsx-pvc
+      create: false
+  envs:
+    - { name: DYNAMO_BACKEND, value: vllm }
+    - { name: ETCD_ENDPOINTS, value: "${ETCD_URL}" }
+    - { name: NATS_SERVER,    value: "${NATS_URL}" }
+    # /tmp, NOT /shared: pods run uid 1000 and /shared is root-owned — the frontend
+    # dies registering the model ("Failed to create cache directory /shared/hf_cache/hub:
+    # Permission denied") and /v1/models stays empty -> every request 404s.
+    - { name: HF_HOME,        value: /tmp/hf_cache }
+  services:
+    # ---- Frontend (router, CPU-only) --------------------------------------
+    Frontend:
+      componentType: frontend
+      replicas: 1
+      resources:
+        requests: { cpu: "2", memory: 4Gi }
+        limits:   { cpu: "4", memory: 8Gi }
+      # The frontend reads the model dir (config/tokenizer, not weights) to build the
+      # preprocessor when the worker registers a local path — without this mount the
+      # model never appears in /v1/models.
+      volumeMounts:
+        - { name: fsx-pvc, mountPoint: /shared }
+      extraPodSpec:
+        nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_FRONTEND} }
+        mainContainer:
+          image: ${REGISTRY}${IMAGE}${TAG}
+          imagePullPolicy: Always
+          command: ["/bin/bash", "-c"]
+          # 1.3.x images have no /opt/dynamo/venv — activate only when present.
+          args:
+            - |-
+              if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+              exec python3 -m dynamo.frontend --http-port 8000 --http-host 0.0.0.0
+          ports: [{ containerPort: 8000, name: http }]
+          # NOTE: no readinessProbe here — the operator injects its own frontend probe;
+          # adding ours makes the API server reject the generated pod
+          # ("may not specify more than 1 handler type").
+    # ---- Aggregated worker (prefill+decode, TP${GPU_PER_WORKER}/PP1, 1 node) ----
+    VllmWorker:
+      componentType: worker
+      replicas: 1
+      resources:
+        requests: { cpu: "48", memory: 800Gi, gpu: "${GPU_PER_WORKER}" }
+        limits:   { cpu: "48", memory: 800Gi, gpu: "${GPU_PER_WORKER}" }
+      volumeMounts:
+        - { name: fsx-pvc, mountPoint: /shared }
+      extraPodSpec:
+        nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_WORKER} }
+        tolerations:
+          - { key: nvidia.com/gpu, operator: Exists, effect: NoSchedule }
+        volumes:
+          - { name: dshm, emptyDir: { medium: Memory, sizeLimit: 64Gi } }
+        mainContainer:
+          image: ${REGISTRY}${IMAGE}${TAG}
+          imagePullPolicy: Always
+          securityContext: { capabilities: { add: ["IPC_LOCK"] } }
+          command: ["/bin/bash", "-c"]
+          args:
+            - |-
+              set -u
+              unset HPCX_DIR HPCX_MPI_DIR HPCX_HOME HPCX_UCX_DIR HPCX_SHARP_DIR \
+                    HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
+              if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+              exec python3 -m dynamo.vllm \
+                --model ${MODEL_PATH} \
+                --served-model-name ${MODEL_NAME} \
+                --load-format ${LOAD_FORMAT} \
+                --tensor-parallel-size ${GPU_PER_WORKER} --pipeline-parallel-size 1 \
+                --max-model-len 4096 --gpu-memory-utilization 0.97 --enforce-eager \
+                --trust-remote-code \
+                --mamba-cache-mode align
+          env:
+            - { name: DYN_SYSTEM_ENABLED, value: "true" }
+            - { name: DYN_SYSTEM_PORT, value: "9090" }
+            - { name: HF_MODULES_CACHE, value: /tmp/hf_cache/modules }
+            - { name: VLLM_LOGGING_LEVEL, value: INFO }
+            # NVFP4 cubin dir is handled in the golden image (build-time chmod); no env needed.
+          # Port MUST be named "system": the operator injects readiness/liveness probes
+          # that target the named port; any other name fails with
+          # 'strconv.Atoi: parsing "system"' and the worker never goes Ready.
+          ports: [{ containerPort: 9090, name: system }]
+          startupProbe:
+            httpGet: { path: /health, port: 9090 }
+            periodSeconds: 30
+            timeoutSeconds: 10
+            # 550B BF16 is a ~1 TB checkpoint; a cold Lustre load can exceed an hour.
+            # 240 x 30s = 120 min. NVFP4 loads far faster; the ceiling is harmless once ready.
+            failureThreshold: 240
+          volumeMounts:
+            - { name: dshm, mountPath: /dev/shm }

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/run.sh
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/run.sh
@@ -24,6 +24,12 @@ elif [ "${MANIFEST_TYPE}" == "ep16" ]; then
 	cat lws-ep16.yaml-template | envsubst > lws-ep16.yaml
 	export CMD="kubectl apply -f ./lws-ep16.yaml"
 
+elif [ "${MANIFEST_TYPE}" == "dgd" ]; then
+
+	# Aggregated as a DynamoGraphDeployment (Dynamo operator manages frontend + worker).
+	cat dgd.yaml-template | envsubst > dgd.yaml
+	export CMD="kubectl apply -f ./dgd.yaml"
+
 else
 
 	echo "Unknown MANIFEST_TYPE ${MANIFEST_TYPE}"

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/stop.sh
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/stop.sh
@@ -23,6 +23,11 @@ elif [ "${MANIFEST_TYPE}" == "ep16" ]; then
 	cat lws-ep16.yaml-template | envsubst > lws-ep16.yaml
 	export CMD="kubectl delete -f ./lws-ep16.yaml"
 
+elif [ "${MANIFEST_TYPE}" == "dgd" ]; then
+
+	cat dgd.yaml-template | envsubst > dgd.yaml
+	export CMD="kubectl delete -f ./dgd.yaml"
+
 else
 
 	echo "Unknown MANIFEST_TYPE ${MANIFEST_TYPE}"


### PR DESCRIPTION
## What

Adds the missing **aggregated DGD** (@iankouls-aws asked — we only had `disagg/dgd.yaml-template`). `agg/dgd.yaml-template` is the Dynamo-operator-managed (`DynamoGraphDeployment`, `nvidia.com/v1alpha1`) equivalent of `agg/deployment.yaml-template`: **Frontend + one VllmWorker**, `componentType: worker` (no prefill/decode split, no NIXL / disaggregation-mode / KV-transfer), TP=${GPU_PER_WORKER}/PP1, single node. Wires `MANIFEST_TYPE=dgd` into run.sh/stop.sh.

## Carries the operator gotchas from disagg/dgd.yaml-template

- `apiVersion: nvidia.com/v1alpha1` (storage version on the 1.3.0 operator; v1beta1 is a different schema).
- Worker port named **`system`** — the operator injects readiness/liveness probes by that name; any other name fails `strconv.Atoi: parsing "system"`.
- **No** frontend readinessProbe — the operator injects its own; adding one makes the API server reject the pod ("may not specify more than 1 handler type").
- `HF_HOME=/tmp/hf_cache` — pods run uid 1000; /shared is root-owned, so a /shared cache dir 404s /v1/models.

## Run

```
cd .../nemotron/ultra/agg
# .env: MODEL_VARIANT=BF16 (or NVFP4)
MANIFEST_TYPE=dgd ./run.sh    # requires the Dynamo platform (operator+etcd+NATS)
```

## Verification

- Rendered via `envsubst` → exactly 1 valid `DynamoGraphDeployment` (v1alpha1); services = {Frontend, VllmWorker}; worker `componentType: worker` with no `subComponentType`; TP8/PP1; port `system`; no disagg/NIXL; no frontend readinessProbe; no unresolved `${...}`.
- run.sh/stop.sh `bash -n` clean.

## Note on NVFP4

The worker uses `${REGISTRY}${IMAGE}${TAG}` from `agg/.env`. **BF16 works on any image.** For **NVFP4**, this needs the golden image (the cubin fix) — i.e. #44 (agg/.env → golden) merged first; on the current stock `1.3.1-efa` .env, NVFP4 would hit the flashinfer-cubin PermissionError. BF16 DGD is unaffected.