### PR TITLE
nemotron/ultra: NVFP4-gated concurrent-batch warmup (follow-up to #59)

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws.yaml-template
@@ -90,24 +90,54 @@ spec:
                 # _causal_conv1d_update) mid-request — startup only warms the PREFILL SSD path,
                 # and --enforce-eager skips cudagraph capture. Without this, the first CUSTOMER
                 # request looks hung for ~4min; warm steady-state is fine (~14 tok/s on B200).
-                # This backgrounded warmer drives ONE tiny generation through the frontend so the
-                # decode kernels JIT before real traffic arrives. It shares the pod, never blocks
-                # the engine launch, and swallows all errors so it can never crash the pod. Polls
+                # This backgrounded warmer drives generations through the frontend so the decode
+                # kernels JIT before real traffic arrives. It shares the pod, never blocks the
+                # engine launch, and swallows all errors so it can never crash the pod. Polls
                 # /v1/models (frontend readiness uses a tcpSocket probe, so /health may be absent)
-                # until the worker registers, then fires one max_tokens=4 completion.
+                # until the worker registers, then warms.
+                # NOTE: the Mamba decode kernel (selective_state_update) compiles a DIFFERENT
+                # Triton variant per batch size (it tunes BLOCK_SIZE_M/num_warps keyed on
+                # effective_batch = batch*nheads, see mamba_ssm.py). A single bs=1 request only
+                # compiles the batch=1 bucket, so a concurrent benchmark (e.g. aiperf
+                # --concurrency 10) still pays per-bucket JIT on its opening. We therefore warm
+                # bs=1 first (fastest to first-token) and then fire a CONCURRENT burst so buckets
+                # 1..N compile up front.
+                # Precision gate: the extra JIT-heavy opening is an NVFP4 concern (the NVFP4
+                # checkpoint FP8-quantizes the Mamba mixer + NVFP4-quantizes MoE, pulling in more
+                # kernel variants). BF16 completes this benchmark without the warmup, so skip it
+                # there. WARMUP_ENABLED=auto (default) follows the served model's precision
+                # suffix; set WARMUP_ENABLED=1/0 to force on/off.
                 (
                   FE="http://${DEPLOYMENT_NAME}-frontend.${NAMESPACE}.svc.cluster.local:8000"
+                  WARMUP_CONCURRENCY=${DOLLAR}{WARMUP_CONCURRENCY:-10}
+                  WARMUP_ENABLED=${DOLLAR}{WARMUP_ENABLED:-auto}
+                  case "${DOLLAR}WARMUP_ENABLED" in
+                    auto) case "${MODEL_NAME}" in
+                            *NVFP4*|*nvfp4*) : ;;
+                            *) echo "[warmup] ${MODEL_NAME} is not NVFP4; warmup not needed, skipping (non-fatal)"; exit 0 ;;
+                          esac ;;
+                    0|false|no) echo "[warmup] WARMUP_ENABLED=${DOLLAR}WARMUP_ENABLED; skipping (non-fatal)"; exit 0 ;;
+                  esac
                   if ! command -v curl >/dev/null 2>&1; then
                     echo "[warmup] curl not present; skipping cold-start warmup (non-fatal)"
                   else
                     for i in ${DOLLAR}(seq 1 360); do
                       if curl -sf -o /dev/null --max-time 5 "${DOLLAR}FE/v1/models" 2>/dev/null; then
-                        echo "[warmup] worker registered; priming Mamba decode kernels (one-time JIT, ~4min)"
+                        echo "[warmup] worker registered; priming batch=1 Mamba decode kernel (one-time JIT, ~4min)"
                         curl -s -o /dev/null --max-time 900 "${DOLLAR}FE/v1/completions" \
                           -H 'Content-Type: application/json' \
                           -d "{\"model\":\"${MODEL_NAME}\",\"prompt\":\"warmup\",\"max_tokens\":4,\"temperature\":0}" \
