### PR TITLE
fix(nemotron-agg): worker cpu request 96 -> 48 so it fits node allocatable

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws-ep16.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws-ep16.yaml-template
@@ -117,8 +117,8 @@ spec:
               # NVFP4 loads far faster; the ceiling is harmless once ready.
               failureThreshold: 240
             resources:
-              requests: { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
-              limits:   { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+              requests: { cpu: "48", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+              limits:   { cpu: "48", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
             volumeMounts:
               - { name: dshm,       mountPath: /dev/shm }
               - { name: infiniband, mountPath: /dev/infiniband }
@@ -199,8 +199,8 @@ spec:
               - { name: NCCL_DEBUG, value: INFO }
               - { name: NCCL_DEBUG_SUBSYS, value: "INIT,NET" }
             resources:
-              requests: { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
-              limits:   { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+              requests: { cpu: "48", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+              limits:   { cpu: "48", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
             volumeMounts:
               - { name: dshm,       mountPath: /dev/shm }
               - { name: infiniband, mountPath: /dev/infiniband }

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws.yaml-template
@@ -124,12 +124,12 @@ spec:
               failureThreshold: 10
             resources:
               requests:
-                cpu: "96"
+                cpu: "48"
                 memory: 1000Gi
                 nvidia.com/gpu: "${GPU_PER_WORKER}"
                 vpc.amazonaws.com/efa: "${EFA_PER_WORKER}"
               limits:
-                cpu: "96"
+                cpu: "48"
                 memory: 1000Gi
                 nvidia.com/gpu: "${GPU_PER_WORKER}"
                 vpc.amazonaws.com/efa: "${EFA_PER_WORKER}"
@@ -210,12 +210,12 @@ spec:
               - { name: NCCL_NET_PLUGIN, value: ofi }
             resources:
               requests:
-                cpu: "96"
+                cpu: "48"
                 memory: 1000Gi
                 nvidia.com/gpu: "${GPU_PER_WORKER}"
                 vpc.amazonaws.com/efa: "${EFA_PER_WORKER}"
               limits:
-                cpu: "96"
+                cpu: "48"
                 memory: 1000Gi
                 nvidia.com/gpu: "${GPU_PER_WORKER}"
                 vpc.amazonaws.com/efa: "${EFA_PER_WORKER}"


### PR DESCRIPTION
## Problem (reported by @iankouls-aws on a live b200)

The worker node's allocatable CPU is **95690m** (~95.69 cores) — not a clean 96, because kubelet/system-reserved take a slice. So a worker manifest requesting `cpu: "96"` (96000m) exceeds allocatable and can **never schedule** — the pod sits `Pending` (`Insufficient cpu`) forever.

The proven `agg/deployment.yaml-template` already requests **48** and schedules fine. But the two agg **2-node** manifests still asked for 96:
- `agg/lws.yaml-template` (TP16/PP2 Ray)
- `agg/lws-ep16.yaml-template` (DP2/TP8/EP16)

## Fix

Lower those two to `cpu: "48"` (requests + limits), matching the working single-node template. The GPU worker is GPU-bound, so 48 cores is ample headroom; **memory / GPU / EFA are untouched**. CPU-only diff.

## Verification

- Diff is CPU-only (8 lines each: 96→48); confirmed no other field changed.
- Both templates still render via `envsubst` to valid YAML; worker cpu now `48` (lws.yaml keeps the frontend's 2/4), no unresolved `${...}`.

Fixes the `Pending`/`Insufficient cpu` on nodes whose allocatable is just under 96 cores.