### PR TITLE
nemotron/ultra: remove /dev/infiniband hostPath — it silently disables EFA on B200 (fi_info -61, NCCL falls back to TCP)

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws-ep.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws-ep.yaml-template
@@ -61,7 +61,6 @@ spec:
                 topologyKey: kubernetes.io/hostname
         volumes:
           - { name: dshm,       emptyDir: { medium: Memory, sizeLimit: 64Gi } }
-          - { name: infiniband, hostPath: { path: /dev/infiniband, type: DirectoryOrCreate } }
           - { name: shared,     persistentVolumeClaim: { claimName: fsx-pvc } }
         containers:
           - name: vllm
@@ -138,7 +137,6 @@ spec:
               limits:   { cpu: "48", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
             volumeMounts:
               - { name: dshm,       mountPath: /dev/shm }
-              - { name: infiniband, mountPath: /dev/infiniband }
               - { name: shared,     mountPath: /shared }
     # -------------------------------------------------------------------------
     # WORKER = DP rank 1, headless (no API server), joins the leader's coordinator
@@ -160,7 +158,6 @@ spec:
                 topologyKey: kubernetes.io/hostname
         volumes:
           - { name: dshm,       emptyDir: { medium: Memory, sizeLimit: 64Gi } }
-          - { name: infiniband, hostPath: { path: /dev/infiniband, type: DirectoryOrCreate } }
           - { name: shared,     persistentVolumeClaim: { claimName: fsx-pvc } }
         containers:
           - name: vllm
@@ -229,7 +226,6 @@ spec:
               limits:   { cpu: "48", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
             volumeMounts:
               - { name: dshm,       mountPath: /dev/shm }
-              - { name: infiniband, mountPath: /dev/infiniband }
               - { name: shared,     mountPath: /shared }
 ---
 apiVersion: v1

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws.yaml-template
@@ -44,8 +44,6 @@ spec:
         volumes:
           - name: dshm
             emptyDir: { medium: Memory, sizeLimit: 64Gi }
-          - name: infiniband
-            hostPath: { path: /dev/infiniband, type: DirectoryOrCreate }
           - name: shared
             persistentVolumeClaim: { claimName: fsx-pvc }
         containers:
@@ -235,7 +233,6 @@ spec:
                 vpc.amazonaws.com/efa: "${EFA_PER_WORKER}"
             volumeMounts:
               - { name: dshm, mountPath: /dev/shm }
-              - { name: infiniband, mountPath: /dev/infiniband }
               - { name: shared, mountPath: /shared }
     workerTemplate:
       metadata:
@@ -261,8 +258,6 @@ spec:
         volumes:
           - name: dshm
             emptyDir: { medium: Memory, sizeLimit: 64Gi }
-          - name: infiniband
-            hostPath: { path: /dev/infiniband, type: DirectoryOrCreate }
           - name: shared
             persistentVolumeClaim: { claimName: fsx-pvc }
         containers:
@@ -354,7 +349,6 @@ spec:
                 vpc.amazonaws.com/efa: "${EFA_PER_WORKER}"
             volumeMounts:
               - { name: dshm, mountPath: /dev/shm }
-              - { name: infiniband, mountPath: /dev/infiniband }
               - { name: shared, mountPath: /shared }
 ---
 # Frontend Deployment (separate from LWS, runs on m5).

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/deployment.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/deployment.yaml-template
@@ -31,7 +31,6 @@ spec:
               topologyKey: kubernetes.io/hostname
       volumes:
         - { name: dshm, emptyDir: { medium: Memory, sizeLimit: 64Gi } }
-        - { name: infiniband, hostPath: { path: /dev/infiniband, type: DirectoryOrCreate } }
         - { name: shared, persistentVolumeClaim: { claimName: fsx-pvc } }
       containers:
         - name: vllm
@@ -81,7 +80,6 @@ spec:
             limits:   { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
           volumeMounts:
             - { name: dshm, mountPath: /dev/shm }
-            - { name: infiniband, mountPath: /dev/infiniband }
             - { name: shared, mountPath: /shared }
 ---
 apiVersion: apps/v1
@@ -106,7 +104,6 @@ spec:
               topologyKey: kubernetes.io/hostname
       volumes:
         - { name: dshm, emptyDir: { medium: Memory, sizeLimit: 64Gi } }
-        - { name: infiniband, hostPath: { path: /dev/infiniband, type: DirectoryOrCreate } }
         - { name: shared, persistentVolumeClaim: { claimName: fsx-pvc } }
       containers:
         - name: vllm
@@ -156,7 +153,6 @@ spec:
             limits:   { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
           volumeMounts:
             - { name: dshm, mountPath: /dev/shm }
-            - { name: infiniband, mountPath: /dev/infiniband }
             - { name: shared, mountPath: /shared }
 ---
 apiVersion: apps/v1

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd.yaml-template
@@ -88,7 +88,6 @@ spec:
                 topologyKey: kubernetes.io/hostname
         volumes:
           - { name: dshm,       emptyDir: { medium: Memory, sizeLimit: 64Gi } }
-          - { name: infiniband, hostPath: { path: /dev/infiniband, type: DirectoryOrCreate } }
           - { name: gdrdrv,     hostPath: { path: /dev/gdrdrv, type: CharDevice } }
         mainContainer:
           image: ${REGISTRY}${IMAGE}${TAG}
@@ -138,7 +137,6 @@ spec:
             failureThreshold: 240
           volumeMounts:
             - { name: dshm,       mountPath: /dev/shm }
-            - { name: infiniband, mountPath: /dev/infiniband }
             - { name: gdrdrv,     mountPath: /dev/gdrdrv }
     # ---- Decode worker (TP${GPU_PER_WORKER}/PP1, 1 node) ------------------
     VllmDecodeWorker:
@@ -162,7 +160,6 @@ spec:
                 topologyKey: kubernetes.io/hostname
         volumes:
           - { name: dshm,       emptyDir: { medium: Memory, sizeLimit: 64Gi } }
-          - { name: infiniband, hostPath: { path: /dev/infiniband, type: DirectoryOrCreate } }
           - { name: gdrdrv,     hostPath: { path: /dev/gdrdrv, type: CharDevice } }
         mainContainer:
           image: ${REGISTRY}${IMAGE}${TAG}
@@ -209,5 +206,4 @@ spec:
             failureThreshold: 240
           volumeMounts:
             - { name: dshm,       mountPath: /dev/shm }
-            - { name: infiniband, mountPath: /dev/infiniband }
             - { name: gdrdrv,     mountPath: /dev/gdrdrv }

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-ep.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-ep.yaml-template
@@ -49,7 +49,6 @@ spec:
                 topologyKey: kubernetes.io/hostname
         volumes:
           - { name: dshm,       emptyDir: { medium: Memory, sizeLimit: 64Gi } }
-          - { name: infiniband, hostPath: { path: /dev/infiniband, type: DirectoryOrCreate } }
           - { name: gdrdrv,     hostPath: { path: /dev/gdrdrv, type: CharDevice } }
           - { name: shared,     persistentVolumeClaim: { claimName: fsx-pvc } }
         containers:
@@ -115,7 +114,6 @@ spec:
               limits:   { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
             volumeMounts:
               - { name: dshm,       mountPath: /dev/shm }
-              - { name: infiniband, mountPath: /dev/infiniband }
               - { name: gdrdrv,     mountPath: /dev/gdrdrv }
               - { name: shared,     mountPath: /shared }
     workerTemplate:
@@ -139,7 +137,6 @@ spec:
                 topologyKey: kubernetes.io/hostname
         volumes:
           - { name: dshm,       emptyDir: { medium: Memory, sizeLimit: 64Gi } }
-          - { name: infiniband, hostPath: { path: /dev/infiniband, type: DirectoryOrCreate } }
           - { name: gdrdrv,     hostPath: { path: /dev/gdrdrv, type: CharDevice } }
           - { name: shared,     persistentVolumeClaim: { claimName: fsx-pvc } }
         containers:
@@ -206,7 +203,6 @@ spec:
               limits:   { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
             volumeMounts:
               - { name: dshm,       mountPath: /dev/shm }
-              - { name: infiniband, mountPath: /dev/infiniband }
               - { name: gdrdrv,     mountPath: /dev/gdrdrv }
               - { name: shared,     mountPath: /shared }
 ---

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-pp.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-pp.yaml-template
@@ -53,7 +53,6 @@ spec:
                 topologyKey: kubernetes.io/hostname
         volumes:
           - { name: dshm,       emptyDir: { medium: Memory, sizeLimit: 64Gi } }
-          - { name: infiniband, hostPath: { path: /dev/infiniband, type: DirectoryOrCreate } }
           - { name: gdrdrv,     hostPath: { path: /dev/gdrdrv, type: CharDevice } }
           - { name: shared,     persistentVolumeClaim: { claimName: fsx-pvc } }
         containers:
@@ -135,7 +134,6 @@ spec:
               limits:   { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
             volumeMounts:
               - { name: dshm,       mountPath: /dev/shm }
-              - { name: infiniband, mountPath: /dev/infiniband }
               - { name: gdrdrv,     mountPath: /dev/gdrdrv }
               - { name: shared,     mountPath: /shared }
     workerTemplate:
@@ -156,7 +154,6 @@ spec:
                 topologyKey: kubernetes.io/hostname
         volumes:
           - { name: dshm,       emptyDir: { medium: Memory, sizeLimit: 64Gi } }
-          - { name: infiniband, hostPath: { path: /dev/infiniband, type: DirectoryOrCreate } }
           - { name: gdrdrv,     hostPath: { path: /dev/gdrdrv, type: CharDevice } }
           - { name: shared,     persistentVolumeClaim: { claimName: fsx-pvc } }
         containers:
@@ -202,7 +199,6 @@ spec:
               limits:   { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
             volumeMounts:
               - { name: dshm,       mountPath: /dev/shm }
-              - { name: infiniband, mountPath: /dev/infiniband }
               - { name: gdrdrv,     mountPath: /dev/gdrdrv }
               - { name: shared,     mountPath: /shared }
 ---
@@ -242,7 +238,6 @@ spec:
                 topologyKey: kubernetes.io/hostname
         volumes:
           - { name: dshm,       emptyDir: { medium: Memory, sizeLimit: 64Gi } }
-          - { name: infiniband, hostPath: { path: /dev/infiniband, type: DirectoryOrCreate } }
           - { name: gdrdrv,     hostPath: { path: /dev/gdrdrv, type: CharDevice } }
           - { name: shared,     persistentVolumeClaim: { claimName: fsx-pvc } }
         containers:
@@ -307,7 +302,6 @@ spec:
               limits:   { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
             volumeMounts:
               - { name: dshm,       mountPath: /dev/shm }
-              - { name: infiniband, mountPath: /dev/infiniband }
               - { name: gdrdrv,     mountPath: /dev/gdrdrv }
               - { name: shared,     mountPath: /shared }
 ---

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws.yaml-template
@@ -69,7 +69,6 @@ spec:
         #  - name: dynamo-efa-pull
         volumes:
           - { name: dshm,        emptyDir: { medium: Memory, sizeLimit: 64Gi } }
-          - { name: infiniband,  hostPath: { path: /dev/infiniband, type: DirectoryOrCreate } }
           - { name: gdrdrv,      hostPath: { path: /dev/gdrdrv, type: CharDevice } }
           - { name: shared,      persistentVolumeClaim: { claimName: fsx-pvc } }
         containers:
@@ -160,7 +159,6 @@ spec:
               limits:   { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
             volumeMounts:
               - { name: dshm,       mountPath: /dev/shm }
-              - { name: infiniband, mountPath: /dev/infiniband }
               - { name: gdrdrv,     mountPath: /dev/gdrdrv }
               - { name: shared,     mountPath: /shared }
     workerTemplate:
@@ -188,7 +186,6 @@ spec:
         #  - name: dynamo-efa-pull
         volumes:
           - { name: dshm,       emptyDir: { medium: Memory, sizeLimit: 64Gi } }
-          - { name: infiniband, hostPath: { path: /dev/infiniband, type: DirectoryOrCreate } }
           - { name: gdrdrv,     hostPath: { path: /dev/gdrdrv, type: CharDevice } }
           - { name: shared,     persistentVolumeClaim: { claimName: fsx-pvc } }
         containers:
@@ -241,7 +238,6 @@ spec:
               limits:   { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
             volumeMounts:
               - { name: dshm,       mountPath: /dev/shm }
-              - { name: infiniband, mountPath: /dev/infiniband }
               - { name: gdrdrv,     mountPath: /dev/gdrdrv }
               - { name: shared,     mountPath: /shared }
 ---
@@ -282,7 +278,6 @@ spec:
         #imagePullSecrets: [{ name: dynamo-efa-pull }]
         volumes:
           - { name: dshm,       emptyDir: { medium: Memory, sizeLimit: 64Gi } }
-          - { name: infiniband, hostPath: { path: /dev/infiniband, type: DirectoryOrCreate } }
           - { name: gdrdrv,     hostPath: { path: /dev/gdrdrv, type: CharDevice } }
           - { name: shared,     persistentVolumeClaim: { claimName: fsx-pvc } }
         containers:
@@ -436,7 +431,6 @@ spec:
               limits:   { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
             volumeMounts:
               - { name: dshm,       mountPath: /dev/shm }
-              - { name: infiniband, mountPath: /dev/infiniband }
               - { name: gdrdrv,     mountPath: /dev/gdrdrv }
               - { name: shared,     mountPath: /shared }
     workerTemplate:
@@ -460,7 +454,6 @@ spec:
         #imagePullSecrets: [{ name: dynamo-efa-pull }]
         volumes:
           - { name: dshm,       emptyDir: { medium: Memory, sizeLimit: 64Gi } }
-          - { name: infiniband, hostPath: { path: /dev/infiniband, type: DirectoryOrCreate } }
           - { name: gdrdrv,     hostPath: { path: /dev/gdrdrv, type: CharDevice } }
           - { name: shared,     persistentVolumeClaim: { claimName: fsx-pvc } }
         containers:
@@ -513,7 +506,6 @@ spec:
               limits:   { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
             volumeMounts:
               - { name: dshm,       mountPath: /dev/shm }
-              - { name: infiniband, mountPath: /dev/infiniband }
               - { name: gdrdrv,     mountPath: /dev/gdrdrv }
               - { name: shared,     mountPath: /shared }
 ---


### PR DESCRIPTION
## TL;DR

**The `/dev/infiniband` hostPath mount in every nemotron/ultra manifest silently breaks EFA on your B200 HyperPod nodes.** Removing it makes `fi_info -p efa` work with zero other changes. This also explains the flat EFA hw_counters you observed on 08-08/09 — all cross-node traffic (PP2 activations, EP16 MoE all-to-all) has been going over **TCP**.

## Measured A/B (your cluster, same image `dynamo-vllm-efa:1.3.1-patched`)

| Pod spec | /dev/infiniband contents | `fi_info -p efa` |
|---|---|---|
| **WITH hostPath** (today's manifests) | 10 uverbs: 8 EFA + 2 **mlx5** (`ibp115s0f0/116s0f0`) + umad/issm | **-61 No data available** |
| **plugin-only** (hostPath removed) | exactly the 8 EFA uverbs the device plugin allocated | **24 provider entries (efa + efa-direct)** ✅ |
| plugin-only, **same node** as the failing pod (control) | 8 EFA uverbs | 24 entries ✅ — node state ruled out |

## Mechanism

B200 HyperPod nodes carry **mlx5 NICs alongside the 8 EFA devices**. The hostPath exposes ALL of `/dev/infiniband` — including the mlx5 uverbs nodes. libfabric's EFA provider iterates `ibv_get_device_list()` and must `ibv_open_device()` **every** device to read its GID (`efa_device_list_initialize()` → `efa_device_construct_gid()`); the mlx5 devices fail to open in-container (errno 2) and provider init **aborts** → empty provider list → `-61` → aws-ofi-nccl `No eligible providers were found` → NCCL **NET/Socket (TCP)** fallback. Verified in your running ep16 pods: per-device open test shows all 8 `rdmap*` OPEN-OK, both `ibp*` OPEN-FAIL, and NCCL_DEBUG shows every channel on `NET/Socket`.

The mount was never needed — `vpc.amazonaws.com/efa` device-plugin allocation injects the EFA uverbs devices by itself. On p5en (EFA-only rdmap devices) the mount was harmless surplus, which is why it never bit before.

## Change

Removes the `infiniband` volume + volumeMount from all 7 nemotron/ultra manifests (agg `lws`/`lws-ep16`, disagg `lws`/`lws-pp`/`ep`/`deployment`/`dgd`). No other edits. All templates envsubst-render + YAML-parse.

## After merging

Redeploy any running LWS/deployment and EFA engages immediately (worth re-running aiperf — EP16 especially, since MoE all-to-all is the EFA-heavy path). I can patch your live ep16 group and verify the hw_counter delta if you want it proven before you merge.