### PR TITLE
nemotron/ultra: fix PP1 hybrid-Mamba disagg moving 0 KV bytes (descriptor-id overflow)

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/dynamo-vllm-efa/Dockerfile
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/dynamo-vllm-efa/Dockerfile
@@ -2,7 +2,8 @@
 #
 # Author: Anton Alexander
 #
-# Covers every scenario: aggregated, EP16 (DP2/TP8), and PP>1 hybrid-Mamba disagg (NIXL).
+# Covers every scenario: aggregated, EP16 (DP2/TP8), and hybrid-Mamba disagg (NIXL) at
+# BOTH PP>1 (step 3) and PP1 (step 3b).
 #
 # FULLY PUBLIC, DOCKERFILE-ONLY REPRODUCIBLE: no gist, no external files, no patch step,
 # no fork refs. Anyone can `docker build` this with only public network access.
@@ -13,6 +14,12 @@
 # The PP>1 fix is fetched at build time from vLLM PR #48263's own pull-ref on UPSTREAM
 # github.com/vllm-project/vllm (the PR head IS the E2E-tested revision, SHA-pinned).
 # When #48263 merges into the Dynamo-pinned vLLM, delete the OVERLAY stage entirely.
+#
+# #48263 deliberately does NOT touch the vectorized PP1 fast path, and that path
+# overflows its descriptor list on hybrid (Mamba2+FullAttention) models -- PP1 disagg
+# returns HTTP 200 while transferring ZERO KV bytes. Step 3b is a surgical, md5-pinned
+# edit of the file step 3 fetches, which closes that case. It is a DELTA ON THE OVERLAY:
+# the two are retired together.
 #
 # ---------------------------------------------------------------------------------------
 # BASE: 1.3.1-efa. Verified contents (docker run --rm, 2026-08-06) — this drove which
@@ -114,6 +121,165 @@ RUN set -eux; \
       print('[overlay] tested fix branch applied + v8 marker present + all compile')"; \
     rm -rf /tmp/vllm-fix
 
