### PR TITLE
Fix Nemotron-3 Ultra disagg templates to schedule out of the box on an all-GPU (p6-b200) cluster

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/.env
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/.env
@@ -23,10 +23,25 @@ export MANIFEST_TYPE=${MANIFEST_TYPE:-deployment}
 # The model's expert count must be divisible by the EP degree (Nemotron-3-Ultra + Qwen3-235B: yes;
 # Mixtral's 8 experts: no - it cannot run EP16).
 export EP_DP_SIZE=${EP_DP_SIZE:-2}
-export INSTANCE_TYPE_FRONTEND=m5.8xlarge
-export INSTANCE_TYPE_WORKER=p5en.48xlarge
-export GPU_PER_WORKER=8
-export EFA_PER_WORKER=16
+# ---- Cluster shape ----
+# All ${VAR:-default} so a different accelerator is a one-liner and needs no edit here:
+#   INSTANCE_TYPE_WORKER=p6-b200.48xlarge EFA_PER_WORKER=<node allocatable> ./run.sh
+# INSTANCE_TYPE_FRONTEND is a *preference*, not a requirement: the frontend prefers this
+# instance type and falls back to any schedulable node (incl. a GPU node) when the cluster
+# has none, so an all-GPU cluster does not leave the router Pending.
+export INSTANCE_TYPE_FRONTEND=${INSTANCE_TYPE_FRONTEND:-m5.8xlarge}
+export INSTANCE_TYPE_WORKER=${INSTANCE_TYPE_WORKER:-p5en.48xlarge}
+export GPU_PER_WORKER=${GPU_PER_WORKER:-8}
+# EFA_PER_WORKER must match what the EFA device plugin advertises on YOUR instance type - read
+# it, do not assume it, or the GPU pods sit Pending on Insufficient vpc.amazonaws.com/efa:
+#   kubectl get node <node> -o jsonpath='{.status.allocatable.vpc\.amazonaws\.com/efa}{"\n"}'
+export EFA_PER_WORKER=${EFA_PER_WORKER:-16}
+# Per-GPU-pod CPU/memory budget, requests == limits (Guaranteed QoS, and exclusive cores when
+# the kubelet runs the static CPU manager policy). 48 is the portable default - it fits both
+# p5en.48xlarge and p6-b200.48xlarge and leaves headroom for the EFA/GPU DaemonSets. The old
+# hardcoded cpu: 96 was a p5en-only assumption; set CPU_PER_WORKER=96 to restore it.
+export CPU_PER_WORKER=${CPU_PER_WORKER:-48}
+export MEM_PER_WORKER=${MEM_PER_WORKER:-1000Gi}
 # ---- Model precision toggle (Author: Anton Alexander) ----
 # Switch between the full-precision BF16 checkpoint and the NVFP4 (4-bit) checkpoint
 # WITHOUT editing the templates. BF16 is the default; set MODEL_VARIANT=NVFP4 to switch.

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/deployment.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/deployment.yaml-template
@@ -7,6 +7,14 @@
 # Mamba "External KV connector not verified yet" assertion that blocked the unpatched build.
 # KV transferred prefill->decode over EFA RDMA via NIXL LIBFABRIC. Single-node-per-role uses the
 # same OOM-avoidance recipe as agg (gpu-util 0.97, max-model-len 4096, enforce-eager).
+#
+# PORTABILITY 2026-08-15 (all-GPU clusters such as p6-b200, verified against a live v1.35
+# scheduler - see PR): the podAntiAffinity selector matches only the GPU roles, because a bare
+# `part-of` match also selects the frontend pod and required anti-affinity is enforced against
+# EXISTING pods too - every node holding a GPU pod then rejects the frontend with "didn't satisfy
+# existing pods anti-affinity rules", which strands it on a cluster with no spare CPU node. The
+# frontend now PREFERS INSTANCE_TYPE_FRONTEND instead of requiring it, and cpu/memory come from
+# CPU_PER_WORKER / MEM_PER_WORKER in .env (the old hardcoded cpu: "96" was p5en-only).
 # =========================================================================================================
 ---
 apiVersion: apps/v1
