### PR TITLE
fix(nemotron/ultra/disagg): keep restart forensics on the size-1 decode LWS

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-pp.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-pp.yaml-template
@@ -82,7 +82,18 @@ spec:
                 # Dynamo images differ in python layout: 1.2.0-era images ship /opt/dynamo/venv,
                 # 1.3.0-era images install into the system python and have NO venv.
                 if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
-                LOG=/shared/${DEPLOYMENT_NAME}-prefill-pp2-${DOLLAR}(date -u +%FT%TZ).log
+                # Pick a WRITABLE log dir. /shared (FSx) is preferred because the log then
+                # outlives the pod, but on some clusters the PVC is exported root-squashed or
+                # owned by another uid and every `tee` line fails with "Permission denied" --
+                # the run then leaves no trail at all, which is exactly when you need one.
+                LOG_DIR=/shared
+                if ! ( : > "${DOLLAR}LOG_DIR/.wtest-${DOLLAR}HOSTNAME" ) 2>/dev/null; then
+                  echo "[prefill-leader] ${DOLLAR}LOG_DIR not writable; logging to /tmp instead"
+                  LOG_DIR=/tmp
+                else
+                  rm -f "${DOLLAR}LOG_DIR/.wtest-${DOLLAR}HOSTNAME"
+                fi
+                LOG=${DOLLAR}LOG_DIR/${DEPLOYMENT_NAME}-prefill-pp2-${DOLLAR}(date -u +%FT%TZ).log
                 echo "[prefill-leader] starting; piping to ${DOLLAR}LOG"
                 python3 -c "import vllm; print(f'vllm {vllm.__version__}')" 2>&1 | tee -a "${DOLLAR}LOG"
                 for i in ${DOLLAR}(seq 1 150); do
@@ -245,7 +256,15 @@ spec:
   rolloutStrategy:
     type: RollingUpdate
   leaderWorkerTemplate:
-    restartPolicy: RecreateGroupOnPodRestart
+    # size: 1 => the group IS one pod, so there is no sibling to keep consistent and
+    # nothing to gain from recreating the group. RecreateGroupOnPodRestart here DELETES
+    # the pod on any container exit, which (a) discards `kubectl logs --previous` so the
+    # crash that caused it is unrecoverable, and (b) restarts the ~25 min weight load
+    # from zero, so a group that fails during engine init never reaches Ready. `None`
+    # lets the kubelet restart just the container in place and keeps the previous log.
+    # The prefill LWS above keeps RecreateGroupOnPodRestart on purpose: size: 2 with a
+    # Ray head/worker pair genuinely must be recreated together.
+    restartPolicy: None
     size: 1
     workerTemplate:
       metadata:
@@ -283,7 +302,17 @@ spec:
                 unset HPCX_DIR HPCX_MPI_DIR HPCX_HOME HPCX_UCX_DIR HPCX_SHARP_DIR \
                       HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
                 if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
-                LOG=/shared/${DEPLOYMENT_NAME}-decode-pp1-${DOLLAR}(date -u +%FT%TZ).log
+                # Same writable-log-dir probe as the prefill leader: keep /shared when the PVC
+                # accepts our writes, fall back to /tmp instead of losing the log to EACCES.
+                LOG_DIR=/shared
+                if ! ( : > "${DOLLAR}LOG_DIR/.wtest-${DOLLAR}HOSTNAME" ) 2>/dev/null; then
+                  echo "[decode] ${DOLLAR}LOG_DIR not writable; logging to /tmp instead"
+                  LOG_DIR=/tmp
+                else
+                  rm -f "${DOLLAR}LOG_DIR/.wtest-${DOLLAR}HOSTNAME"
+                fi
+                LOG=${DOLLAR}LOG_DIR/${DEPLOYMENT_NAME}-decode-pp1-${DOLLAR}(date -u +%FT%TZ).log
+                echo "[decode] starting; piping to ${DOLLAR}LOG"
                 python3 -c "import vllm; print(f'vllm {vllm.__version__}')" 2>&1 | tee -a "${DOLLAR}LOG"
                 # Single-node decode: TP8/PP1, no Ray - the validated decode shape for hybrid-Mamba.
                 exec python3 -m dynamo.vllm \

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws.yaml-template
@@ -106,7 +106,18 @@ spec:
                 # 1.3.0-era images (NGC vllm-runtime:1.3.0 and derivatives) install into the system
                 # python and have NO venv. Activate only when present so one manifest serves both.
                 if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
-                LOG=/shared/disagg-prefill-p5en-$(date -u +%FT%TZ).log
+                # Pick a WRITABLE log dir. /shared (FSx) is preferred because the log then
+                # outlives the pod, but on some clusters the PVC is exported root-squashed or
+                # owned by another uid and every `tee` line fails with "Permission denied" --
+                # the run then leaves no trail at all, which is exactly when you need one.
+                LOG_DIR=/shared
+                if ! ( : > "${DOLLAR}LOG_DIR/.wtest-${DOLLAR}HOSTNAME" ) 2>/dev/null; then
+                  echo "[prefill-leader p5en] ${DOLLAR}LOG_DIR not writable; logging to /tmp instead"
+                  LOG_DIR=/tmp
+                else
+                  rm -f "${DOLLAR}LOG_DIR/.wtest-${DOLLAR}HOSTNAME"
+                fi
+                LOG=${DOLLAR}LOG_DIR/disagg-prefill-p5en-$(date -u +%FT%TZ).log
                 echo "[prefill-leader p5en] starting; piping to ${DOLLAR}LOG"
                 python3 -c "import vllm; print(f'vllm {vllm.__version__}')" 2>&1 | tee -a "${DOLLAR}LOG"
                 # Verify the PR #42522 patch is present
