### PR TITLE
fix(nemotron/test): persist aiperf results via --artifact-dir (space-safe)

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/test/.env
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/test/.env
@@ -11,3 +11,6 @@ export SERVICE_URL="http://${SERVICE_NAME}.${NAMESPACE}.svc.cluster.local:8000"
 export MODEL_NAME=nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16
 export MODEL_PATH=/shared/models/hf/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16
 
+
+# aiperf artifact output (persisted to the fsx /shared mount in the do-aiperf pod)
+export ARTIFACT_DIR="${MODEL_PATH}/aiperf"

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/test/test-aiperf.sh
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/test/test-aiperf.sh
@@ -15,7 +15,7 @@ kubectl wait --for=condition=Ready pod/do-aiperf --timeout=120s
 # Execute the aiperf command interactively
 echo "Executing aiperf command in do-aiperf pod ..."
 
-export CMD="kubectl exec -it do-aiperf -- aiperf profile --model \"${MODEL_NAME}\" --tokenizer \"${MODEL_PATH}\" --url \"${SERVICE_URL}\" --transport http --endpoint-type chat --streaming --concurrency 10 --request-count 100 --synthetic-input-tokens-mean 1024 --synthetic-input-tokens-stddev 0 --output-tokens-mean 512 --extra-inputs \"ignore_eos:true\" --random-seed 42"
+export CMD="kubectl exec -it do-aiperf -- aiperf profile --model \"${MODEL_NAME}\" --tokenizer \"${MODEL_PATH}\" --artifact-dir \"${ARTIFACT_DIR}\" --url \"${SERVICE_URL}\" --transport http --endpoint-type chat --streaming --concurrency 10 --request-count 100 --synthetic-input-tokens-mean 1024 --synthetic-input-tokens-stddev 0 --output-tokens-mean 512 --extra-inputs \"ignore_eos:true\" --random-seed 42"
 
 if [ ! "$VERBOSE" == "false" ]; then echo -e "\n${CMD}\n"; fi
 


### PR DESCRIPTION
## Problem
`test-aiperf.sh` runs `aiperf profile` with **no `--artifact-dir`**, so results live only in the ephemeral `do-aiperf` pod and vanish when the script deletes it at the end. Adding the flag by hand is a footgun: a **missing space** between the artifact-dir value and the next flag makes aiperf glue them and reject the URL as an unattached positional —
```
Unused Tokens: ['http://nemotron3-ultra-550b-agg-frontend...:8000']
command terminated with exit code 1
```
— even though the server is healthy (chat/completions work).

## Fix
- Add `--artifact-dir "${ARTIFACT_DIR}"` to the built command, **space-delimited, before `--url`**.
- Default `ARTIFACT_DIR=${MODEL_PATH}/aiperf` in the test `.env` (`.env`-overridable).
- The `do-aiperf` pod already mounts `fsx-pvc` at `/shared`, so results now persist on the shared filesystem across pod restarts (also sidesteps the empty-CSV-on-pod-delete gotcha).

## Verification
- `envsubst` render shows `--artifact-dir "/shared/.../aiperf" --url "http://...:8000"` with correct spacing.
- `bash -n` clean.
- Context: verified against a live agg-LWS run where chat + completions served correctly and only the aiperf harness failed on this quoting issue.