+# ---- 3b) FIX: PP1 hybrid-Mamba descriptor-id overflow (follow-up to #48263) ----------
+#    SYMPTOM this fixes, on the image built WITHOUT this step: every PP1
+#    disaggregated request against a hybrid (Mamba2 + FullAttention) model
+#    returns HTTP 200 but moves ZERO KV bytes. The decode worker logs
+#      "makeXferReq: local index out of range at index 192 with value 26357617"
+#    -> NIXL_ERR_INVALID_PARAM -> the transfer is dropped and decode silently
+#    recomputes the whole prefill. Nothing crashes, so it is easy to mistake for
+#    "disagg works, EFA is just idle".
+#
+#    ROOT CAUSE: #48263 deliberately does not touch the vectorized PP1 fast
+#    path, and that path is only valid when the dlist it indexes spans every
+#    local region at whole-engine counts. For a hybrid model the per-remote
+#    handle is built from the producer's registered_layer_names with the SSM-only
+#    filter, while _compute_desc_ids derives its SSM region count from the
+#    whole-engine (re-advertised, #46407-grown) self.block_len_per_layer. The
+#    SSM count therefore overshoots what the dlist actually holds and the first
+#    phantom region's desc id lands past the end. The FullAttention half is
+#    coincidentally consistent, so ONLY the SSM count diverges -- which is why
+#    this reproduces on hybrids and never on pure-attention models.
+#    _get_block_descs_ids_for_shard takes BOTH counts from the recorded xfer
+#    layout, so its ids are in-bounds by construction and it already asserts
+#    max(desc_id) < num_descs. The fix routes hybrids there and leaves the fast
+#    path untouched for pure-attention models (the common case).
+#
+#    MEASURED, same overlay + same patch (a returning request is NOT evidence --
+#    only the read-counter delta is):
+#      * 550B TP8/PP1 on p6-b200: 0 -> 584 MiB KV per request, 816 makeXferReq
+#        errors -> 0, needle recall 4/4.
+#      * Hybrid PP1 2-node p5en/H200, prefill and decode on SEPARATE nodes:
+#        byte-identical output vs the aggregated control, and the decode node's
+#        EFA rdma_read_bytes counter moved by the connector's own byte count.
+#      * Reproduced 3x before the fix (desc value 335665 / 423582 / 26357617).
+#
+#    Applied as a surgical, anchored edit of the file step 3 just fetched -- NOT
+#    a second overlay -- so the two must stay in lockstep. Both anchors are
+#    asserted unique before the edit and the RESULT is md5-pinned to the exact
+#    bytes that produced the measurements above; if #48263's head moves and
+#    reflows either anchor, this fails at build time instead of shipping an
+#    unmeasured image.
+#
+#    RETIRE THIS STEP when the fast-path guard lands in the Dynamo-pinned vLLM
+#    (or in #48263 itself) -- then the md5 assert below fails loud and you delete
+#    3b, exactly as step 1 and the FLASHINFER fence were retired.
+ARG NIXL_WORKER_MD5_PRISTINE=7c4871726d013e79ecd1e62249e523c2
+ARG NIXL_WORKER_MD5_FIXED=93ef4a4e1aa3b191fcdb3bd194238185
+RUN set -eux; \
+    NIXL_WORKER_MD5_PRISTINE=7c4871726d013e79ecd1e62249e523c2 \
+    NIXL_WORKER_MD5_FIXED=93ef4a4e1aa3b191fcdb3bd194238185 \
+    python3 - <<'PY'
+import hashlib, importlib.util, os, py_compile
+
+nixl = os.path.join(
+    importlib.util.find_spec("vllm").submodule_search_locations[0],
+    "distributed", "kv_transfer", "kv_connector", "v1", "nixl")
+path = os.path.join(nixl, "worker.py")
+src = open(path).read()
+
+want_pristine = os.environ["NIXL_WORKER_MD5_PRISTINE"]
+want_fixed = os.environ["NIXL_WORKER_MD5_FIXED"]
+got = hashlib.md5(src.encode()).hexdigest()
+assert got == want_pristine, (
+    f"step 3 produced worker.py md5 {got}, expected {want_pristine}. PR#48263's "
+    "head moved -- re-validate the fix against the new revision before bumping "
+    "VLLM_FIX_SHA and the md5 pins here.")
+
+# Hunk 1: refuse the whole-engine layout for hybrids instead of computing
+# plausible-but-out-of-range ids.
+A1_OLD = '''\
+        """Compute NIXL descriptor IDs for given block IDs."""
+        num_fa_regions = self.num_regions
+'''
+A1_NEW = '''\
+        """Compute NIXL descriptor IDs for given block IDs."""
+        # P6' FIX-3 invariant: this whole-engine layout is only valid when the
+        # dlist being indexed spans every local region at whole-engine counts.
+        # A hybrid model's per-remote handle is built from the producer's
+        # registered_layer_names with the FIX-2 SSM-only filter, so the counts
+        # below (self.num_regions / len(self.block_len_per_layer), both grown by
+        # the #46407 re-advertise) overshoot its mamba section. Hybrid transfers
+        # are routed to _get_block_descs_ids_for_shard in _read_blocks; assert
+        # here so a future caller gets a loud failure instead of an
+        # out-of-range desc id (or, worse, in-bounds ids at wrong offsets).
+        assert not self._has_mamba, (
+            "_compute_desc_ids is whole-engine-layout only; hybrid/HMA models "
+            "must use _get_block_descs_ids_for_shard (P6' FIX-3)"
+        )
+        num_fa_regions = self.num_regions
+'''
+
+# Hunk 2: route hybrid/HMA transfers off the fast path.
+A2_OLD = '''\
+        # proven P1->D1 / P2->D1 topologies (consumer PP==1, no BUG-10 filtering).
+        _consumer_single_stage = (
+            self.vllm_config.parallel_config.pipeline_parallel_size == 1
+        )
+        if self._remote_pp_size[dst_engine_id] == 1 and _consumer_single_stage:
+'''
+A2_NEW = '''\
+        # proven P1->D1 / P2->D1 topologies (consumer PP==1, no BUG-10 filtering).
+        #
+        # P6' FIX-3 (hybrid P1->D1 desc-id overflow, measured 3x: cgk H200
+        # 2026-07-08 value=335665, cgk H200 2026-07-26 value=423582, B200
+        # 550B 2026-08-14 value=26357617): the "fast path preserved for the
+        # proven P1->D1" claim above does NOT hold once the model is hybrid AND
+        # the producer re-advertises dedup'd members (P6' FIX-2 / vLLM #46407).
+        # Reason: the local handle this xfer indexes is NOT the whole-engine
+        # init-time dlist -- _read_blocks receives
+        # src_xfer_handles_by_remote[(engine, pp_rank, remote_block_size)],
+        # which register_local_xfer_handler built from the producer's
+        # registered_layer_names, applying the FIX-2 SSM-only filter to the
+        # mamba section (len(_ssm_layer_names(registered)) * 4 desc-groups).
+        # _compute_desc_ids instead derives its SSM region count from the
+        # whole-engine, FIX-2-GROWN self.block_len_per_layer (len * 4), so it
+        # addresses more SSM regions than that dlist contains and the first
+        # phantom region's desc id lands past the end:
+        #   bad_id = num_fa_descs + n_ssm_regions_registered * logical + block
+        # nixl then correctly rejects the prepped xfer with
+        # "makeXferReq: local index out of range" -> NIXL_ERR_INVALID_PARAM ->
+        # 0 KV bytes on every request (decode silently recomputes prefill).
+        # The FA half is coincidentally consistent (both sides are 2x the
+        # registered region count), so ONLY the SSM count diverges.
+        # _get_block_descs_ids_for_shard has no such divergence: it takes BOTH
+        # counts from _xfer_desc_layouts[(engine, pp_rank, side)] -- the layout
+        # recorded from the same registered_layer_names the dlist was built
+        # from -- so ids are in-bounds by construction, it skips SSM-group
+        # regions in the FA loop instead of reading Mamba bytes at FA stride,
+        # and it asserts max(desc_id) < num_descs before returning. That path is
+        # also the one measured moving correct KV on this same overlay+model
+        # (P2->D1, +1.53 GB/req, 2026-08-12). So: keep the vectorized fast path
+        # for pure-attention models (unaffected, and it stays the common case),
+        # and route every hybrid/HMA transfer through the layout-derived path.
+        _consumer_single_stage = (
+            self.vllm_config.parallel_config.pipeline_parallel_size == 1
+        )
+        if (
+            self._remote_pp_size[dst_engine_id] == 1
+            and _consumer_single_stage
+            and not self._has_mamba
+        ):
+'''
+
+for name, old in (("A1", A1_OLD), ("A2", A2_OLD)):
+    n = src.count(old)
+    assert n == 1, f"anchor {name} found {n}x (expected 1) -- upstream reflowed it"
+
+src = src.replace(A1_OLD, A1_NEW, 1).replace(A2_OLD, A2_NEW, 1)
+
+got = hashlib.md5(src.encode()).hexdigest()
+assert got == want_fixed, (
+    f"patched worker.py md5 {got} != measured {want_fixed} -- the image would "
+    "differ from the one that was gated; refusing to build.")
+
+open(path, "w").write(src)
+py_compile.compile(path, doraise=True)
+assert "whole-engine-layout only" in open(path).read()  # unique to this fix
+print(f"[fix-3] PP1 hybrid fast-path bypass applied; worker.py md5 {got} "
+      "(byte-identical to the gated image)")
+PY
+
 # ---- 4) CVE remediation: drop worker-UNUSED /usr/bin/nats-server --------------------
 #    Carries the image's sole CRITICAL (CVE-2025-68121, Go stdlib). GA STILL bakes it
 #    (16MB, verified) — not converged. The deploy uses an EXTERNAL nats pod, so this