-                          && echo "[warmup] decode kernels warm; first real request will be fast" \
-                          || echo "[warmup] warmup request returned non-zero (non-fatal)"
+                          && echo "[warmup] batch=1 warm; priming concurrent batch buckets 1..${DOLLAR}WARMUP_CONCURRENCY" \
+                          || echo "[warmup] batch=1 warmup returned non-zero (non-fatal)"
+                        # Concurrent burst: compile the batch>1 kernel buckets a concurrent
+                        # benchmark will hit, so its opening doesn't pay per-bucket JIT.
+                        for j in ${DOLLAR}(seq 1 "${DOLLAR}WARMUP_CONCURRENCY"); do
+                          curl -s -o /dev/null --max-time 900 "${DOLLAR}FE/v1/completions" \
+                            -H 'Content-Type: application/json' \
+                            -d "{\"model\":\"${MODEL_NAME}\",\"prompt\":\"warmup\",\"max_tokens\":4,\"temperature\":0}" &
+                        done
+                        wait
+                        echo "[warmup] concurrent batch buckets warm; benchmark opening will be fast"
                         break
                       fi
                       sleep 5

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws.yaml-template
@@ -312,24 +312,54 @@ spec:
                 # _causal_conv1d_update) mid-request — startup only warms the PREFILL SSD path,
                 # and --enforce-eager skips cudagraph capture. Without this, the first CUSTOMER
                 # request looks hung for ~4min; warm steady-state is fine (~14 tok/s on B200).
-                # This backgrounded warmer drives ONE tiny generation through the frontend (which
-                # exercises both prefill and decode roles) so the decode kernels JIT before real
-                # traffic arrives. It shares the pod, never blocks the engine launch, and swallows
-                # all errors so it can never crash the pod. Polls /v1/models (frontend readiness
-                # uses a tcpSocket probe, so /health may be absent) until the worker registers.
+                # This backgrounded warmer drives generations through the frontend (which exercises
+                # both prefill and decode roles) so the decode kernels JIT before real traffic
+                # arrives. It shares the pod, never blocks the engine launch, and swallows all
+                # errors so it can never crash the pod. Polls /v1/models (frontend readiness uses
+                # a tcpSocket probe, so /health may be absent) until the worker registers.
+                # NOTE: the Mamba decode kernel (selective_state_update) compiles a DIFFERENT
+                # Triton variant per batch size (it tunes BLOCK_SIZE_M/num_warps keyed on
+                # effective_batch = batch*nheads, see mamba_ssm.py). A single bs=1 request only
+                # compiles the batch=1 bucket, so a concurrent benchmark (e.g. aiperf
+                # --concurrency 10) still pays per-bucket JIT on its opening. We therefore warm
+                # bs=1 first (fastest to first-token) and then fire a CONCURRENT burst so buckets
+                # 1..N compile up front.
+                # Precision gate: the extra JIT-heavy opening is an NVFP4 concern (the NVFP4
+                # checkpoint FP8-quantizes the Mamba mixer + NVFP4-quantizes MoE, pulling in more
+                # kernel variants). BF16 completes this benchmark without the warmup, so skip it
+                # there. WARMUP_ENABLED=auto (default) follows the served model's precision
+                # suffix; set WARMUP_ENABLED=1/0 to force on/off.
                 (
                   FE="http://${DEPLOYMENT_NAME}-frontend.${NAMESPACE}.svc.cluster.local:8000"
+                  WARMUP_CONCURRENCY=${DOLLAR}{WARMUP_CONCURRENCY:-10}
+                  WARMUP_ENABLED=${DOLLAR}{WARMUP_ENABLED:-auto}
+                  case "${DOLLAR}WARMUP_ENABLED" in
+                    auto) case "${MODEL_NAME}" in
+                            *NVFP4*|*nvfp4*) : ;;
+                            *) echo "[warmup] ${MODEL_NAME} is not NVFP4; warmup not needed, skipping (non-fatal)"; exit 0 ;;
+                          esac ;;
+                    0|false|no) echo "[warmup] WARMUP_ENABLED=${DOLLAR}WARMUP_ENABLED; skipping (non-fatal)"; exit 0 ;;
+                  esac
                   if ! command -v curl >/dev/null 2>&1; then
                     echo "[warmup] curl not present; skipping cold-start warmup (non-fatal)"
                   else
                     for i in ${DOLLAR}(seq 1 360); do
                       if curl -sf -o /dev/null --max-time 5 "${DOLLAR}FE/v1/models" 2>/dev/null; then
