### PR TITLE
Fix nemotron-ultra lws-ep on B200: DNS guard race, engine-ready timeout, DP group restart policy

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws-ep.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws-ep.yaml-template
@@ -75,12 +75,17 @@ spec:
                       HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
                 if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
                 # Wait for own DNS to be resolvable (LWS pods come up simultaneously)
+                # Resolve in ONE getent per attempt and break only on a NON-EMPTY address. The previous
+                # shape probed with one getent and captured the address with a second one, so a single
+                # empty capture immediately after a successful probe killed the pod ~2s in while printing
+                # a 300s timeout it had never waited for (measured: B200 lws-ep worker, 2026-08-15).
+                # NR==1 also keeps a multi-record answer from producing a two-word LEADER_IP.
                 for i in ${DOLLAR}(seq 1 150); do
-                  if getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" >/dev/null 2>&1; then break; fi
+                  LEADER_IP=${DOLLAR}(getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" | awk 'NR==1{print ${DOLLAR}1; exit}')
+                  if [ -n "${DOLLAR}LEADER_IP" ]; then break; fi
                   echo "[dp0/leader] waiting for DNS LWS_LEADER_ADDRESS=${DOLLAR}LWS_LEADER_ADDRESS (${DOLLAR}i)"
                   sleep 2
                 done
-                LEADER_IP=${DOLLAR}(getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" | awk '{print ${DOLLAR}1}')
                 echo "[dp0/leader] LWS_LEADER_ADDRESS=${DOLLAR}LWS_LEADER_ADDRESS LEADER_IP=${DOLLAR}LEADER_IP"
                 if [ -z "${DOLLAR}LEADER_IP" ]; then
                   echo "[dp0/leader] FATAL: ${DOLLAR}LWS_LEADER_ADDRESS did not resolve within 300s; exiting for a clean restart (do NOT proceed with an empty leader address)"
@@ -215,11 +220,16 @@ spec:
                       HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
                 if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
                 # resolve the leader (DP rank 0) for the coordinator dial-in
+                # Resolve in ONE getent per attempt and break only on a NON-EMPTY address. The previous
+                # shape probed with one getent and captured the address with a second one, so a single
+                # empty capture immediately after a successful probe killed the pod ~2s in while printing
+                # a 300s timeout it had never waited for (measured: B200 lws-ep worker, 2026-08-15).
+                # NR==1 also keeps a multi-record answer from producing a two-word LEADER_IP.
                 for i in ${DOLLAR}(seq 1 150); do
-                  if getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" >/dev/null 2>&1; then break; fi
+                  LEADER_IP=${DOLLAR}(getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" | awk 'NR==1{print ${DOLLAR}1; exit}')
+                  if [ -n "${DOLLAR}LEADER_IP" ]; then break; fi
                   sleep 2
                 done
-                LEADER_IP=${DOLLAR}(getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" | awk '{print ${DOLLAR}1}')
                 echo "[dp1/worker] LEADER_IP=${DOLLAR}LEADER_IP MY_IP=${DOLLAR}MY_IP"
                 if [ -z "${DOLLAR}LEADER_IP" ]; then
                   echo "[dp1/worker] FATAL: ${DOLLAR}LWS_LEADER_ADDRESS did not resolve within 300s; exiting for a clean restart (do NOT proceed with an empty leader address)"

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws.yaml-template
@@ -62,12 +62,17 @@ spec:
                       HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
                 if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
                 # Wait for own DNS to be resolvable (LWS pods come up simultaneously)
+                # Resolve in ONE getent per attempt and break only on a NON-EMPTY address. The previous
+                # shape probed with one getent and captured the address with a second one, so a single
+                # empty capture immediately after a successful probe killed the pod ~2s in while printing
+                # a 300s timeout it had never waited for (measured: B200 lws-ep worker, 2026-08-15).
+                # NR==1 also keeps a multi-record answer from producing a two-word LEADER_IP.
                 for i in ${DOLLAR}(seq 1 150); do
-                  if getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" >/dev/null 2>&1; then break; fi
+                  LEADER_IP=${DOLLAR}(getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" | awk 'NR==1{print ${DOLLAR}1; exit}')
+                  if [ -n "${DOLLAR}LEADER_IP" ]; then break; fi
                   echo "[leader] waiting for DNS LWS_LEADER_ADDRESS=${DOLLAR}LWS_LEADER_ADDRESS (${DOLLAR}i)"
                   sleep 2
                 done
-                LEADER_IP=${DOLLAR}(getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" | awk '{print ${DOLLAR}1}')
                 echo "[leader] LWS_LEADER_ADDRESS=${DOLLAR}LWS_LEADER_ADDRESS LEADER_IP=${DOLLAR}LEADER_IP"
                 if [ -z "${DOLLAR}LEADER_IP" ]; then
                   echo "[leader] FATAL: ${DOLLAR}LWS_LEADER_ADDRESS did not resolve within 300s; exiting for a clean restart (do NOT proceed with an empty leader address)"
@@ -278,12 +283,17 @@ spec:
                 unset HPCX_DIR HPCX_MPI_DIR HPCX_HOME HPCX_UCX_DIR HPCX_SHARP_DIR \
                       HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
                 if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+                # Resolve in ONE getent per attempt and break only on a NON-EMPTY address. The previous
+                # shape probed with one getent and captured the address with a second one, so a single
+                # empty capture immediately after a successful probe killed the pod ~2s in while printing
+                # a 300s timeout it had never waited for (measured: B200 lws-ep worker, 2026-08-15).
+                # NR==1 also keeps a multi-record answer from producing a two-word LEADER_IP.
                 for i in ${DOLLAR}(seq 1 150); do
-                  if getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" >/dev/null 2>&1; then break; fi
+                  LEADER_IP=${DOLLAR}(getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" | awk 'NR==1{print ${DOLLAR}1; exit}')
+                  if [ -n "${DOLLAR}LEADER_IP" ]; then break; fi
                   echo "[worker] waiting for DNS LWS_LEADER_ADDRESS=$LWS_LEADER_ADDRESS (${DOLLAR}i)"
                   sleep 2
                 done
-                LEADER_IP=${DOLLAR}(getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" | awk '{print ${DOLLAR}1}')
                 if [ -z "${DOLLAR}LEADER_IP" ]; then
                   echo "[worker] FATAL: ${DOLLAR}LWS_LEADER_ADDRESS did not resolve within 300s; exiting for a clean restart (do NOT proceed with an empty leader address)"
                   exit 1

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-ep.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-ep.yaml-template
@@ -164,11 +164,16 @@ spec:
                       HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
                 if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
                 mkdir -p /tmp/hf_cache
+                # Resolve in ONE getent per attempt and break only on a NON-EMPTY address. The previous
+                # shape probed with one getent and captured the address with a second one, so a single
+                # empty capture immediately after a successful probe killed the pod ~2s in while printing
+                # a 300s timeout it had never waited for (measured: B200 lws-ep worker, 2026-08-15).
+                # NR==1 also keeps a multi-record answer from producing a two-word LEADER_IP.
                 for i in ${DOLLAR}(seq 1 150); do
-                  if getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" >/dev/null 2>&1; then break; fi
+                  LEADER_IP=${DOLLAR}(getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" | awk 'NR==1{print ${DOLLAR}1; exit}')
+                  if [ -n "${DOLLAR}LEADER_IP" ]; then break; fi
                   sleep 2
                 done
-                LEADER_IP=${DOLLAR}(getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" | awk '{print ${DOLLAR}1}')
                 echo "[ep dp${DOLLAR}{LWS_WORKER_INDEX}/worker] LEADER_IP=${DOLLAR}LEADER_IP MY_IP=${DOLLAR}MY_IP"
                 if [ -z "${DOLLAR}LEADER_IP" ]; then
                   echo "[ep worker] FATAL: ${DOLLAR}LWS_LEADER_ADDRESS did not resolve within 300s; exiting for a clean restart (do NOT proceed with an empty leader address)"

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-ep.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-ep.yaml-template
@@ -32,7 +32,14 @@ spec:
   replicas: 1
   startupPolicy: LeaderCreated
   leaderWorkerTemplate:
-    restartPolicy: None
+    # RecreateGroupOnPodRestart, matching agg/lws-ep: the DP ranks share one TCPStore and one DP
+    # coordinator hosted by the leader, so a leader restart invalidates every rank. With None,
+    # a leader container restart leaves the DP1 worker alive on the dead store - measured on
+    # B200 2026-08-15: worker pid 1 still from the previous epoch 31 minutes later, logging
+    # "sendBytes failed ... remote=[...-ep-0...]:50413: Broken pipe" - and the new leader can
+    # never assemble data_parallel_size=2, so it re-times-out every ~25 min forever.
+    # Trade-off: recreating the group discards the crashed pod's logs (see #68).
+    restartPolicy: RecreateGroupOnPodRestart
     size: ${EP_DP_SIZE}
     leaderTemplate:
       metadata:

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-ep.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-ep.yaml-template
@@ -97,7 +97,14 @@ spec:
               - { name: HF_HUB_OFFLINE, value: "1" }
               - { name: TRANSFORMERS_OFFLINE, value: "1" }
               - { name: VLLM_LOGGING_LEVEL, value: INFO }
-              - { name: VLLM_ENGINE_READY_TIMEOUT_S, value: "1200" }
+              # 2400 not 1200: with data_parallel_size > 1 vLLM builds a DPLBAsyncMPClient and the
+              # API-server process waits for the engine cores INSIDE this budget, so the whole
+              # weight load counts against it. Measured on B200 (2026-08-15): 51023-tensor
+              # runai_streamer load 21:06 + 70.8s engine init, engine ready 07:18:18Z against a
+              # 1200s deadline that expired 07:18:22Z - it missed by 4 seconds and the pod died
+              # with "TimeoutError: Timed out waiting for engine core processes to start".
+              # agg/lws-ep.yaml-template already uses 2400 for this checkpoint.
+              - { name: VLLM_ENGINE_READY_TIMEOUT_S, value: "2400" }
               - { name: VLLM_SSM_CONV_STATE_LAYOUT, value: DS }
               - { name: FLASHINFER_DISABLE_VERSION_CHECK, value: "1" }
               - { name: FI_PROVIDER, value: efa }
@@ -206,7 +213,14 @@ spec:
               - { name: HF_HUB_OFFLINE, value: "1" }
               - { name: TRANSFORMERS_OFFLINE, value: "1" }
               - { name: VLLM_LOGGING_LEVEL, value: INFO }
-              - { name: VLLM_ENGINE_READY_TIMEOUT_S, value: "1200" }
+              # 2400 not 1200: with data_parallel_size > 1 vLLM builds a DPLBAsyncMPClient and the
+              # API-server process waits for the engine cores INSIDE this budget, so the whole
+              # weight load counts against it. Measured on B200 (2026-08-15): 51023-tensor
+              # runai_streamer load 21:06 + 70.8s engine init, engine ready 07:18:18Z against a
+              # 1200s deadline that expired 07:18:22Z - it missed by 4 seconds and the pod died
+              # with "TimeoutError: Timed out waiting for engine core processes to start".
+              # agg/lws-ep.yaml-template already uses 2400 for this checkpoint.
+              - { name: VLLM_ENGINE_READY_TIMEOUT_S, value: "2400" }
               - { name: VLLM_SSM_CONV_STATE_LAYOUT, value: DS }
               - { name: FLASHINFER_DISABLE_VERSION_CHECK, value: "1" }
               - { name: FI_PROVIDER, value: efa }

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-pp.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-pp.yaml-template
@@ -96,11 +96,16 @@ spec:
                 LOG=${DOLLAR}LOG_DIR/${DEPLOYMENT_NAME}-prefill-pp2-${DOLLAR}(date -u +%FT%TZ).log
                 echo "[prefill-leader] starting; piping to ${DOLLAR}LOG"
                 python3 -c "import vllm; print(f'vllm {vllm.__version__}')" 2>&1 | tee -a "${DOLLAR}LOG"
+                # Resolve in ONE getent per attempt and break only on a NON-EMPTY address. The previous
+                # shape probed with one getent and captured the address with a second one, so a single
+                # empty capture immediately after a successful probe killed the pod ~2s in while printing
+                # a 300s timeout it had never waited for (measured: B200 lws-ep worker, 2026-08-15).
+                # NR==1 also keeps a multi-record answer from producing a two-word LEADER_IP.
                 for i in ${DOLLAR}(seq 1 150); do
-                  if getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" >/dev/null 2>&1; then break; fi
+                  LEADER_IP=${DOLLAR}(getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" | awk 'NR==1{print ${DOLLAR}1; exit}')
+                  if [ -n "${DOLLAR}LEADER_IP" ]; then break; fi
                   sleep 2
                 done
-                LEADER_IP=${DOLLAR}(getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" | awk '{print ${DOLLAR}1}')
                 echo "[prefill-leader] LEADER_IP=${DOLLAR}LEADER_IP MY_IP=${DOLLAR}MY_IP" | tee -a "${DOLLAR}LOG"
                 if [ -z "${DOLLAR}LEADER_IP" ]; then
                   echo "[prefill-leader] FATAL: ${DOLLAR}LWS_LEADER_ADDRESS did not resolve within 300s; exiting for a clean restart (do NOT proceed with an empty leader address)"
@@ -201,11 +206,16 @@ spec:
                 unset HPCX_DIR HPCX_MPI_DIR HPCX_HOME HPCX_UCX_DIR HPCX_SHARP_DIR \
                       HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
                 if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+                # Resolve in ONE getent per attempt and break only on a NON-EMPTY address. The previous
+                # shape probed with one getent and captured the address with a second one, so a single
+                # empty capture immediately after a successful probe killed the pod ~2s in while printing
+                # a 300s timeout it had never waited for (measured: B200 lws-ep worker, 2026-08-15).
+                # NR==1 also keeps a multi-record answer from producing a two-word LEADER_IP.
                 for i in ${DOLLAR}(seq 1 150); do
-                  if getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" >/dev/null 2>&1; then break; fi
+                  LEADER_IP=${DOLLAR}(getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" | awk 'NR==1{print ${DOLLAR}1; exit}')
+                  if [ -n "${DOLLAR}LEADER_IP" ]; then break; fi
                   sleep 2
                 done
-                LEADER_IP=${DOLLAR}(getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" | awk '{print ${DOLLAR}1}')
                 if [ -z "${DOLLAR}LEADER_IP" ]; then
                   echo "[pp-worker] FATAL: ${DOLLAR}LWS_LEADER_ADDRESS did not resolve within 300s; exiting for a clean restart (do NOT proceed with an empty leader address)"
                   exit 1

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws.yaml-template
@@ -164,11 +164,16 @@ spec:
                 # Verify the PR #42522 patch is present
                 VLLM_DIR=${DOLLAR}(python3 -c "import vllm, os; print(os.path.dirname(vllm.__file__))")
                 grep -A2 "is_kv_consumer" "${DOLLAR}VLLM_DIR/model_executor/models/config.py" 2>&1 | tee -a "${DOLLAR}LOG"
+                # Resolve in ONE getent per attempt and break only on a NON-EMPTY address. The previous
+                # shape probed with one getent and captured the address with a second one, so a single
+                # empty capture immediately after a successful probe killed the pod ~2s in while printing
+                # a 300s timeout it had never waited for (measured: B200 lws-ep worker, 2026-08-15).
+                # NR==1 also keeps a multi-record answer from producing a two-word LEADER_IP.
                 for i in ${DOLLAR}(seq 1 150); do
-                  if getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" >/dev/null 2>&1; then break; fi
+                  LEADER_IP=${DOLLAR}(getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" | awk 'NR==1{print ${DOLLAR}1; exit}')
+                  if [ -n "${DOLLAR}LEADER_IP" ]; then break; fi
                   sleep 2
                 done
-                LEADER_IP=${DOLLAR}(getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" | awk '{print ${DOLLAR}1}')
                 echo "[prefill-leader p5en] LEADER_IP=${DOLLAR}LEADER_IP" | tee -a "${DOLLAR}LOG"
                 if [ -z "${DOLLAR}LEADER_IP" ]; then
                   echo "[prefill-leader] FATAL: ${DOLLAR}LWS_LEADER_ADDRESS did not resolve within 300s; exiting for a clean restart (do NOT proceed with an empty leader address)"
@@ -289,11 +294,16 @@ spec:
                 # 1.3.0-era images (NGC vllm-runtime:1.3.0 and derivatives) install into the system
                 # python and have NO venv. Activate only when present so one manifest serves both.
                 if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+                # Resolve in ONE getent per attempt and break only on a NON-EMPTY address. The previous
+                # shape probed with one getent and captured the address with a second one, so a single
+                # empty capture immediately after a successful probe killed the pod ~2s in while printing
+                # a 300s timeout it had never waited for (measured: B200 lws-ep worker, 2026-08-15).
+                # NR==1 also keeps a multi-record answer from producing a two-word LEADER_IP.
                 for i in ${DOLLAR}(seq 1 150); do
-                  if getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" >/dev/null 2>&1; then break; fi
+                  LEADER_IP=${DOLLAR}(getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" | awk 'NR==1{print ${DOLLAR}1; exit}')
+                  if [ -n "${DOLLAR}LEADER_IP" ]; then break; fi
                   sleep 2
                 done
-                LEADER_IP=${DOLLAR}(getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" | awk '{print ${DOLLAR}1}')
                 if [ -z "${DOLLAR}LEADER_IP" ]; then
                   echo "[prefill-worker] FATAL: ${DOLLAR}LWS_LEADER_ADDRESS did not resolve within 300s; exiting for a clean restart (do NOT proceed with an empty leader address)"
                   exit 1
@@ -411,11 +421,16 @@ spec:
                 python3 -c "import vllm; print(f'vllm {vllm.__version__}')" 2>&1 | tee -a "${DOLLAR}LOG"
                 VLLM_DIR=${DOLLAR}(python3 -c "import vllm, os; print(os.path.dirname(vllm.__file__))")
                 grep -A2 "is_kv_consumer" "${DOLLAR}VLLM_DIR/model_executor/models/config.py" 2>&1 | tee -a "${DOLLAR}LOG"
+                # Resolve in ONE getent per attempt and break only on a NON-EMPTY address. The previous
+                # shape probed with one getent and captured the address with a second one, so a single
+                # empty capture immediately after a successful probe killed the pod ~2s in while printing
+                # a 300s timeout it had never waited for (measured: B200 lws-ep worker, 2026-08-15).
+                # NR==1 also keeps a multi-record answer from producing a two-word LEADER_IP.
                 for i in ${DOLLAR}(seq 1 150); do
-                  if getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" >/dev/null 2>&1; then break; fi
+                  LEADER_IP=${DOLLAR}(getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" | awk 'NR==1{print ${DOLLAR}1; exit}')
+                  if [ -n "${DOLLAR}LEADER_IP" ]; then break; fi
                   sleep 2
                 done
-                LEADER_IP=${DOLLAR}(getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" | awk '{print ${DOLLAR}1}')
                 if [ -z "${DOLLAR}LEADER_IP" ]; then
                   echo "[decode-leader] FATAL: ${DOLLAR}LWS_LEADER_ADDRESS did not resolve within 300s; exiting for a clean restart (do NOT proceed with an empty leader address)"
                   exit 1
@@ -599,11 +614,16 @@ spec:
                 # 1.3.0-era images (NGC vllm-runtime:1.3.0 and derivatives) install into the system
                 # python and have NO venv. Activate only when present so one manifest serves both.
                 if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+                # Resolve in ONE getent per attempt and break only on a NON-EMPTY address. The previous
+                # shape probed with one getent and captured the address with a second one, so a single
+                # empty capture immediately after a successful probe killed the pod ~2s in while printing
+                # a 300s timeout it had never waited for (measured: B200 lws-ep worker, 2026-08-15).
+                # NR==1 also keeps a multi-record answer from producing a two-word LEADER_IP.
                 for i in ${DOLLAR}(seq 1 150); do
-                  if getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" >/dev/null 2>&1; then break; fi
+                  LEADER_IP=${DOLLAR}(getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" | awk 'NR==1{print ${DOLLAR}1; exit}')
+                  if [ -n "${DOLLAR}LEADER_IP" ]; then break; fi
                   sleep 2
                 done
-                LEADER_IP=${DOLLAR}(getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" | awk '{print ${DOLLAR}1}')
                 if [ -z "${DOLLAR}LEADER_IP" ]; then
                   echo "[decode-worker] FATAL: ${DOLLAR}LWS_LEADER_ADDRESS did not resolve within 300s; exiting for a clean restart (do NOT proceed with an empty leader address)"
                   exit 1


### PR DESCRIPTION
Two startup defects found while monitoring a live `lws-ep.yaml-template` (DP2 / TP8 / EP16) run of Nemotron-3-Ultra-550B-BF16 on B200 this morning. Both are in the nemotron/ultra manifests, both are measured, and the second one is what actually kills the run.

## 1. Leader-DNS guard could kill a pod 2 seconds in and blame a 300s timeout

The guard probed with one `getent hosts` and captured the address with a second one:

```bash
for i in $(seq 1 150); do
  if getent hosts "$LWS_LEADER_ADDRESS" >/dev/null 2>&1; then break; fi
  sleep 2
done
LEADER_IP=$(getent hosts "$LWS_LEADER_ADDRESS" | awk '{print $1}')
```

The loop breaks on the probe; the value comes from the capture. One empty capture right after a successful probe drops into the FATAL branch. Measured on the `lws-ep` worker: container up 06:53:38Z, `exit code 1` at 06:53:40Z — 2 seconds of life — printing

```
[ep dp1/worker] LEADER_IP= MY_IP=10.1.80.223
[ep worker] FATAL: ...-ep-0.<svc>.default did not resolve within 300s; exiting for a clean restart
```

a 300s timeout it never waited for. LWS recreated the pod, the retry resolved the leader immediately, and the pod has been `1/1 Running` since — so what reaches the operator is a bare `RESTARTS 1` plus a log line that points at the wrong thing.

Fixed at all 11 leader-resolve sites (`disagg/lws` ×4, `disagg/lws-pp` ×2, `disagg/lws-ep` ×1, `agg/lws` ×2, `agg/lws-ep` ×2): one `getent` per attempt, break only on a non-empty address, `awk NR==1 ... exit` so a multi-record answer can't yield a two-word `LEADER_IP`. FATAL now means what it claims.

## 2. `disagg/lws-ep` engine-ready timeout is ~4 seconds too small

`disagg/lws-ep` sets `VLLM_ENGINE_READY_TIMEOUT_S=1200`; `agg/lws-ep` already uses `2400` for the same checkpoint. Measured on the same run:

```
06:53:39Z  container start
06:54:45Z  ApiServer_0 / ApiServer_1 resolve config (spawned BEFORE the load)
~06:58:22Z API server starts waiting for engine cores
07:15:5xZ  runai_streamer 51023/51023 tensors, 21:06 elapsed
07:18:18Z  init engine (profile, create kv cache, warmup model) took 70.80 s
07:18:22Z  All engine subscriptions received by DP coordinator
07:18:22Z  ApiServer_0: TimeoutError: Timed out waiting for engine core processes to start ... Waited 1200s
07:18:31Z  vllm serve exits 1 -> LWS recreates the group -> another 25 minutes
```

The engine was ready within ~4 seconds of the deadline, so FSx read jitter decides it: the manifest can pass once and fail the next attempt. With `data_parallel_size > 1` vLLM builds a `DPLBAsyncMPClient` and the API-server process waits for the engine cores inside this budget, so the whole weight load counts against it. Raised to `2400` (~80% headroom over the measured 1337s), matching `agg/lws-ep`.

**`disagg/lws` and `disagg/lws-pp` are deliberately untouched.** They are PP-only, set no override, and readied fine on the vLLM default of 600s through the identical 21:06 load, so the DP path is what needs the raise. Those two templates are left byte-for-byte as validated.

## Verification

- All five templates render through `envsubst` to valid YAML (PyYAML `safe_load_all`) and every embedded launch script passes `bash -n`.
- The new resolve loop was executed inside a live pod on both paths: resolvable name breaks on iteration 1 with `LEADER_IP=10.1.219.142`; unresolvable name spends its full budget and leaves `LEADER_IP` empty, so the FATAL branch still fires.
- `getent hosts` on an absent pod name under the same headless service returns `rc=2` with no output, which is why the two-call shape is the defect rather than a resolver quirk.

Not yet verified end-to-end: a full `lws-ep` startup on the raised timeout. The measured requirement is 1337s and the new budget is 2400s, but the Ready event itself is still pending.

## 3. `disagg/lws-ep` uses `restartPolicy: None`, so a leader restart orphans the DP worker

The DP ranks share one TCPStore and one DP coordinator hosted by the leader, so a leader restart invalidates every rank. With `None`, LWS leaves the rest of the group untouched. Measured after the timeout above (leader container restarted 07:18:33Z):

- the DP1 worker was **not** recreated — `pid 1` was still the process started `06:53:40Z`, 31 minutes and one leader epoch later, holding 8 B200s of weights from the dead epoch
- it logged, against the leader's old store: `sendBytes failed on SocketImpl(... remote=[...-ep-0...]:50413): Broken pipe` and `[PG ID 0 Rank 13] Failed to check the "should dump" flag on TCPStore`
- so the restarted leader could never assemble `data_parallel_size=2` and would re-time-out every ~25 min, indefinitely

`agg/lws-ep` already uses `RecreateGroupOnPodRestart` for the same DP/EP topology — `disagg/lws-ep` was the outlier. The PP-only templates keep their current policy (`disagg/lws-pp` already sets `RecreateGroupOnPodRestart` on the PP prefill group and `None` on the size-1 decode group, which is correct for them).

Trade-off, stated because it cost a debugging cycle in #68: recreating the group deletes the crashed pod, so its logs go with it. That is the right trade here — a DP group that cannot self-assemble is worse than a lost log.

## Net

All three defects are `disagg/lws-ep` missing hardenings that `agg/lws-ep` already carries (`2400`, `RecreateGroupOnPodRestart`), plus the shared DNS guard shape. Fix 1 removes a misleading restart; fixes 2 and 3 are what stand between `lws-ep` and a Ready B200 deployment.