@@ -124,17 +290,29 @@ RUN rm -f /usr/bin/nats-server || true
 
 # ---- 5) Final assert: every scenario's prerequisites present in ONE image ------------
 RUN set -eux; \
+    NIXL_WORKER_MD5_FIXED=93ef4a4e1aa3b191fcdb3bd194238185 \
     python3 - <<'PY'
-import importlib.metadata as m, importlib.util, os, subprocess
+import hashlib, importlib.metadata as m, importlib.util, os, subprocess
 need = {"vllm": "0.23", "ai-dynamo": "1.3", "ray": "2.55.1", "transformers": "5.13.0"}
 for p, want in need.items():
     got = m.version(p); assert got.startswith(want), f"{p} {got} !~ {want}"
 b = importlib.util.find_spec("vllm").submodule_search_locations[0]
 md = os.path.join(b, "distributed/kv_transfer/kv_connector/v1/nixl/metadata.py")
 assert "NIXL_CONNECTOR_VERSION: int = 8" in open(md).read(), "PP>1 overlay missing"
+w = os.path.join(b, "distributed/kv_transfer/kv_connector/v1/nixl/worker.py")
+# NOTE: do NOT assert on "and not self._has_mamba" alone -- that string already
+# occurs twice in the UNPATCHED file (a PP filter and a use_mla guard), so its
+# presence proves nothing. Pin the md5 step 3b produced: exact, and it is the
+# revision the measurements in 3b were taken on.
+got = hashlib.md5(open(w, "rb").read()).hexdigest()
+assert got == os.environ["NIXL_WORKER_MD5_FIXED"], (
+    f"worker.py md5 {got} is not the FIX-3 revision step 3b produces "
+    f"({os.environ['NIXL_WORKER_MD5_FIXED']}); PP1 hybrid disagg would return 200 "
+    "and move 0 KV bytes")
 assert os.path.exists("/opt/amazon/efa/bin/fi_info"), "EFA userspace missing"
 assert not os.path.exists("/usr/bin/nats-server"), "nats-server still present (CRITICAL CVE)"
-print("[golden] agg + EP16 + PP>1 prerequisites all present; EFA present; 0-CRITICAL precondition met")
+print("[golden] agg + EP16 + PP>1 + PP1-hybrid prerequisites all present; EFA present; "
+      "0-CRITICAL precondition met")
 PY
 
 # ---- 6) NVFP4 fix: make flashinfer's cubin package dir writable ----------------------
