### PR TITLE
fix(nemotron-agg-lws): resolve Ray worker IP via route-to-leader (not hostname -i)

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws.yaml-template
@@ -184,9 +184,16 @@ spec:
                   echo "[worker] waiting for DNS LWS_LEADER_ADDRESS=$LWS_LEADER_ADDRESS (${DOLLAR}i)"
                   sleep 2
                 done
-                LEADER_IP=$(getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" | awk '{print ${DOLLAR}1}')
-                MY_IP=${DOLLAR}(hostname -i | awk '{print ${DOLLAR}1}')
-                echo "[worker] LEADER_IP=${DOLLAR}LEADER_IP MY_IP=$MY_IP"
+                LEADER_IP=${DOLLAR}(getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" | awk '{print ${DOLLAR}1}')
+                # Resolve MY_IP on the SAME interface that routes to the leader. Under
+                # hostNetwork:true, `hostname -i` can return empty or a secondary/EFA IP
+                # (e.g. 172.16.x) that the GCS on the primary VPC CIDR (10.x) can't route
+                # back to -> the raylet registers on an unreachable IP and Ray start times
+                # out ("Failed to get node info: RPC error: Deadline Exceeded"). Deriving
+                # the source IP from `ip route get <leader>` guarantees the primary-CIDR IP.
+                MY_IP=${DOLLAR}(ip -4 route get "${DOLLAR}LEADER_IP" 2>/dev/null | awk '{for(i=1;i<=NF;i++) if(${DOLLAR}i=="src"){print ${DOLLAR}(i+1); exit}}')
+                [ -z "${DOLLAR}MY_IP" ] && MY_IP=${DOLLAR}(hostname -i | awk '{print ${DOLLAR}1}')
+                echo "[worker] LEADER_IP=${DOLLAR}LEADER_IP MY_IP=${DOLLAR}MY_IP"
                 # Wait for Ray head to be reachable
                 for i in ${DOLLAR}(seq 1 60); do
                   if (echo > /dev/tcp/${DOLLAR}LEADER_IP/6379) 2>/dev/null; then break; fi


### PR DESCRIPTION
## Problem (reported by @iankouls-aws — combined agg-pods log)

The agg-LWS run (TP16/PP2, Ray) worker never joins the head. The log shows:
```
[worker] LEADER_IP=10.1.227.0 MY_IP=            <- MY_IP is EMPTY
worker  scripts.py:1128 -- Local node IP: 172.16.89.194
worker  node.py:421 -- Failed to get node info b'RPC error: Deadline Exceeded'
worker  Exception: The current node timed out during startup ... raylet failed to startup
leader  [leader] ray nodes seen: 1 (target 2)   <- stuck at 1 forever
```

## Root cause

The worker resolves its own IP with `MY_IP=$(hostname -i | awk '{print $1}')`. Under **`hostNetwork: true`**, `hostname -i` returned **empty**, so `ray start --node-ip-address=""` fell back to auto-detection and bound the raylet to a **secondary interface (172.16.89.194)** — while the GCS/head is on the **primary VPC CIDR (10.1.x)**. The head can't route back to the 172.16 raylet, so registration RPC times out and the node count never reaches 2.

The leader is unaffected because it resolves its IP from `LWS_LEADER_ADDRESS` DNS (correct 10.1.x), not `hostname -i`.

## Fix

Resolve `MY_IP` from **`ip route get $LEADER_IP`** — the source IP on the exact interface that routes to the leader, which is guaranteed to be the primary-CIDR IP the GCS can reach. Falls back to `hostname -i` if unavailable. Also fixes a mangled echo (`MY_IP=$MY_IP` → `${DOLLAR}MY_IP`) that envsubst was blanking.

## Verification

- Template renders via `envsubst`; worker shell `bash -n` clean; YAML parses (3 docs).
- The `ip route get` idiom functionally verified to yield the host's real primary src IP.

Unblocks the agg-LWS (TP16/PP2) multi-node Ray join. (Same worker-IP idiom would also harden any other hostNetwork Ray-join manifest.)