### PR TITLE
fix(efa-device-plugin): add p5en/p6-b200/p5e/g6/g6e to instance allowlist

### DIFF
--- a/Container-Root/eks/deployment/efa-device-plugin/efa-k8s-device-plugin.yaml
+++ b/Container-Root/eks/deployment/efa-device-plugin/efa-k8s-device-plugin.yaml
@@ -59,6 +59,13 @@ spec:
                       - trn1.32xlarge
                       - trn1n.32xlarge
                       - p5.48xlarge
+                      - p5e.48xlarge
+                      - p5en.48xlarge
+                      - p6-b200.48xlarge
+                      - g6.8xlarge
+                      - g6.48xlarge
+                      - g6e.8xlarge
+                      - g6e.48xlarge
                       - g5.8xlarge
                       - ml.g5.8xlarge
               - matchExpressions:
@@ -85,6 +92,13 @@ spec:
                       - trn1.32xlarge
                       - trn1n.32xlarge
                       - p5.48xlarge
+                      - p5e.48xlarge
+                      - p5en.48xlarge
+                      - p6-b200.48xlarge
+                      - g6.8xlarge
+                      - g6.48xlarge
+                      - g6e.8xlarge
+                      - g6e.48xlarge
                       - g5.8xlarge
                       - ml.g5.8xlarge
       hostNetwork: true


### PR DESCRIPTION
## Silent production blocker

The vendored `aws-efa-k8s-device-plugin` DaemonSet pins a **static instance-type nodeAffinity allowlist** that ends at `p5.48xlarge`. On any newer EFA-capable GPU node (**`p5en.48xlarge`, `p6-b200.48xlarge`**, p5e, g6/g6e) the DaemonSet's `DESIRED` count is **0** — it silently never schedules.

Consequence chain (all observed on a live p6-b200 cluster):
- no device plugin → `/dev/infiniband/uverbs*` + `/dev/gdrdrv` never advertised/injected into pods
- inside the container: `ibv_open_device failed! errno: 2` (ENOENT) → `fi_info -p efa` = `-61 (No data available)`
- libfabric's efa provider returns an empty list → **NCCL falls back to `NET/Socket` (TCP)**
- any cross-node collective (PP / EP / TP spanning nodes) then dies (`NCCL error: remote process exited`)

This is the worst kind of blocker for production: the image builds, the pod schedules, the GPUs work — **EFA is quietly absent**, and it only surfaces at the first cross-node NCCL op (or as silent 10-100× slower TCP fallback).

## Fix
Add the modern EFA GPU instance types to **both** `matchExpressions` blocks:
`p5e.48xlarge`, `p5en.48xlarge`, `p6-b200.48xlarge`, `g6.8xlarge`, `g6.48xlarge`, `g6e.8xlarge`, `g6e.48xlarge`.

## Verification
- Live evidence: p6-b200 cluster showed this DS `DESIRED=0` (allowlist stops at p5.48xlarge); the p5en cluster whose allowlist already includes p5en runs `9/9`.
- YAML parses; both duplicate blocks updated identically.

## Scope note
Does **not** bump the plugin image (`v0.3.6`) — the allowlist is the blocker; an image bump is a separate, independently-verifiable change. A more future-proof alternative is to drop the static allowlist and gate on a label like `vpc.amazonaws.com/efa`/`feature.node.kubernetes.io/...`, but that's a larger behavioral change; this PR is the minimal, safe fix.