@@ -165,6 +343,6 @@ RUN set -eux; \
     echo "[nvfp4-cubin-fix] ${CUBINS} made writable (chmod -R a+rwX; subtree left empty for the worker to own)"
 
 USER dynamo
-LABEL org.opencontainers.image.description="Golden image: Dynamo 1.3.1 (-efa base, EFA 1.49 baked) + vLLM 0.23 + ray 2.55.1 + vLLM PR#48263 overlay (agg + EP16 + PP>1, Dockerfile-only reproducible)"
+LABEL org.opencontainers.image.description="Golden image: Dynamo 1.3.1 (-efa base, EFA 1.49 baked) + vLLM 0.23 + ray 2.55.1 + vLLM PR#48263 overlay + PP1 hybrid-Mamba descriptor-id fix (agg + EP16 + PP>1 + PP1 disagg, Dockerfile-only reproducible)"
 LABEL org.opencontainers.image.source="https://github.com/vllm-project/vllm/pull/48263"
 


### PR DESCRIPTION
## What breaks today

On the image `dynamo-vllm-efa/Dockerfile` builds, **PP1 disaggregated serving of a hybrid (Mamba2 + FullAttention) model returns HTTP 200 while transferring ZERO KV bytes.** The decode worker logs:

```
makeXferReq: local index out of range at index 192 with value 26357617
-> NIXL_ERR_INVALID_PARAM
```

The transfer is dropped and decode silently recomputes the whole prefill. Nothing crashes and every request looks healthy, so it presents as *"disagg works, EFA is just idle"* — the KV cache never moves and the disaggregation buys nothing. This is the failure mode that makes a P/D deployment look correct while delivering aggregated behaviour at 2× the GPUs.

## Why

PR [vllm-project/vllm#48263](https://github.com/vllm-project/vllm/pull/48263), which step 3 overlays, deliberately does **not** touch the vectorized PP1 fast path. That path is only valid when the descriptor list it indexes spans every local region at whole-engine counts. For a hybrid model:

* the per-remote handle is built from the producer's `registered_layer_names` with the **SSM-only filter**, but
* `_compute_desc_ids` derives its SSM region count from the whole-engine (re-advertised) `self.block_len_per_layer`.

So the SSM count overshoots what the list actually holds, and the first phantom region's descriptor id lands past the end. The FullAttention half is coincidentally consistent, which is why **only** the SSM count diverges — and why this reproduces on hybrids and never on pure-attention models.

## The fix — new step 3b

Route hybrid/HMA transfers off the fast path onto `_get_block_descs_ids_for_shard`, which takes *both* counts from the recorded transfer layout and already asserts `max(desc_id) < num_descs`, so its ids are in-bounds by construction. Pure-attention models keep the fast path unchanged. An assert on `_compute_desc_ids` documents the whole-engine-layout precondition so a future caller cannot reintroduce the same overshoot silently.

It is applied as a **surgical, anchored edit of the file step 3 fetches** — not a second overlay — so the two stay in lockstep:

* both anchors are asserted **unique** before the edit;
* the input is md5-pinned to `refs/pull/48263/head` at the already-pinned `VLLM_FIX_SHA`;
* the **result** is md5-pinned to the exact bytes that produced the measurements below.

If #48263's head moves and reflows either anchor, **the build fails loudly instead of shipping an unmeasured image.** Step 5 now also asserts the marker, since an image missing 3b boots fine and fails only at runtime, in the silent way described above.

## Measured

A request that returns is not evidence — only the read-counter delta is. Both runs used this Dockerfile's own output.

| | 550B TP8/PP1, p6-b200 | Hybrid PP1, 2× p5en.48xlarge (**separate nodes**) |
|---|---|---|
| KV moved / request | **0 → 584 MiB** | **203.5 MiB** @ 18.9 GB/s |
| `makeXferReq` errors | **816 → 0** | **0** |
| Successful transfers | — | 1 (0 failed, 1012 descriptors) |
| Output correctness | needle recall 4/4 | **byte-identical to the aggregated control** |
| Decode-node EFA `rdma_read_bytes` delta | — | **213,352,448 B** |

On the 2-node run the EFA hardware counter delta equals the connector's own byte count exactly (213,352,448 = 213,352,448) — two accountings that share no code. `rdma_write` delta was 0, as expected since the consumer issues the READ. The overflow signature appears **zero** times in either worker log.

## Scope / retirement

* One file changed. No behaviour change for pure-attention models or for the PP>1 path.
* `docker build --check`: clean, no warnings.
* **Retire step 3b together with the step 3 overlay**, once the fast-path guard lands in the Dynamo-pinned vLLM. The md5 assert will fail loudly at that point, exactly as the retired EFA-install layer and FLASHINFER fence did.

Draft while the corresponding upstream vLLM fix is prepared, so the two can be cross-referenced.

## By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
