### PR TITLE
fix(nemotron-agg-lws): set GLOO/NCCL_SOCKET_IFNAME (cross-node PP2 was falling back to loopback)

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws.yaml-template
@@ -110,6 +110,14 @@ spec:
               - { name: NIXL_LIBFABRIC_MAX_RAILS, value: "1" }
               - { name: NIXL_SKIP_TOPOLOGY_CHECK, value: "1" }
               - { name: NCCL_NET_PLUGIN, value: ofi }
+              # hostNetwork:true has many NICs (lo, docker, veth, EFA 172.16.x, primary 10.x).
+              # Without these, vLLM's CPU coordination group (Gloo) can't resolve the pod
+              # hostname to a routable addr and falls back to 127.0.0.1 -> cross-node ranks
+              # try to reach each other at loopback -> "Gloo connectFullMesh ... Connection
+              # refused, remote=[127.0.0.1]". Pin both Gloo and NCCL to the primary VPC NIC
+              # (exclude lo/docker/veth/eni) so they advertise the routable 10.x IP.
+              - { name: GLOO_SOCKET_IFNAME, value: "^lo,docker,veth,eni" }
+              - { name: NCCL_SOCKET_IFNAME, value: "^lo,docker,veth,eni" }
             ports:
               - { containerPort: 9090, name: dyn-system }
             startupProbe:
@@ -215,6 +223,14 @@ spec:
               - { name: NIXL_LIBFABRIC_MAX_RAILS, value: "1" }
               - { name: NIXL_SKIP_TOPOLOGY_CHECK, value: "1" }
               - { name: NCCL_NET_PLUGIN, value: ofi }
+              # hostNetwork:true has many NICs (lo, docker, veth, EFA 172.16.x, primary 10.x).
+              # Without these, vLLM's CPU coordination group (Gloo) can't resolve the pod
+              # hostname to a routable addr and falls back to 127.0.0.1 -> cross-node ranks
+              # try to reach each other at loopback -> "Gloo connectFullMesh ... Connection
+              # refused, remote=[127.0.0.1]". Pin both Gloo and NCCL to the primary VPC NIC
+              # (exclude lo/docker/veth/eni) so they advertise the routable 10.x IP.
+              - { name: GLOO_SOCKET_IFNAME, value: "^lo,docker,veth,eni" }
+              - { name: NCCL_SOCKET_IFNAME, value: "^lo,docker,veth,eni" }
             resources:
               requests:
                 cpu: "48"


### PR DESCRIPTION
## Problem (reported by @iankouls-aws — follows #49)

After #49 fixed the Ray raylet IP (both nodes now join — `ray nodes seen: 2 (target 2)`), vLLM engine init fails at the CPU coordination (Gloo) group:
```
[rank8] Warning: Unable to resolve hostname to a (local) address. Using the loopback
        address as fallback. Manually set the network interface with GLOO_SOCKET_IFNAME
[rank8] Gloo connectFullMesh failed ... timed out connecting: SO_ERROR: Connection refused,
        remote=[127.0.0.1]:14215
RuntimeError: Gloo connectFullMesh failed ...
EngineCore failed to start.
```

## Root cause

Under `hostNetwork: true` the pod sees many NICs (lo, docker, veth, EFA 172.16.x, primary 10.x). vLLM's world-group **Gloo** (CPU-side coordination, TP16 across 2 nodes) couldn't map the pod hostname to a routable address and **fell back to 127.0.0.1**. So rank8 (worker node) tries to reach the leader-node ranks at its own loopback → `Connection refused` → `connectFullMesh` never completes → EngineCore dies.

`lws.yaml-template` set neither `GLOO_SOCKET_IFNAME` nor `NCCL_SOCKET_IFNAME`.

## Fix

Pin both `GLOO_SOCKET_IFNAME` and `NCCL_SOCKET_IFNAME` to the primary VPC NIC via the exclusion list **`^lo,docker,veth,eni`** (the same pattern the proven EP16-agg run used) on **both** leader and worker, so Gloo/NCCL advertise the routable 10.x IP instead of loopback.

## Verification

- Both roles carry `GLOO_SOCKET_IFNAME` + `NCCL_SOCKET_IFNAME` (grep = 2 each); `NCCL_NET_PLUGIN` unchanged.
- Template renders via `envsubst` → 3 valid docs; both roles' env asserted; no unresolved `${...}`.

Chain for the agg-LWS 2-node PP2 path: #48 (cpu fits node) → #49 (Ray raylet IP) → this (Gloo/NCCL ifname). With all three, the TP16/PP2 workers should form the world group and load.