### PR TITLE
fix(nemotron/agg): add NCCL_NVLS_ENABLE=0 + cross-node EFA env for PP=2

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws.yaml-template
@@ -112,9 +112,18 @@ spec:
               - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
               - { name: FI_EFA_ENABLE_SHM, value: "0" }
               - { name: FI_EFA_ENABLE_SHM_TRANSFER, value: "0" }
+              - { name: FI_EFA_FORK_SAFE, value: "1" }
               - { name: NIXL_LIBFABRIC_MAX_RAILS, value: "1" }
               - { name: NIXL_SKIP_TOPOLOGY_CHECK, value: "1" }
               - { name: NCCL_NET_PLUGIN, value: ofi }
+              - { name: NCCL_TUNER_PLUGIN, value: ofi }
+              # PP=2 spans two nodes, so the PP group is the FIRST cross-node NCCL collective
+              # (TP groups are intra-node/NVLink and init fine). NVLS must be OFF or that first
+              # all-reduce dies with "NCCL error: remote process exited or there was a network
+              # error". This is the exact env the proven cross-node EP16 template uses.
+              - { name: NCCL_NVLS_ENABLE, value: "0" }
+              - { name: NCCL_DEBUG, value: INFO }
+              - { name: NCCL_DEBUG_SUBSYS, value: "INIT,NET" }
               # NCCL accepts the ^exclude list; Gloo does NOT (it needs a single concrete
               # iface name — a "^lo" value fails with "Unable to find address for: ^lo").
               # GLOO_SOCKET_IFNAME is therefore exported at runtime in the launch script
@@ -226,9 +235,18 @@ spec:
               - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
               - { name: FI_EFA_ENABLE_SHM, value: "0" }
               - { name: FI_EFA_ENABLE_SHM_TRANSFER, value: "0" }
+              - { name: FI_EFA_FORK_SAFE, value: "1" }
               - { name: NIXL_LIBFABRIC_MAX_RAILS, value: "1" }
               - { name: NIXL_SKIP_TOPOLOGY_CHECK, value: "1" }
               - { name: NCCL_NET_PLUGIN, value: ofi }
+              - { name: NCCL_TUNER_PLUGIN, value: ofi }
+              # PP=2 spans two nodes, so the PP group is the FIRST cross-node NCCL collective
+              # (TP groups are intra-node/NVLink and init fine). NVLS must be OFF or that first
+              # all-reduce dies with "NCCL error: remote process exited or there was a network
+              # error". This is the exact env the proven cross-node EP16 template uses.
+              - { name: NCCL_NVLS_ENABLE, value: "0" }
+              - { name: NCCL_DEBUG, value: INFO }
+              - { name: NCCL_DEBUG_SUBSYS, value: "INIT,NET" }
               # NCCL accepts the ^exclude list; Gloo does NOT (it needs a single concrete
               # iface name — a "^lo" value fails with "Unable to find address for: ^lo").
               # GLOO_SOCKET_IFNAME is therefore exported at runtime in the launch script


### PR DESCRIPTION
## Progress
The #48→#52 chain got the agg-LWS worker all the way into the **vLLM V1 engine** (v0.23.0, TP=8 × PP=2 = 16 ranks, NVFP4). World-init (Gloo), Ray join, and the frontend (NATS) are all clean now.

## New failure — first cross-node NCCL collective
The worker forms its **TP groups (intra-node / NVLink) fine**, then dies forming the **PP group**, which is the *first* collective that crosses the node boundary (ranks span `10.1.227.0` + `10.1.216.156`, `world_size=16`, `distributed_init_method=tcp://10.1.227.0:51263`):

```
init_model_parallel_group -> _PP -> PyNcclCommunicator.__init__
  -> all_reduce -> ncclAllReduce
RuntimeError: NCCL error: remote process exited or there was a network error
```

## Root cause
The agg `lws.yaml-template` was **missing the cross-node NCCL/EFA env** that the **proven EP16 template in the same directory** carries — the one that MEASURED 550B serving cross-node over EFA (NET/OFI efa both nodes, socket_fallback=0). Most importantly **`NCCL_NVLS_ENABLE=0`**: NVLS (NVLink SHARP) init over a 2-node fabric is exactly what produces this "remote process exited" class of failure — the repo documents this var verbatim as *"Prevents NVLS init failures."* TP-only (single node) never triggers it, which is why EP16-agg and PP1 worked but PP2 didn't.

## Fix
Add to **both** leaderTemplate and workerTemplate, matching the EP16 env:
- `NCCL_NVLS_ENABLE=0` (the fix)
- `NCCL_TUNER_PLUGIN=ofi`, `FI_EFA_FORK_SAFE=1`
- `NCCL_DEBUG=INFO` + `NCCL_DEBUG_SUBSYS=INIT,NET` — this run produced **zero** NET/OFI lines, so the next run will show the provider selection and confirm EFA is chosen (vs a silent socket fallback).

## Verification
- `envsubst` render + `yaml.safe_load_all` = 3 docs OK; both roles show `NCCL_NVLS_ENABLE=0 NCCL_TUNER_PLUGIN=ofi FI_EFA_FORK_SAFE=1 NCCL_DEBUG=INFO ...`.
- Env now at parity with the working EP16 template.

## agg-LWS chain
#48 (cpu) → #49 (Ray IP) → #50/#51 (Gloo ifname) → #52 (frontend NATS DNS-wait) → **this** (PP2 cross-node NCCL NVLS/EFA env).