### PR TITLE
Fix nemotron-ultra disagg lws-ep: add the missing -frontend Service the test scripts resolve

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-ep.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-ep.yaml-template
@@ -265,3 +265,43 @@ spec:
     - port: 8000
       targetPort: 8000
       name: http
+---
+# Frontend service alias - the piece that makes ../test/*.sh work against this permutation.
+#
+# The EP16 leader runs native `vllm serve` (not dynamo.vllm), so it already exposes the whole
+# OpenAI-compatible API on :8000 (/v1/completions, /v1/chat/completions, /v1/models, /health)
+# and no dynamo.frontend pod exists here - unlike lws / lws-pp / deployment, which each ship a
+# real ${DEPLOYMENT_NAME}-frontend Deployment. But ../test/.env hardcodes
+# SERVICE_NAME=${DOLLAR}{DEPLOYMENT_NAME}-frontend, so every test script (test-aiperf.sh,
+# test-chat-completions.sh, test-completions.sh, models-health.sh, models-list.sh,
+# aiperf-sweep) resolves a name that this template never created: the tests fail on DNS while
+# the deployment itself is perfectly healthy and serving. This alias closes that gap, exactly
+# as agg/lws-ep.yaml-template already does.
+#
+# Why a SECOND Service rather than relying on ${DEPLOYMENT_NAME}-ep above: that name collides
+# with the headless Service the LeaderWorkerSet controller creates for its own pod DNS, and
+# the controller OWNS it (ownerReferences controller=true, clusterIP: None,
+# publishNotReadyAddresses: true) - so it also answers for a leader that is still loading
+# weights. This alias is a plain ClusterIP nothing else owns, and it routes only to a READY
+# leader (readinessProbe = GET /health).
+#
+# Selector note: disagg labels the leader `dynamo-role: leader` where agg uses `dp-role`, and
+# the part-of label must stay ${DOLLAR}{DEPLOYMENT_NAME} (not -ep) because stop.sh sweeps
+# leftovers by `--selector app.kubernetes.io/part-of=${DOLLAR}{DEPLOYMENT_NAME}`.
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${DEPLOYMENT_NAME}-frontend
+  namespace: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}
+    app.kubernetes.io/component: frontend
+spec:
+  selector:
+    app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}
+    app.kubernetes.io/component: ep-agg
+    dynamo-role: leader
+  ports:
+    - port: 8000
+      targetPort: 8000
+      name: http


### PR DESCRIPTION
## Problem

`disagg/lws-ep.yaml-template` is the only LeaderWorkerSet template in the `nemotron/ultra` tree
that creates no `${DEPLOYMENT_NAME}-frontend` resource of any kind:

| template | `${DEPLOYMENT_NAME}-frontend` |
|---|---|
| `disagg/lws.yaml-template` | Deployment + Service |
| `disagg/lws-pp.yaml-template` | Deployment + Service |
| `disagg/deployment.yaml-template` | Deployment + Service |
| `agg/lws-ep.yaml-template` | Service alias (leader runs `vllm serve`) |
| **`disagg/lws-ep.yaml-template`** | **nothing** |
| `*/dgd.yaml-template` | created by the Dynamo operator |

The EP16 leader runs native `vllm serve`, not `dynamo.vllm`, so it already exposes the entire
OpenAI-compatible API on `:8000` (`/v1/completions`, `/v1/chat/completions`, `/v1/models`,
`/health`) and genuinely needs no frontend pod. But `../test/.env` hardcodes

```sh
export SERVICE_NAME=${DEPLOYMENT_NAME}-frontend
export SERVICE_URL="http://${SERVICE_NAME}.${NAMESPACE}.svc.cluster.local:8000"
```

so `test-aiperf.sh`, `test-chat-completions.sh`, `test-completions.sh`, `models-health.sh`,
`models-list.sh` and `aiperf-sweep.yaml-template` all resolve a name this template never
created. The tests fail on DNS resolution while the deployment itself is perfectly healthy and
serving — which is exactly what it looks like from the outside: "not crashing any more, but the
test does not work."

