### PR TITLE
nemotron/ultra: gate cold-start warmup on leader /health, not frontend (follow-up to #59/#60)

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws.yaml-template
@@ -109,6 +109,13 @@ spec:
                 # suffix; set WARMUP_ENABLED=1/0 to force on/off.
                 (
                   FE="http://${DEPLOYMENT_NAME}-frontend.${NAMESPACE}.svc.cluster.local:8000"
+                  # Gate on the LEADER's own dyn-system /health (localhost:${DYN_SYSTEM_PORT}),
+                  # the same signal the startupProbe uses. The frontend is up (and answers
+                  # /v1/models 200) ~15-18min BEFORE the engine finishes loading, so gating on
+                  # the frontend fires the warmup against a not-yet-ready engine and compiles
+                  # nothing. localhost:9090/health only returns 200 once THIS leader's engine is
+                  # loaded + its routes are registered.
+                  LH="http://localhost:${DOLLAR}{DYN_SYSTEM_PORT:-9090}/health"
                   WARMUP_CONCURRENCY=${DOLLAR}{WARMUP_CONCURRENCY:-10}
                   WARMUP_ENABLED=${DOLLAR}{WARMUP_ENABLED:-auto}
                   case "${DOLLAR}WARMUP_ENABLED" in
@@ -122,8 +129,11 @@ spec:
                     echo "[warmup] curl not present; skipping cold-start warmup (non-fatal)"
                   else
                     for i in ${DOLLAR}(seq 1 360); do
-                      if curl -sf -o /dev/null --max-time 5 "${DOLLAR}FE/v1/models" 2>/dev/null; then
-                        echo "[warmup] worker registered; priming batch=1 Mamba decode kernel (one-time JIT, ~4min)"
+                      # Engine ready = leader /health is 200 AND the frontend lists this model
+                      # (the model only appears in /v1/models once the backend has registered).
+                      if curl -sf -o /dev/null --max-time 5 "${DOLLAR}LH" 2>/dev/null \
+                         && curl -sf --max-time 5 "${DOLLAR}FE/v1/models" 2>/dev/null | grep -q "${MODEL_NAME}"; then
+                        echo "[warmup] engine ready (leader /health 200 + model registered); priming batch=1 Mamba decode kernel (one-time JIT, ~4min)"
                         curl -s -o /dev/null --max-time 900 "${DOLLAR}FE/v1/completions" \
                           -H 'Content-Type: application/json' \
                           -d "{\"model\":\"${MODEL_NAME}\",\"prompt\":\"warmup\",\"max_tokens\":4,\"temperature\":0}" \

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws.yaml-template
@@ -174,6 +174,12 @@ spec:
               - { name: NATS_SERVER, value: "${NATS_URL}" }
               - { name: DYN_SYSTEM_ENABLED, value: "true" }
               - { name: DYN_SYSTEM_PORT, value: "9090" }
+              # Raise the multiproc-executor RPC deadline (default 300s) so a JIT-heavy first
+              # concurrent decode step (per-batch-size Mamba kernel Triton compile under an
+              # aiperf --concurrency N opening) cannot trip the timeout and kill EngineCore
+              # ("TimeoutError: RPC call to execute_model timed out" -> EngineDeadError -> pod
+              # restart loop). Harmless in steady state — real decode steps are ms.
+              - { name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS, value: "1800" }
               - { name: HF_HOME, value: /tmp/hf_cache }
               - { name: HF_MODULES_CACHE, value: /tmp/hf_cache/modules }
               - { name: VLLM_LOGGING_LEVEL, value: INFO }
@@ -304,6 +310,9 @@ spec:
               - { name: DYN_NAMESPACE, value: dynamo }
               - { name: ETCD_ENDPOINTS, value: "${ETCD_URL}" }
               - { name: NATS_SERVER, value: "${NATS_URL}" }
+              # Match the leader: raise the execute_model RPC deadline so a JIT-heavy first
+              # concurrent decode step can't trip the 300s default and kill this worker's shard.
+              - { name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS, value: "1800" }
               - { name: HF_HOME, value: /tmp/hf_cache }
               - { name: HF_MODULES_CACHE, value: /tmp/hf_cache/modules }
               - { name: FI_PROVIDER, value: efa }

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws.yaml-template
@@ -331,6 +331,12 @@ spec:
                 # suffix; set WARMUP_ENABLED=1/0 to force on/off.
                 (
                   FE="http://${DEPLOYMENT_NAME}-frontend.${NAMESPACE}.svc.cluster.local:8000"
+                  # Gate on the LEADER's own dyn-system /health (localhost:${DYN_SYSTEM_PORT}),
+                  # the same signal the startupProbe uses. The frontend answers /v1/models 200
+                  # ~15-18min BEFORE the engine finishes loading, so gating on the frontend fires
+                  # the warmup against a not-yet-ready engine and compiles nothing. The leader
+                  # /health only returns 200 once THIS role's engine is loaded + routes registered.
+                  LH="http://localhost:${DOLLAR}{DYN_SYSTEM_PORT:-9090}/health"
                   WARMUP_CONCURRENCY=${DOLLAR}{WARMUP_CONCURRENCY:-10}
                   WARMUP_ENABLED=${DOLLAR}{WARMUP_ENABLED:-auto}
                   case "${DOLLAR}WARMUP_ENABLED" in
@@ -344,8 +350,11 @@ spec:
                     echo "[warmup] curl not present; skipping cold-start warmup (non-fatal)"
                   else
                     for i in ${DOLLAR}(seq 1 360); do
-                      if curl -sf -o /dev/null --max-time 5 "${DOLLAR}FE/v1/models" 2>/dev/null; then
-                        echo "[warmup] worker registered; priming batch=1 Mamba decode kernel (one-time JIT, ~4min)"
+                      # Engine ready = leader /health is 200 AND the frontend lists this model
+                      # (the model only appears in /v1/models once the backend has registered).
+                      if curl -sf -o /dev/null --max-time 5 "${DOLLAR}LH" 2>/dev/null \
+                         && curl -sf --max-time 5 "${DOLLAR}FE/v1/models" 2>/dev/null | grep -q "${MODEL_NAME}"; then
+                        echo "[warmup] engine ready (leader /health 200 + model registered); priming batch=1 Mamba decode kernel (one-time JIT, ~4min)"
                         curl -s -o /dev/null --max-time 900 "${DOLLAR}FE/v1/completions" \
                           -H 'Content-Type: application/json' \
                           -d "{\"model\":\"${MODEL_NAME}\",\"prompt\":\"warmup\",\"max_tokens\":4,\"temperature\":0}" \

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws.yaml-template
@@ -131,6 +131,10 @@ spec:
               - { name: DYN_SYSTEM_PORT, value: "9091" }
               - { name: VLLM_LOGGING_LEVEL, value: INFO }
               - { name: VLLM_SSM_CONV_STATE_LAYOUT, value: DS }
+              # Raise the execute_model RPC deadline (default 300s) so a JIT-heavy first
+              # concurrent decode step (per-batch-size Mamba kernel Triton compile under an
+              # aiperf --concurrency N opening) cannot trip the timeout and kill EngineCore.
+              - { name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS, value: "1800" }
               - { name: VLLM_USE_RAY_COMPILED_DAG, value: "0"}
               - { name: FI_PROVIDER, value: efa }
               - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
@@ -216,6 +220,10 @@ spec:
               - { name: MY_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
               - { name: HF_HOME, value: /shared/hf_cache }
               - { name: VLLM_SSM_CONV_STATE_LAYOUT, value: DS }
+              # Raise the execute_model RPC deadline (default 300s) so a JIT-heavy first
+              # concurrent decode step (per-batch-size Mamba kernel Triton compile under an
+              # aiperf --concurrency N opening) cannot trip the timeout and kill EngineCore.
+              - { name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS, value: "1800" }
               - { name: VLLM_USE_RAY_COMPILED_DAG, value: "0" }
               - { name: FI_PROVIDER, value: efa }
               - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
@@ -400,6 +408,10 @@ spec:
               - { name: DYN_SYSTEM_ENABLED, value: "true" }
               - { name: DYN_SYSTEM_PORT, value: "9092" }
               - { name: VLLM_SSM_CONV_STATE_LAYOUT, value: DS }
+              # Raise the execute_model RPC deadline (default 300s) so a JIT-heavy first
+              # concurrent decode step (per-batch-size Mamba kernel Triton compile under an
+              # aiperf --concurrency N opening) cannot trip the timeout and kill EngineCore.
+              - { name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS, value: "1800" }
               - { name: VLLM_USE_RAY_COMPILED_DAG, value: "0" }
               - { name: FI_PROVIDER, value: efa }
               - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
@@ -480,6 +492,10 @@ spec:
               - { name: MY_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
               - { name: HF_HOME, value: /shared/hf_cache }
               - { name: VLLM_SSM_CONV_STATE_LAYOUT, value: DS }
+              # Raise the execute_model RPC deadline (default 300s) so a JIT-heavy first
+              # concurrent decode step (per-batch-size Mamba kernel Triton compile under an
+              # aiperf --concurrency N opening) cannot trip the timeout and kill EngineCore.
+              - { name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS, value: "1800" }
               - { name: VLLM_USE_RAY_COMPILED_DAG, value: "0" }
               - { name: ETCD_ENDPOINTS, value: "${ETCD_URL}" }
               - { name: NATS_SERVER, value: "${NATS_URL}" }


### PR DESCRIPTION
## What

Follow-up to #59/#60. The cold-start warmup used the **frontend** `/v1/models` as its "engine ready" gate — but the frontend binds and answers `/v1/models` **200 ~15-18min before** the leader's engine finishes loading. So the warmup fired against a not-yet-ready engine, its requests were no-ops, and it **compiled nothing** — the Mamba decode batch buckets were still cold when the real benchmark arrived.

## Evidence (live, HyperPod B200)

In a real run, the warmup log lines printed at pod second ~5:
```
[warmup] worker registered; priming batch=1 Mamba decode kernel ...
[warmup] concurrent batch buckets warm; benchmark opening will be fast
```
…but the engine didn't init until **+11min** (`Initializing a V1 LLM engine`) and routes weren't registered until **+18min** (`Registered engine routes`). Then aiperf `--concurrency 10` hit cold buckets and (pre the #NNN timeout raise) crashed the engine on the 300s `execute_model` RPC deadline.

## Fix

Gate on the **leader's own** dyn-system `/health` (`localhost:${DYN_SYSTEM_PORT}` — the exact signal the `startupProbe` uses; only 200 once the engine is loaded + routes registered) **and** require the frontend `/v1/models` to actually **list the served model** (it only appears once the backend registers). Only then warm.

- `${DYN_SYSTEM_PORT:-9090}` resolves per role (agg leader `9090`, disagg decode leader `9092`).
- Still detached, non-fatal, `curl`-guarded, NVFP4-gated (from #60).

## Verification
- ✅ Both templates render via `envsubst` (0 stray `${DOLLAR}`, valid YAML); the `localhost:${DYN_SYSTEM_PORT}` ref stays literal for the pod shell.
- ⚠️ The misfire it fixes was observed **live** on a B200 run; the corrected gate is render-verified but **not yet re-run on a fresh pod**. Happy to co-verify on the next cold start (expect `[warmup] engine ready (leader /health 200 + model registered)` only after the ~18min load, then the buckets pre-compile before traffic).

AI assistance (Claude) was used to author this change.