### PR TITLE
fix(nemotron/agg-lws): pass --load-format ${LOAD_FORMAT} (runai_streamer/mx never engaged on LWS)

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws.yaml-template
@@ -89,6 +89,7 @@ spec:
                 exec python3 -m dynamo.vllm \
                   --model ${MODEL_PATH} \
                   --served-model-name ${MODEL_NAME} \
+                  --load-format ${LOAD_FORMAT} \
                   --tensor-parallel-size ${GPU_PER_WORKER} \
                   --pipeline-parallel-size 2 \
                   --distributed-executor-backend ray \


### PR DESCRIPTION
## Problem
`deployment.yaml-template` launches `dynamo.vllm` with `--load-format ${LOAD_FORMAT}` — and `agg/.env` documents the choices: `auto` / `runai_streamer` (streams shards, overlaps download+load) / `mx` (ModelExpress `MxModelLoader`). But the **LWS leader launch omitted the flag entirely**, so it always used the default `auto` loader no matter what `LOAD_FORMAT` was set to. Result: runai-streamer / mx fast loaders worked on the plain Deployment path but **never engaged on the LWS (multi-node agg/PP) path** — reported by a user whose LWS worker wasn't loading safetensors via runai_streamer/mx like `deployment.yaml-template` does.

## Fix
Add `--load-format ${LOAD_FORMAT}` to the LWS leader `dynamo.vllm` exec (after `--served-model-name`, matching the deployment template's arg order). `LOAD_FORMAT` already exists in `agg/.env` (default `auto`), so this is caller-controlled and inert unless overridden to `runai_streamer`/`mx`.

Leader-only by design: the worker template is a Ray joiner (no `dynamo.vllm` launch) and the frontend doesn't load weights.

## Verification
- `envsubst` render shows `--load-format auto` (default); set `LOAD_FORMAT=runai_streamer` → `--load-format runai_streamer`.
- `yaml.safe_load_all` = 3 docs OK. One-line change.