@@ -331,7 +342,17 @@ spec:
                 # 1.3.0-era images (NGC vllm-runtime:1.3.0 and derivatives) install into the system
                 # python and have NO venv. Activate only when present so one manifest serves both.
                 if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
-                LOG=/shared/disagg-decode-p5en-$(date -u +%FT%TZ).log
+                # Same writable-log-dir probe as the prefill leader: keep /shared when the PVC
+                # accepts our writes, fall back to /tmp instead of losing the log to EACCES.
+                LOG_DIR=/shared
+                if ! ( : > "${DOLLAR}LOG_DIR/.wtest-${DOLLAR}HOSTNAME" ) 2>/dev/null; then
+                  echo "[decode p5en] ${DOLLAR}LOG_DIR not writable; logging to /tmp instead"
+                  LOG_DIR=/tmp
+                else
+                  rm -f "${DOLLAR}LOG_DIR/.wtest-${DOLLAR}HOSTNAME"
+                fi
+                LOG=${DOLLAR}LOG_DIR/disagg-decode-p5en-$(date -u +%FT%TZ).log
+                echo "[decode p5en] starting; piping to ${DOLLAR}LOG"
                 python3 -c "import vllm; print(f'vllm {vllm.__version__}')" 2>&1 | tee -a "${DOLLAR}LOG"
                 VLLM_DIR=${DOLLAR}(python3 -c "import vllm, os; print(os.path.dirname(vllm.__file__))")
                 grep -A2 "is_kv_consumer" "${DOLLAR}VLLM_DIR/model_executor/models/config.py" 2>&1 | tee -a "${DOLLAR}LOG"


### PR DESCRIPTION
## What

Two fixes to the Nemotron-3 Ultra 550B LWS disagg manifests, both about keeping a container
failure *diagnosable* instead of erasing it.

1. **`lws-pp.yaml-template`: decode `restartPolicy: RecreateGroupOnPodRestart` -> `None`.**
   The decode LeaderWorkerSet is `size: 1`, so a "group" is a single pod. There is no sibling
   to keep consistent, and the policy has two costs: LWS **deletes the pod** on any container
   exit, so `kubectl logs --previous` is gone and the crash that caused the restart cannot be
   read; and the ~25 min 550B weight load restarts from zero.
   Prefill keeps `RecreateGroupOnPodRestart` — `size: 2` with a Ray head/worker pair genuinely
   must be recreated together.

2. **Writable-log-dir probe before `LOG=/shared/...`** (`lws-pp.yaml-template` prefill + decode,
   and the same idiom in the p5en sibling `lws.yaml-template`). `/shared` is still preferred so
   the log outlives the pod; it just falls back to `/tmp` and says so, instead of losing the log.

## Why — observed live on 4x ml.p6-b200.48xlarge

Decode group 0 failed during engine init roughly 25 min into the load, and LWS recreated the group:

```
Worker pod nemotron3-ultra-550b-disagg-decode-0 failed, deleted leader pod
nemotron3-ultra-550b-disagg-decode-0 to recreate group 0
```

The recreate cadence in the event stream is 13–15 min against a ~25 min load, so that group can
never reach Ready. `kubectl logs --previous` on the new pod returns:

```
Error from server (BadRequest): previous terminated container "vllm" in pod
"nemotron3-ultra-550b-disagg-decode-0" not found
```

and the on-disk log that should have covered it was never written:

```
tee: '/shared/nemotron3-ultra-550b-disagg-prefill-pp2-2026-08-15T04:23:51Z.log': Permission denied
```

`/shared` listed from inside a pod that mounts it contains only `out.txt`, `aiperf-results`,
`models` — no run logs from any generation. So both halves of the evidence trail were missing at
the same time, which is what turns a normal crash-and-retry into "the pods are restarting and I
can't see why".

Sibling context: `disagg/lws.yaml-template` already uses `restartPolicy: None`, so this aligns
`lws-pp` with the convention already in the directory.

## Verification

- Rendered both templates through `envsubst` with the `config.sh` variable set: 4 documents each,
  `yaml.safe_load_all` parses, and every container script passes `bash -n`.
- `/shared` behaviour is unchanged where the PVC is writable (the p5en path) — the probe only adds
  a fallback.

## Not changed here (observed, not fixed — flagging for the maintainers)

- The prefill Ray readiness gate parses `ray status` text:
  `N=$(ray status | awk '/Active:/{...}' | grep -c node_)`. It works today but is coupled to Ray's
  human-readable output format.
- The prefill leader logs `Tensor parallel size (16) exceeds available GPUs (8)` at startup and then
  proceeds normally (PP2 across two nodes). Non-fatal, but confusing in a bring-up log.
- The decode container runs `--gpu-memory-utilization 0.98` where prefill uses `0.92`. That may or
  may not relate to the engine-init failure above; I have not proven a link, so this PR does not
  touch it. Only one of the two decode groups failed on an identical spec, so it is not a plain
  config error either.