## Fix

Add the `${DEPLOYMENT_NAME}-frontend` Service alias, the same one `agg/lws-ep.yaml-template`
already carries. One new YAML document, no change to the LeaderWorkerSet.

## Verified live (p6-b200, 2 × `ml.p6-b200.48xlarge`, `EFA_PER_WORKER=8`)

Before, on a healthy EP16 run:

```
$ kubectl -n default get lws,svc
NAME                             READY   DESIRED   UP-TO-DATE   AGE
nemotron3-ultra-550b-disagg-ep   1       1         1            38m

NAME                             TYPE        CLUSTER-IP   PORT(S)    AGE
nemotron3-ultra-550b-disagg-ep   ClusterIP   None         8000/TCP   38m      <-- only Service

$ kubectl exec nemotron3-ultra-550b-disagg-ep-0 -- curl -s localhost:8000/v1/models
{"object":"list","data":[{"id":"nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16", ...}]}
HTTP /health = 200
```

The engine is up and answering; only the name the tests look for is missing.

## Why a second Service and not just `${DEPLOYMENT_NAME}-ep`

That name collides with the headless Service the LeaderWorkerSet controller creates for its own
pod DNS, and the controller **owns** it:

```
ownerReferences: [{kind: LeaderWorkerSet, controller: true, blockOwnerDeletion: true}]
clusterIP: None
publishNotReadyAddresses: true
```

`publishNotReadyAddresses` means it also answers for a leader that is still loading weights (a
~21 min window on 550B), so a test fired early gets a connection to a not-yet-serving engine
rather than waiting. The alias is a plain ClusterIP that nothing else owns, and it routes only
to a **READY** leader (`readinessProbe` = `GET /health`).

## Two details that differ from the agg copy

Pasting `agg/lws-ep`'s Service verbatim would produce a Service with **no endpoints** and a
resource that `stop.sh` leaks:

- the leader label here is `dynamo-role: leader`; `agg/lws-ep` uses `dp-role: leader`
- `part-of` must stay `${DEPLOYMENT_NAME}` (not `${DEPLOYMENT_NAME}-ep`) because `stop.sh`
  sweeps leftovers with `--selector app.kubernetes.io/part-of=${DEPLOYMENT_NAME}`

Both are handled and commented in the template.

## Gates

- `envsubst` renders 3 valid YAML documents, Service names unique (`yaml.safe_load_all`)
- `kubectl apply --dry-run=server` against the live cluster:
  `service/...-frontend created`, `service/...-ep unchanged`, **no change to the
  LeaderWorkerSet spec** (the only `kubectl diff` delta on the LWS came from my local `.env`
  defaults — `p5en.48xlarge`/EFA 16 vs the live `ml.p6-b200.48xlarge`/EFA 8 — not from this
  change)

## Applying to a run that is already up

No restart needed and no need to wait for this PR. On the live deployment, apply just the
Service:

```sh
kubectl -n default apply -f - <<'YAML'
apiVersion: v1
kind: Service
metadata:
  name: nemotron3-ultra-550b-disagg-frontend
  namespace: default
  labels:
    app.kubernetes.io/part-of: nemotron3-ultra-550b-disagg
    app.kubernetes.io/component: frontend
spec:
  selector:
    app.kubernetes.io/part-of: nemotron3-ultra-550b-disagg
    app.kubernetes.io/component: ep-agg
    dynamo-role: leader
  ports:
    - port: 8000
      targetPort: 8000
      name: http
YAML
```

Then `cd ../test && DEPLOYMENT_TYPE=disagg ./models-health.sh` before `./test-aiperf.sh` —
`test/.env` defaults to `DEPLOYMENT_TYPE=agg`, which would point `SERVICE_URL` at the agg name.

Re-running `MANIFEST_TYPE=lws-ep ./run.sh` after this merges is also safe: the LWS spec is
byte-identical, so the pods are not restarted; only the Service is added.