@@ -27,7 +35,12 @@ spec:
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector: { matchLabels: { app.kubernetes.io/part-of: ${DEPLOYMENT_NAME} } }
+            - labelSelector:
+                matchExpressions:
+                  # GPU roles ONLY. A bare part-of match also selects the frontend pod, and
+                  # required anti-affinity is enforced against EXISTING pods too - see header.
+                  - { key: app.kubernetes.io/part-of,   operator: In, values: [ "${DEPLOYMENT_NAME}" ] }
+                  - { key: app.kubernetes.io/component, operator: In, values: [ prefill, decode ] }
               topologyKey: kubernetes.io/hostname
       volumes:
         - { name: dshm, emptyDir: { medium: Memory, sizeLimit: 64Gi } }
@@ -76,8 +89,8 @@ spec:
           ports: [ { containerPort: 9091, name: dyn-system } ]
           startupProbe: { httpGet: { path: /health, port: 9091 }, periodSeconds: 30, timeoutSeconds: 10, failureThreshold: 150 }
           resources:
-            requests: { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
-            limits:   { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+            requests: { cpu: "${CPU_PER_WORKER}", memory: ${MEM_PER_WORKER}, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+            limits:   { cpu: "${CPU_PER_WORKER}", memory: ${MEM_PER_WORKER}, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
           volumeMounts:
             - { name: dshm, mountPath: /dev/shm }
             - { name: shared, mountPath: /shared }
@@ -100,7 +113,12 @@ spec:
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector: { matchLabels: { app.kubernetes.io/part-of: ${DEPLOYMENT_NAME} } }
+            - labelSelector:
+                matchExpressions:
+                  # GPU roles ONLY. A bare part-of match also selects the frontend pod, and
+                  # required anti-affinity is enforced against EXISTING pods too - see header.
+                  - { key: app.kubernetes.io/part-of,   operator: In, values: [ "${DEPLOYMENT_NAME}" ] }
+                  - { key: app.kubernetes.io/component, operator: In, values: [ prefill, decode ] }
               topologyKey: kubernetes.io/hostname
       volumes:
         - { name: dshm, emptyDir: { medium: Memory, sizeLimit: 64Gi } }
@@ -149,8 +167,8 @@ spec:
           ports: [ { containerPort: 9092, name: dyn-system } ]
           startupProbe: { httpGet: { path: /health, port: 9092 }, periodSeconds: 30, timeoutSeconds: 10, failureThreshold: 150 }
           resources:
-            requests: { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
-            limits:   { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+            requests: { cpu: "${CPU_PER_WORKER}", memory: ${MEM_PER_WORKER}, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+            limits:   { cpu: "${CPU_PER_WORKER}", memory: ${MEM_PER_WORKER}, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
           volumeMounts:
             - { name: dshm, mountPath: /dev/shm }
             - { name: shared, mountPath: /shared }
@@ -164,7 +182,19 @@ spec:
   template:
     metadata: { labels: { app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}, app.kubernetes.io/component: frontend } }
     spec:
-      nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_FRONTEND} }
+      # PREFER the small CPU node when the cluster has one, but stay schedulable when it
+      # does not (all-GPU cluster): a hard nodeSelector on an absent instance type pins
+      # this pod to Pending. Tolerations let it land on a GPU node as the fallback.
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - { key: node.kubernetes.io/instance-type, operator: In, values: [ "${INSTANCE_TYPE_FRONTEND}" ] }
+      tolerations:
+        - { key: nvidia.com/gpu, operator: Exists, effect: NoSchedule }
+        - { key: vpc.amazonaws.com/efa, operator: Exists, effect: NoSchedule }
       volumes:
         - { name: shared, persistentVolumeClaim: { claimName: fsx-pvc } }
       containers:

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-ep.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-ep.yaml-template
@@ -12,6 +12,12 @@
 #
 # This is the AGGREGATED expert-parallel permutation - no prefill/decode split,
 # no Dynamo platform required (the vllm leader serves OpenAI API directly).
+#
+# PORTABILITY 2026-08-15 (all-GPU clusters such as p6-b200): the podAntiAffinity selector
+# matches only the GPU role (component In [ep-agg]) rather than every pod carrying
+# `part-of`, and cpu/memory come from CPU_PER_WORKER / MEM_PER_WORKER in .env (the old
+# hardcoded cpu: "96" was a p5en-192-vCPU assumption). Same change as the sibling
+# templates - see the PR for the live-scheduler probe.
 # =============================================================================
 ---
 apiVersion: leaderworkerset.x-k8s.io/v1
@@ -44,8 +50,11 @@ spec:
           podAntiAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:
               - labelSelector:
-                  matchLabels:
-                    app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}
+                  matchExpressions:
+                    # GPU roles ONLY. A bare part-of match also selects the frontend pod, and
+                    # required anti-affinity is enforced against EXISTING pods too - see header.
+                    - { key: app.kubernetes.io/part-of,   operator: In, values: [ "${DEPLOYMENT_NAME}" ] }
+                    - { key: app.kubernetes.io/component, operator: In, values: [ ep-agg ] }
                 topologyKey: kubernetes.io/hostname
         volumes:
           - { name: dshm,       emptyDir: { medium: Memory, sizeLimit: 64Gi } }
@@ -110,8 +119,8 @@ spec:
               timeoutSeconds: 10
               failureThreshold: 120
             resources:
-              requests: { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
-              limits:   { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+              requests: { cpu: "${CPU_PER_WORKER}", memory: ${MEM_PER_WORKER}, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+              limits:   { cpu: "${CPU_PER_WORKER}", memory: ${MEM_PER_WORKER}, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
             volumeMounts:
               - { name: dshm,       mountPath: /dev/shm }
               - { name: gdrdrv,     mountPath: /dev/gdrdrv }
@@ -132,8 +141,11 @@ spec:
           podAntiAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:
               - labelSelector:
-                  matchLabels:
-                    app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}
+                  matchExpressions:
+                    # GPU roles ONLY. A bare part-of match also selects the frontend pod, and
+                    # required anti-affinity is enforced against EXISTING pods too - see header.
+                    - { key: app.kubernetes.io/part-of,   operator: In, values: [ "${DEPLOYMENT_NAME}" ] }
+                    - { key: app.kubernetes.io/component, operator: In, values: [ ep-agg ] }
                 topologyKey: kubernetes.io/hostname
         volumes:
           - { name: dshm,       emptyDir: { medium: Memory, sizeLimit: 64Gi } }
@@ -203,8 +215,8 @@ spec:
               - { name: NCCL_CUMEM_ENABLE, value: "1" }
               - { name: NCCL_SOCKET_IFNAME, value: "^lo,docker,veth,eni" }
             resources:
-              requests: { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
-              limits:   { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+              requests: { cpu: "${CPU_PER_WORKER}", memory: ${MEM_PER_WORKER}, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+              limits:   { cpu: "${CPU_PER_WORKER}", memory: ${MEM_PER_WORKER}, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
             volumeMounts:
               - { name: dshm,       mountPath: /dev/shm }
               - { name: gdrdrv,     mountPath: /dev/gdrdrv }

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-pp.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-pp.yaml-template
@@ -4,7 +4,7 @@
 #
 # Author: Anton Alexander
 #
-# Topology (4 GPU nodes + 1 CPU node):
+# Topology (4 GPU nodes + 1 CPU node - the CPU node is preferred, not required):
 #   - prefill: 1 LWS group of size 2 -> TP=${GPU_PER_WORKER} PP=2 across 2 nodes
 #              (Ray distributed executor, Ray V2 executor backend)
 #   - decode:  1 LWS with 2 single-node groups -> 2x independent TP=${GPU_PER_WORKER} PP=1 workers
@@ -17,6 +17,14 @@
 # etcd/NATS come from the Dynamo platform (see ../../../nvidia-dynamo): ${ETCD_URL} / ${NATS_URL}.
 # Scheduling uses resource requests + instance-type nodeSelector + podAntiAffinity
 # only - no node hostnames, so the manifest is portable across clusters.
+#
+# PORTABILITY 2026-08-15 (all-GPU clusters such as p6-b200, verified against a live v1.35
+# scheduler - see PR): the podAntiAffinity selector matches only the GPU roles. A bare
+# `part-of` match also selects the frontend pod, and required anti-affinity is enforced
+# against EXISTING pods too, so every node holding a GPU pod rejected the frontend with
+# "didn't satisfy existing pods anti-affinity rules" - fatal when the cluster has no spare
+# CPU node. The frontend now PREFERS INSTANCE_TYPE_FRONTEND (+ GPU/EFA tolerations) rather
+# than requiring it, and cpu/memory come from CPU_PER_WORKER / MEM_PER_WORKER in .env.
 # =============================================================================
 ---
 apiVersion: leaderworkerset.x-k8s.io/v1
@@ -49,7 +57,12 @@ spec:
         affinity:
           podAntiAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:
-              - labelSelector: { matchLabels: { app.kubernetes.io/part-of: ${DEPLOYMENT_NAME} } }
+              - labelSelector:
+                  matchExpressions:
+                    # GPU roles ONLY. A bare part-of match also selects the frontend pod, and
+                    # required anti-affinity is enforced against EXISTING pods too - see header.
+                    - { key: app.kubernetes.io/part-of,   operator: In, values: [ "${DEPLOYMENT_NAME}" ] }
+                    - { key: app.kubernetes.io/component, operator: In, values: [ prefill, decode ] }
                 topologyKey: kubernetes.io/hostname
         volumes:
           - { name: dshm,       emptyDir: { medium: Memory, sizeLimit: 64Gi } }
@@ -134,8 +147,8 @@ spec:
               timeoutSeconds: 10
               failureThreshold: 240
             resources:
-              requests: { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
-              limits:   { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+              requests: { cpu: "${CPU_PER_WORKER}", memory: ${MEM_PER_WORKER}, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+              limits:   { cpu: "${CPU_PER_WORKER}", memory: ${MEM_PER_WORKER}, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
             volumeMounts:
               - { name: dshm,       mountPath: /dev/shm }
               - { name: gdrdrv,     mountPath: /dev/gdrdrv }
@@ -154,7 +167,12 @@ spec:
         affinity:
           podAntiAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:
-              - labelSelector: { matchLabels: { app.kubernetes.io/part-of: ${DEPLOYMENT_NAME} } }
+              - labelSelector:
+                  matchExpressions:
+                    # GPU roles ONLY. A bare part-of match also selects the frontend pod, and
+                    # required anti-affinity is enforced against EXISTING pods too - see header.
+                    - { key: app.kubernetes.io/part-of,   operator: In, values: [ "${DEPLOYMENT_NAME}" ] }
+                    - { key: app.kubernetes.io/component, operator: In, values: [ prefill, decode ] }
                 topologyKey: kubernetes.io/hostname
         volumes:
           - { name: dshm,       emptyDir: { medium: Memory, sizeLimit: 64Gi } }
@@ -203,8 +221,8 @@ spec:
               - { name: NCCL_TUNER_PLUGIN, value: ofi }
               - { name: OFI_NCCL_FORCE_NUM_RAILS, value: "4" }
             resources:
-              requests: { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
-              limits:   { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+              requests: { cpu: "${CPU_PER_WORKER}", memory: ${MEM_PER_WORKER}, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+              limits:   { cpu: "${CPU_PER_WORKER}", memory: ${MEM_PER_WORKER}, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
             volumeMounts:
               - { name: dshm,       mountPath: /dev/shm }
               - { name: gdrdrv,     mountPath: /dev/gdrdrv }
@@ -242,7 +260,12 @@ spec:
         affinity:
           podAntiAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:
-              - labelSelector: { matchLabels: { app.kubernetes.io/part-of: ${DEPLOYMENT_NAME} } }
+              - labelSelector:
+                  matchExpressions:
+                    # GPU roles ONLY. A bare part-of match also selects the frontend pod, and
+                    # required anti-affinity is enforced against EXISTING pods too - see header.
+                    - { key: app.kubernetes.io/part-of,   operator: In, values: [ "${DEPLOYMENT_NAME}" ] }
+                    - { key: app.kubernetes.io/component, operator: In, values: [ prefill, decode ] }
                 topologyKey: kubernetes.io/hostname
         volumes:
           - { name: dshm,       emptyDir: { medium: Memory, sizeLimit: 64Gi } }
@@ -306,8 +329,8 @@ spec:
               timeoutSeconds: 10
               failureThreshold: 240
             resources:
-              requests: { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
-              limits:   { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+              requests: { cpu: "${CPU_PER_WORKER}", memory: ${MEM_PER_WORKER}, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+              limits:   { cpu: "${CPU_PER_WORKER}", memory: ${MEM_PER_WORKER}, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
             volumeMounts:
               - { name: dshm,       mountPath: /dev/shm }
               - { name: gdrdrv,     mountPath: /dev/gdrdrv }
@@ -333,7 +356,19 @@ spec:
         app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}
         app.kubernetes.io/component: frontend
     spec:
-      nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_FRONTEND} }
+      # PREFER the small CPU node when the cluster has one, but stay schedulable when it
+      # does not (all-GPU cluster): a hard nodeSelector on an absent instance type pins
+      # this pod to Pending. Tolerations let it land on a GPU node as the fallback.
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - { key: node.kubernetes.io/instance-type, operator: In, values: [ "${INSTANCE_TYPE_FRONTEND}" ] }
+      tolerations:
+        - { key: nvidia.com/gpu, operator: Exists, effect: NoSchedule }
+        - { key: vpc.amazonaws.com/efa, operator: Exists, effect: NoSchedule }
       volumes:
         - { name: shared, persistentVolumeClaim: { claimName: fsx-pvc } }
       containers:

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws.yaml-template
@@ -19,6 +19,23 @@
 #   (2) decode worker now uses ${DOLLAR}LEADER_IP (was a bare $LEADER_IP that envsubst
 #       collapsed to /dev/tcp//6379, wasting the Ray-join wait).
 #
+# FIXED 2026-08-15 - all-GPU-cluster (p6-b200) portability. Reproduced and verified against a
+# live v1.35 scheduler before the change; see the PR for the two-pod scheduling probe.
+#   (3) podAntiAffinity selector narrowed to the GPU roles (component In [prefill,decode]).
+#       A bare `app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}` match ALSO selects the frontend
+#       pod, and required anti-affinity is enforced against EXISTING pods as well as the
+#       incoming one - so every node already holding a GPU pod became ineligible for the
+#       frontend: "0/N nodes are available: N node(s) didn't satisfy existing pods
+#       anti-affinity rules". Invisible on a cluster with spare CPU nodes (the frontend went
+#       to the m5); fatal on a 4-node all-GPU cluster, where the 4 GPU pods take every node
+#       and the frontend has no 5th node to fall back to.
+#   (4) frontend placement: INSTANCE_TYPE_FRONTEND is now a PREFERRED nodeAffinity + GPU/EFA
+#       tolerations instead of a hard nodeSelector. A hard match on an instance type the
+#       cluster does not have pins the frontend to Pending; preferred keeps the same placement
+#       wherever an m5 exists.
+#   (5) cpu/memory of the GPU pods come from CPU_PER_WORKER / MEM_PER_WORKER in .env. The old
+#       hardcoded cpu: "96" was a p5en-192-vCPU assumption; the default is now 48.
+#
 # KNOWN-UNPROVEN (verified live on cgk, 2026-06-07): this TP8/PP2, 4-pod, multi-node-per-role
 #   + Ray-compiled-graph topology DEADLOCKS in decode for the hybrid-Mamba model. KV DOES transfer
 #   over EFA (decode rdma_read_bytes climbs), but all decode GPUs stay 0% and output_tokens=0 —
@@ -62,8 +79,11 @@ spec:
           podAntiAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:
               - labelSelector:
-                  matchLabels:
-                    app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}
+                  matchExpressions:
+                    # GPU roles ONLY. A bare part-of match also selects the frontend pod, and
+                    # required anti-affinity is enforced against EXISTING pods too - see header.
+                    - { key: app.kubernetes.io/part-of,   operator: In, values: [ "${DEPLOYMENT_NAME}" ] }
+                    - { key: app.kubernetes.io/component, operator: In, values: [ prefill, decode ] }
                 topologyKey: kubernetes.io/hostname
         #imagePullSecrets:
         #  - name: dynamo-efa-pull
@@ -159,8 +179,8 @@ spec:
               timeoutSeconds: 10
               failureThreshold: 120
             resources:
-              requests: { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
-              limits:   { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+              requests: { cpu: "${CPU_PER_WORKER}", memory: ${MEM_PER_WORKER}, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+              limits:   { cpu: "${CPU_PER_WORKER}", memory: ${MEM_PER_WORKER}, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
             volumeMounts:
               - { name: dshm,       mountPath: /dev/shm }
               - { name: gdrdrv,     mountPath: /dev/gdrdrv }
@@ -183,8 +203,11 @@ spec:
           podAntiAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:
               - labelSelector:
-                  matchLabels:
-                    app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}
+                  matchExpressions:
+                    # GPU roles ONLY. A bare part-of match also selects the frontend pod, and
+                    # required anti-affinity is enforced against EXISTING pods too - see header.
+                    - { key: app.kubernetes.io/part-of,   operator: In, values: [ "${DEPLOYMENT_NAME}" ] }
+                    - { key: app.kubernetes.io/component, operator: In, values: [ prefill, decode ] }
                 topologyKey: kubernetes.io/hostname
         #imagePullSecrets:
         #  - name: dynamo-efa-pull
@@ -242,8 +265,8 @@ spec:
               - { name: NCCL_TUNER_PLUGIN, value: ofi }
               - { name: OFI_NCCL_FORCE_NUM_RAILS, value: "4" }
             resources:
-              requests: { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
-              limits:   { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+              requests: { cpu: "${CPU_PER_WORKER}", memory: ${MEM_PER_WORKER}, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+              limits:   { cpu: "${CPU_PER_WORKER}", memory: ${MEM_PER_WORKER}, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
             volumeMounts:
               - { name: dshm,       mountPath: /dev/shm }
               - { name: gdrdrv,     mountPath: /dev/gdrdrv }
@@ -281,7 +304,12 @@ spec:
         affinity:
           podAntiAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:
-              - labelSelector: { matchLabels: { app.kubernetes.io/part-of: ${DEPLOYMENT_NAME} } }
+              - labelSelector:
+                  matchExpressions:
+                    # GPU roles ONLY. A bare part-of match also selects the frontend pod, and
+                    # required anti-affinity is enforced against EXISTING pods too - see header.
+                    - { key: app.kubernetes.io/part-of,   operator: In, values: [ "${DEPLOYMENT_NAME}" ] }
+                    - { key: app.kubernetes.io/component, operator: In, values: [ prefill, decode ] }
                 topologyKey: kubernetes.io/hostname
         #imagePullSecrets: [{ name: dynamo-efa-pull }]
         volumes:
@@ -439,8 +467,8 @@ spec:
               timeoutSeconds: 10
               failureThreshold: 120
             resources:
-              requests: { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
-              limits:   { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+              requests: { cpu: "${CPU_PER_WORKER}", memory: ${MEM_PER_WORKER}, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+              limits:   { cpu: "${CPU_PER_WORKER}", memory: ${MEM_PER_WORKER}, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
             volumeMounts:
               - { name: dshm,       mountPath: /dev/shm }
               - { name: gdrdrv,     mountPath: /dev/gdrdrv }
@@ -461,7 +489,12 @@ spec:
         affinity:
           podAntiAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:
-              - labelSelector: { matchLabels: { app.kubernetes.io/part-of: ${DEPLOYMENT_NAME} } }
+              - labelSelector:
+                  matchExpressions:
+                    # GPU roles ONLY. A bare part-of match also selects the frontend pod, and
+                    # required anti-affinity is enforced against EXISTING pods too - see header.
+                    - { key: app.kubernetes.io/part-of,   operator: In, values: [ "${DEPLOYMENT_NAME}" ] }
+                    - { key: app.kubernetes.io/component, operator: In, values: [ prefill, decode ] }
                 topologyKey: kubernetes.io/hostname
         #imagePullSecrets: [{ name: dynamo-efa-pull }]
         volumes:
@@ -518,8 +551,8 @@ spec:
               - { name: NCCL_TUNER_PLUGIN, value: ofi }
               - { name: OFI_NCCL_FORCE_NUM_RAILS, value: "4" }
             resources:
-              requests: { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
-              limits:   { cpu: "96", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+              requests: { cpu: "${CPU_PER_WORKER}", memory: ${MEM_PER_WORKER}, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+              limits:   { cpu: "${CPU_PER_WORKER}", memory: ${MEM_PER_WORKER}, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
             volumeMounts:
               - { name: dshm,       mountPath: /dev/shm }
               - { name: gdrdrv,     mountPath: /dev/gdrdrv }
@@ -546,8 +579,19 @@ spec:
         app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}
         app.kubernetes.io/component: frontend
     spec:
-      nodeSelector:
-        node.kubernetes.io/instance-type: ${INSTANCE_TYPE_FRONTEND}
+      # PREFER the small CPU node when the cluster has one, but stay schedulable when it
+      # does not (all-GPU cluster): a hard nodeSelector on an absent instance type pins
+      # this pod to Pending. Tolerations let it land on a GPU node as the fallback.
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - { key: node.kubernetes.io/instance-type, operator: In, values: [ "${INSTANCE_TYPE_FRONTEND}" ] }
+      tolerations:
+        - { key: nvidia.com/gpu, operator: Exists, effect: NoSchedule }
+        - { key: vpc.amazonaws.com/efa, operator: Exists, effect: NoSchedule }
       volumes:
         - name: shared
           persistentVolumeClaim: { claimName: fsx-pvc }


### PR DESCRIPTION
## Problem

The `nemotron/ultra/disagg` templates were authored against a p5en cluster that
also had spare `m5.8xlarge` CPU nodes. On a **4-node all-GPU cluster**
(`p6-b200.48xlarge`, 8 GPUs + EFA per node, no CPU node) they do not come up
out of the box: the GPU pods take all four nodes and the frontend pod stays
`Pending` with

```
0/4 nodes are available: 4 node(s) didn't satisfy existing pods anti-affinity rules
```

Three independent assumptions are involved.

### 1. `podAntiAffinity` selected the frontend as well as the GPU pods

Every GPU pod template carried:

```yaml
- labelSelector: { matchLabels: { app.kubernetes.io/part-of: ${DEPLOYMENT_NAME} } }
  topologyKey: kubernetes.io/hostname
```

`app.kubernetes.io/part-of` is on **all** pods of the deployment, frontend
included. `requiredDuringSchedulingIgnoredDuringExecution` is enforced
**bidirectionally** — the scheduler also checks the anti-affinity rules of the
pods *already* on a node against the incoming pod. So once a prefill/decode pod
is running, that node refuses the frontend. Note the message differs from the
more familiar one: `didn't satisfy existing pods anti-affinity rules` (the
running pods' rule rejects the newcomer) vs `didn't match pod anti-affinity
rules` (the newcomer's own rule fails).

On p5en this was invisible: the frontend was pinned to an `m5.8xlarge`, which
never hosted a GPU pod.

**Fix** — select the GPU roles explicitly:

```yaml
- labelSelector:
    matchExpressions:
      - { key: app.kubernetes.io/part-of,   operator: In, values: [ "${DEPLOYMENT_NAME}" ] }
      - { key: app.kubernetes.io/component, operator: In, values: [ prefill, decode ] }
  topologyKey: kubernetes.io/hostname
```

(`[ ep-agg ]` in `lws-ep.yaml-template`.) A whitelist rather than
`NotIn [frontend]` on purpose: if a future role is added and not listed, the
worst case is that it co-schedules and then fails on GPU resources — it cannot
silently break the prefill/decode one-per-node spread.

### 2. The frontend *required* an instance type the cluster may not have

```yaml
nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_FRONTEND} }   # m5.8xlarge
```

A hard `nodeSelector` on an absent instance type is a permanent `Pending`. It is
now a preference plus tolerations, so placement is unchanged where an `m5`
exists and the pod still schedules where it does not:

```yaml
affinity:
  nodeAffinity:
    preferredDuringSchedulingIgnoredDuringExecution:
      - weight: 100
        preference:
          matchExpressions:
            - { key: node.kubernetes.io/instance-type, operator: In, values: [ "${INSTANCE_TYPE_FRONTEND}" ] }
tolerations:
  - { key: nvidia.com/gpu, operator: Exists, effect: NoSchedule }
  - { key: vpc.amazonaws.com/efa, operator: Exists, effect: NoSchedule }
```

### 3. `cpu: "96"` was a p5en-192-vCPU assumption

requests == limits (Guaranteed QoS / exclusive cores under the static CPU
manager), so 96 is a hard admission requirement, and on a node with fewer
allocatable cores the GPU pod itself will not schedule. `cpu`/`memory` now come
from `CPU_PER_WORKER` / `MEM_PER_WORKER` in `.env`, defaulting to **48** — the
value the sibling `agg/` templates already use, which fits both
`p5en.48xlarge` and `p6-b200.48xlarge`. `CPU_PER_WORKER=96 ./run.sh` restores
the previous behaviour.

`.env` also promotes `INSTANCE_TYPE_FRONTEND/WORKER`, `GPU_PER_WORKER` and
`EFA_PER_WORKER` to `${VAR:-default}` (the convention the file already
documents for `NAMESPACE`/`MANIFEST_TYPE`), so retargeting an accelerator is a
run-time override instead of a template edit:

```bash
INSTANCE_TYPE_WORKER=p6-b200.48xlarge EFA_PER_WORKER=<node allocatable> ./run.sh
```

`EFA_PER_WORKER` gained a comment saying to *read* the allocatable value rather
than assume it — it differs by instance type and a wrong value is another silent
`Pending`:

```bash
kubectl get node <node> -o jsonpath='{.status.allocatable.vpc\.amazonaws\.com/efa}{"\n"}'
```

## Verification

**Live scheduler probe** (Kubernetes v1.35), two 10m-CPU pods carrying the real
label set:

| Selector | Result |
|---|---|
| broad `matchLabels: {part-of}` (before) | frontend `Pending` — `1 node(s) didn't satisfy existing pods anti-affinity rules` — the exact reported symptom |
| narrowed `matchExpressions` (after) | frontend `Running` on the same node as the GPU pod, **and** a second `component=decode` pod still correctly refused → one-per-node spreading preserved |
| `preferred` nodeAffinity on a non-existent instance type | schedules (falls back), proving the OOTB path |

**Manifest validation** — all four templates rendered with `envsubst` and the
new `.env`, parsed with `yaml.safe_load_all` (deployment 4 docs, lws 4, lws-pp
4, lws-ep 2) and applied with `kubectl apply --dry-run=server` against a live
cluster with the LeaderWorkerSet CRD installed. Rendered GPU pods show
`requests == limits == { cpu: "48", memory: 1000Gi, nvidia.com/gpu: "8",
vpc.amazonaws.com/efa: "16" }`.

## Scope

Deliberately **not** changed:

- `disagg/dgd.yaml-template` — same three patterns are present, but its pods are
  labelled by the Dynamo operator, so the `component` label assumption is
  unverified. Worth a follow-up once the operator's label set is confirmed.
- everything under `agg/` — already uses `cpu: 48`, and it is in active use.

No behavioural change on p5en: with `INSTANCE_TYPE_FRONTEND=m5.8xlarge` present
the frontend still lands on the m5, prefill/decode still spread one per node, and
`CPU_PER_WORKER=96` reproduces the old resource block exactly.
