### PR TITLE
fix(nemotron/agg): guard frontend startup against cold-start NATS DNS race

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws.yaml-template
@@ -284,6 +284,17 @@ spec:
           # 1.3.x images ship plain python3 and have NO /opt/dynamo/venv - activate only when present.
           args:
             - |-
+              set -eu
+              # dynamo.frontend calls DistributedRuntime() which connects to NATS immediately
+              # with NO retry, so a transient cold-start DNS miss (EAI_AGAIN, "Temporary failure
+              # in name resolution") is fatal and CrashLoops the pod even though NATS is healthy.
+              # The worker template already guards its startup with a getent loop; mirror that here.
+              NATS_HOST=${DOLLAR}{NATS_SERVER#*://}; NATS_HOST=${DOLLAR}{NATS_HOST%%:*}
+              for i in ${DOLLAR}(seq 1 60); do
+                if getent hosts "${DOLLAR}NATS_HOST" >/dev/null 2>&1; then break; fi
+                echo "[frontend] waiting for DNS NATS_HOST=${DOLLAR}NATS_HOST (${DOLLAR}i)"
+                sleep 2
+              done
               if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
               exec python3 -m dynamo.frontend --http-port 8000 --http-host 0.0.0.0
           env:


### PR DESCRIPTION
## Problem

On a cold 2-node agg-LWS bring-up, the **frontend** pod CrashLoops with:

```
Exception: Failed to connect to NATS: DNS error: failed to lookup address
information: Temporary failure in name resolution. Verify NATS server is
running and accessible.
```

This is `EAI_AGAIN` (a **transient** resolver failure), not `NXDOMAIN`. NATS is healthy — `dynamo-platform-nats-0` is Running 2/2 — and the **worker resolves etcd on the same `*.dynamo-system.svc.cluster.local` domain** in the same run. The frontend just loses a cold-start race with CoreDNS.

## Root cause

`dynamo.frontend` calls `DistributedRuntime(...)` which connects to NATS **immediately, with no retry**. The worker `leaderTemplate`/`workerTemplate` already guard their startup with a `getent hosts` loop (for `LWS_LEADER_ADDRESS`), but the frontend launch script had **no DNS-readiness guard** — so the first lookup miss is fatal.

## Fix

Mirror the worker's existing idiom in the frontend launch script: derive `NATS_HOST` from `NATS_SERVER` and wait (up to 120s) for it to resolve before `exec`'ing `dynamo.frontend`. No behavior change once DNS is warm.

## Verification
- `envsubst` render: runtime `$`-vars survive, deploy-time vars expand; `NATS_HOST` → `dynamo-platform-nats.dynamo-system.svc.cluster.local`.
- `bash -n` clean; full template parses as 3 YAML docs.
- Confirmed against a live cgk run: worker cleared world-init (chain #48→#51) and reached Dynamo runtime; the only remaining failure was this frontend NATS race.

## Relationship to the agg-LWS chain
Independent of #51 (worker Gloo ifname) — a **different block** of the same file, no conflict. The full 2-node agg-LWS PP2 bring-up is now: #48 (cpu fits node) → #49 (Ray raylet IP) → #50/#51 (Gloo/NCCL ifname) → **this** (frontend DNS-wait).