### PR TITLE
nemotron/ultra: ep16 -frontend Service alias — test suite works unchanged

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws-ep16.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws-ep16.yaml-template
@@ -215,3 +215,19 @@ metadata:
 spec:
   selector: { app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}-ep16, app.kubernetes.io/component: agg-ep16, dp-role: leader }
   ports: [ { port: 8000, targetPort: 8000, name: http } ]
+---
+# Frontend-name alias for the test suite. The ep16 topology has no separate
+# Dynamo frontend (vLLM-native DP: the LEADER pod runs the OpenAI server), but
+# test/ scripts and benchmarks target ${DEPLOYMENT_NAME}-frontend. This alias
+# keeps them working unchanged for MANIFEST_TYPE=ep16. Deploy ONE manifest
+# type at a time: the lws/deployment/dgd types create a real
+# ${DEPLOYMENT_NAME}-frontend and would collide with this alias.
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${DEPLOYMENT_NAME}-frontend
+  namespace: ${NAMESPACE}
+  labels: { app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}-ep16, app.kubernetes.io/component: agg-ep16 }
+spec:
+  selector: { app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}-ep16, app.kubernetes.io/component: agg-ep16, dp-role: leader }
+  ports: [ { port: 8000, targetPort: 8000, name: http } ]


### PR DESCRIPTION
Bakes in what you did by hand tonight ("I exposed the vllm worker via service called nemotron3-ultra-550b-agg-frontend ... then the tests work").

**Why ep16 has no frontend:** it's vLLM-native data parallelism — the LEADER pod itself runs the OpenAI API server; there's no Dynamo runtime in the path, so no separate frontend deployment. But `test/.env` points every script at `${DEPLOYMENT_NAME}-frontend`, so ep16 needed a manual Service to be testable.

**Change:** `agg/lws-ep16.yaml-template` now renders an additional Service named `${DEPLOYMENT_NAME}-frontend` selecting the ep16 leader — `./test-chat-completions.sh` / `./test-aiperf.sh` work with zero overrides. One caveat documented in the template: deploy one MANIFEST_TYPE at a time, since lws/deployment/dgd create the real `-frontend` under the same name.

Renders to 3 docs, YAML-parses. Note: your hand-made Service will conflict with a re-apply of this manifest — `kubectl delete svc nemotron3-ultra-550b-agg-frontend` first (or just let this template own it going forward).