### PR TITLE
fix(nemotron/agg): exclude pod-id-link0 from NCCL sockets + drop disagg-only FI/NIXL env

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws.yaml-template
@@ -110,11 +110,11 @@ spec:
               # EFA / libfabric
               - { name: FI_PROVIDER, value: efa }
               - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
-              - { name: FI_EFA_ENABLE_SHM, value: "0" }
-              - { name: FI_EFA_ENABLE_SHM_TRANSFER, value: "0" }
               - { name: FI_EFA_FORK_SAFE, value: "1" }
-              - { name: NIXL_LIBFABRIC_MAX_RAILS, value: "1" }
-              - { name: NIXL_SKIP_TOPOLOGY_CHECK, value: "1" }
+              # NOTE: FI_EFA_ENABLE_SHM/SHM_TRANSFER=0 and NIXL_* were disagg-only
+              # (NIXL KV transfer). agg doesn't use NIXL; the proven cross-node EP16
+              # agg template omits them. Kept out here so libfabric provider
+              # enumeration matches the known-working env.
               - { name: NCCL_NET_PLUGIN, value: ofi }
               - { name: NCCL_TUNER_PLUGIN, value: ofi }
               # PP=2 spans two nodes, so the PP group is the FIRST cross-node NCCL collective
@@ -128,7 +128,12 @@ spec:
               # iface name — a "^lo" value fails with "Unable to find address for: ^lo").
               # GLOO_SOCKET_IFNAME is therefore exported at runtime in the launch script
               # (resolved from the route to the leader), NOT set here.
-              - { name: NCCL_SOCKET_IFNAME, value: "^lo,docker,veth,eni" }
+              # MUST exclude pod-id-link0: EKS Pod Identity adds a link-local NIC
+              # (169.254.170.x) that NCCL otherwise enumerates as a net device; cross-node
+              # it then tries to connect to 169.254.170.23 -> "Connection refused" and the
+              # PP all-reduce dies with "remote process exited". Excluding it leaves only
+              # the routable primary VPC NIC (enp73s0:10.x).
+              - { name: NCCL_SOCKET_IFNAME, value: "^lo,docker,veth,eni,pod-id-link0" }
             ports:
               - { containerPort: 9090, name: dyn-system }
             startupProbe:
@@ -233,11 +238,11 @@ spec:
               - { name: HF_MODULES_CACHE, value: /tmp/hf_cache/modules }
               - { name: FI_PROVIDER, value: efa }
               - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
-              - { name: FI_EFA_ENABLE_SHM, value: "0" }
-              - { name: FI_EFA_ENABLE_SHM_TRANSFER, value: "0" }
               - { name: FI_EFA_FORK_SAFE, value: "1" }
-              - { name: NIXL_LIBFABRIC_MAX_RAILS, value: "1" }
-              - { name: NIXL_SKIP_TOPOLOGY_CHECK, value: "1" }
+              # NOTE: FI_EFA_ENABLE_SHM/SHM_TRANSFER=0 and NIXL_* were disagg-only
+              # (NIXL KV transfer). agg doesn't use NIXL; the proven cross-node EP16
+              # agg template omits them. Kept out here so libfabric provider
+              # enumeration matches the known-working env.
               - { name: NCCL_NET_PLUGIN, value: ofi }
               - { name: NCCL_TUNER_PLUGIN, value: ofi }
               # PP=2 spans two nodes, so the PP group is the FIRST cross-node NCCL collective
@@ -251,7 +256,12 @@ spec:
               # iface name — a "^lo" value fails with "Unable to find address for: ^lo").
               # GLOO_SOCKET_IFNAME is therefore exported at runtime in the launch script
               # (resolved from the route to the leader), NOT set here.
-              - { name: NCCL_SOCKET_IFNAME, value: "^lo,docker,veth,eni" }
+              # MUST exclude pod-id-link0: EKS Pod Identity adds a link-local NIC
+              # (169.254.170.x) that NCCL otherwise enumerates as a net device; cross-node
+              # it then tries to connect to 169.254.170.23 -> "Connection refused" and the
+              # PP all-reduce dies with "remote process exited". Excluding it leaves only
+              # the routable primary VPC NIC (enp73s0:10.x).
+              - { name: NCCL_SOCKET_IFNAME, value: "^lo,docker,veth,eni,pod-id-link0" }
             resources:
               requests:
                 cpu: "48"


### PR DESCRIPTION
## What #53's NCCL_DEBUG revealed
Adding `NCCL_DEBUG=INFO` in #53 exposed the real PP2 cross-node failure — **it was not NVLS**. The log shows two chained problems:

**1. EFA fails to initialize on this node → TCP fallback**
```
NET/OFI Using transport protocol RDMA (platform set)
NET/OFI No eligible providers were found
NET/OFI aws-ofi-nccl initialization failed
NET/IB : No device found → Failed to initialize NET plugin IB
Initialized NET plugin Socket        ← falls back to TCP
```

**2. The TCP fallback then picks the wrong NIC and hangs cross-node**
```
NET/Socket : Using [0]enp73s0:10.1.216.156<0> [1]pod-id-link0:169.254.170.23<0>
socketPollConnect: connect to 169.254.170.23<...> returned Connection refused, retrying (13/34)
→ RuntimeError: NCCL error: remote process exited or there was a network error
```
`pod-id-link0` is the **EKS Pod Identity** link-local NIC (169.254.170.x, per-node, non-routable). The old exclude `^lo,docker,veth,eni` didn't cover it, so cross-node ranks tried the 169.254 address → refused → the PP all-reduce never completes.

## Fix (both leader + worker)
1. **`NCCL_SOCKET_IFNAME=^lo,docker,veth,eni,pod-id-link0`** — exclude the Pod-Identity link-local so only the routable primary VPC NIC (`enp73s0:10.x`) is used. Makes the socket fallback work cross-node, and is harmless once EFA init is fixed.
2. **Drop `FI_EFA_ENABLE_SHM`/`FI_EFA_ENABLE_SHM_TRANSFER=0` and `NIXL_*`** — those were disagg-only (NIXL KV transfer); the proven cross-node **EP16 agg** template omits them. Narrowing libfabric's env to the known-working set removes them as suspects for the "no eligible providers" init failure.

## Still being chased (needs one diagnostic from the pod)
`NET/OFI No eligible providers were found` means libfabric enumerated no usable `efa` provider in-container. Could be device-count/allocatable or a stale env. The definitive check is `fi_info -p efa` from inside the worker pod (should list rdmap/efa devices). Requesting that; this PR removes the socket-fallback wall in the meantime so we can see whether EFA then initializes.

## agg-LWS chain
#48 → #49 → #50/#51 → #52 → #53 → **this** (pod-id-link0 exclude + env narrowing).