-                        echo "[warmup] worker registered; priming Mamba decode kernels (one-time JIT, ~4min)"
+                        echo "[warmup] worker registered; priming batch=1 Mamba decode kernel (one-time JIT, ~4min)"
                         curl -s -o /dev/null --max-time 900 "${DOLLAR}FE/v1/completions" \
                           -H 'Content-Type: application/json' \
                           -d "{\"model\":\"${MODEL_NAME}\",\"prompt\":\"warmup\",\"max_tokens\":4,\"temperature\":0}" \
-                          && echo "[warmup] decode kernels warm; first real request will be fast" \
-                          || echo "[warmup] warmup request returned non-zero (non-fatal)"
+                          && echo "[warmup] batch=1 warm; priming concurrent batch buckets 1..${DOLLAR}WARMUP_CONCURRENCY" \
+                          || echo "[warmup] batch=1 warmup returned non-zero (non-fatal)"
+                        # Concurrent burst: compile the batch>1 kernel buckets a concurrent
+                        # benchmark will hit, so its opening doesn't pay per-bucket JIT.
+                        for j in ${DOLLAR}(seq 1 "${DOLLAR}WARMUP_CONCURRENCY"); do
+                          curl -s -o /dev/null --max-time 900 "${DOLLAR}FE/v1/completions" \
+                            -H 'Content-Type: application/json' \
+                            -d "{\"model\":\"${MODEL_NAME}\",\"prompt\":\"warmup\",\"max_tokens\":4,\"temperature\":0}" &
+                        done
+                        wait
+                        echo "[warmup] concurrent batch buckets warm; benchmark opening will be fast"
                         break
                       fi
                       sleep 5


### PR DESCRIPTION
## What

Follow-up to #59. Two refinements to the cold-start warmup, both defaulting to "only when necessary":

### 1. Warm concurrent batch buckets, not just bs=1
The Mamba decode kernel `selective_state_update` (`mamba_ssm.py`) tunes `BLOCK_SIZE_M`/`num_warps` keyed on `effective_batch = batch × nheads` — so it compiles a **distinct Triton variant per batch size**. #59's bs=1 warmup only compiled the **batch=1** bucket, so a concurrent benchmark (`aiperf --concurrency 10`) still paid a one-time per-bucket JIT on its opening — which inflated the benchmark's early ETA estimate (observed "2.5h after 16m"). After the bs=1 warm, this fires a **concurrent burst** (`WARMUP_CONCURRENCY`, default 10) so buckets `1..N` compile up front.

### 2. Precision gate (`WARMUP_ENABLED`, default `auto`)
The JIT-heavy opening is an **NVFP4** concern: the NVFP4 checkpoint FP8-quantizes the Mamba mixer and NVFP4-quantizes the MoE experts, pulling in more kernel variants. BF16 completes this benchmark **without** any warmup (measured: ITL p50 ~50ms, 100/100). So:
- `WARMUP_ENABLED=auto` (default) → warm **iff** the served model name carries an `NVFP4` suffix.
- `WARMUP_ENABLED=1|0` → force on/off.
- For BF16, the block prints one line and exits the detached subshell — a no-op.

## Safety (unchanged from #59)
- Detached subshell + `&` → never blocks the engine `exec`.
- Swallows all errors, `exit 0` only exits the warmer subshell → **can't crash the pod**.
- Guarded on `command -v curl`.

## Verification
- ✅ Both templates render via `envsubst` for **both** precisions (0 stray `${DOLLAR}`, valid YAML).
- ✅ Gate simulated: `NVFP4 → run burst`, `BF16 → skip`.
- ⚠️ **Not yet live-verified** on a fresh 550B pod — non-fatal detached warmer; logic follows from the measured per-batch-size JIT mechanism. Happy to co-verify on a cold start (watch `[warmup] concurrent batch buckets warm` then confirm the aiperf opening ETA is stable, not 2.5h).

AI assistance (Claude) was used to author this change.