### PR TITLE
nemotron/ultra: warm Mamba decode kernels on cold pod start (agg + disagg LWS)

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws.yaml-template
@@ -85,6 +85,35 @@ spec:
                   if [ "${DOLLAR}{N:-0}" -ge 2 ]; then break; fi
                   sleep 5
                 done
+                # Cold-start warmup (detached): a fresh pod's FIRST request pays a one-time
+                # ~4min Triton JIT tax compiling the Mamba DECODE kernels (_selective_scan_update,
+                # _causal_conv1d_update) mid-request — startup only warms the PREFILL SSD path,
+                # and --enforce-eager skips cudagraph capture. Without this, the first CUSTOMER
+                # request looks hung for ~4min; warm steady-state is fine (~14 tok/s on B200).
+                # This backgrounded warmer drives ONE tiny generation through the frontend so the
+                # decode kernels JIT before real traffic arrives. It shares the pod, never blocks
+                # the engine launch, and swallows all errors so it can never crash the pod. Polls
+                # /v1/models (frontend readiness uses a tcpSocket probe, so /health may be absent)
+                # until the worker registers, then fires one max_tokens=4 completion.
+                (
+                  FE="http://${DEPLOYMENT_NAME}-frontend.${NAMESPACE}.svc.cluster.local:8000"
+                  if ! command -v curl >/dev/null 2>&1; then
+                    echo "[warmup] curl not present; skipping cold-start warmup (non-fatal)"
+                  else
+                    for i in ${DOLLAR}(seq 1 360); do
+                      if curl -sf -o /dev/null --max-time 5 "${DOLLAR}FE/v1/models" 2>/dev/null; then
+                        echo "[warmup] worker registered; priming Mamba decode kernels (one-time JIT, ~4min)"
+                        curl -s -o /dev/null --max-time 900 "${DOLLAR}FE/v1/completions" \
+                          -H 'Content-Type: application/json' \
+                          -d "{\"model\":\"${MODEL_NAME}\",\"prompt\":\"warmup\",\"max_tokens\":4,\"temperature\":0}" \
+                          && echo "[warmup] decode kernels warm; first real request will be fast" \
+                          || echo "[warmup] warmup request returned non-zero (non-fatal)"
+                        break
+                      fi
+                      sleep 5
+                    done
+                  fi
+                ) &
                 # Launch Dynamo vLLM worker
                 exec python3 -m dynamo.vllm \
                   --model ${MODEL_PATH} \

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws.yaml-template
@@ -307,6 +307,35 @@ spec:
                   if [ "${DOLLAR}{N:-0}" -ge 2 ]; then break; fi
                   sleep 5
                 done
+                # Cold-start warmup (detached): a fresh pod's FIRST request pays a one-time
+                # ~4min Triton JIT tax compiling the Mamba DECODE kernels (_selective_scan_update,
+                # _causal_conv1d_update) mid-request — startup only warms the PREFILL SSD path,
+                # and --enforce-eager skips cudagraph capture. Without this, the first CUSTOMER
+                # request looks hung for ~4min; warm steady-state is fine (~14 tok/s on B200).
+                # This backgrounded warmer drives ONE tiny generation through the frontend (which
+                # exercises both prefill and decode roles) so the decode kernels JIT before real
+                # traffic arrives. It shares the pod, never blocks the engine launch, and swallows
+                # all errors so it can never crash the pod. Polls /v1/models (frontend readiness
+                # uses a tcpSocket probe, so /health may be absent) until the worker registers.
+                (
+                  FE="http://${DEPLOYMENT_NAME}-frontend.${NAMESPACE}.svc.cluster.local:8000"
+                  if ! command -v curl >/dev/null 2>&1; then
+                    echo "[warmup] curl not present; skipping cold-start warmup (non-fatal)"
+                  else
+                    for i in ${DOLLAR}(seq 1 360); do
+                      if curl -sf -o /dev/null --max-time 5 "${DOLLAR}FE/v1/models" 2>/dev/null; then
+                        echo "[warmup] worker registered; priming Mamba decode kernels (one-time JIT, ~4min)"
+                        curl -s -o /dev/null --max-time 900 "${DOLLAR}FE/v1/completions" \
+                          -H 'Content-Type: application/json' \
+                          -d "{\"model\":\"${MODEL_NAME}\",\"prompt\":\"warmup\",\"max_tokens\":4,\"temperature\":0}" \
+                          && echo "[warmup] decode kernels warm; first real request will be fast" \
+                          || echo "[warmup] warmup request returned non-zero (non-fatal)"
+                        break
+                      fi
+                      sleep 5
+                    done
+                  fi
+                ) &
                 exec python3 -m dynamo.vllm \
                   --model ${MODEL_PATH} \
                   --served-model-name ${MODEL_NAME} \


### PR DESCRIPTION
## What

A fresh Nemotron-3-Ultra-550B pod's **first** request pays a one-time **~4min Triton JIT tax** compiling the Mamba **decode** kernels (`_selective_scan_update_kernel`, `_causal_conv1d_update_kernel`) *mid-request*. Startup warmup only exercises the **prefill** SSD path (`mamba_mixer2.py`), and `--enforce-eager` skips cudagraph capture — so the decode-shape kernels JIT on the first real decode step. A customer hitting a fresh pod sees the first request appear to **hang for ~4min**.

This adds a **detached background warmer** to the leader (agg) / decode-leader (disagg) launch script that drives ONE `max_tokens=4` completion through the frontend, so the decode kernels JIT *before* real traffic arrives.

## Measured evidence (B200, agg-LWS TP8×PP2, NVFP4)

3× `bs=1` curl on a fresh pod:

| run | total | tok/s |
|---|---|---|
| 1st (cold) | 253.7s | 0.50 |
| 2nd (warm) | 9.02s | **14.2** |
| 3rd (warm) | 8.95s | **14.3** |

The ~245s gap is the one-time decode-JIT; warm steady-state NVFP4 is **14.25 tok/s (70 ms/token)**. Confirmed in the worker log: `jit_monitor.py` warns `Triton kernel JIT compilation during inference: _selective_scan_update_kernel ... consider extending warmup`. So this is **not** a kernel bug and **not** upstream — just a cold-start warmup gap.

## Why it's safe

- Runs in a subshell + `&`, so it **never blocks** the engine `exec`.
- Polls `/v1/models` until the worker registers (frontend readiness is a `tcpSocket` probe, so `/health` may be absent).
- Swallows all errors (`|| echo ...`) — it **can never crash the pod**.
- Guards on `command -v curl` and no-ops if curl is absent.
- Independent of the MoE backend (`--moe-backend`) choice.

## Verification

- ✅ Both templates render cleanly via `envsubst` (the `${DOLLAR}` runtime-`$` escaping resolves correctly).
- ✅ Rendered YAML is valid (`yaml.safe_load_all`).
- ⚠️ **Not yet live-verified** on a full 550B bring-up — the change is a non-fatal detached warmer, and the "first request is fast" outcome follows from the measured one-time-JIT mechanism above. Happy to co-verify on a live pod before merge.

## Notes

- Scope: the `bs=1` warmup covers the single-stream decode shape (the dominant first-compile cost). A concurrent first-hit may still do a smaller incremental compile; the ~4min cliff is removed.
- Complementary (not included): persisting the Triton cache on a per-**node** hostPath (`TRITON_CACHE_DIR`/`VLLM_CACHE_ROOT`) would help 2nd+ pods on a warm node, but not the first cold pod — this warmer handles the first pod with no image rebuild.

AI assistance (Claude) was used to author this change.