### PR TITLE
nemotron/ultra: make agg/.env overridable like disagg/.env (${VAR:-default})

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/.env
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/.env
@@ -5,8 +5,11 @@ export IMAGE=${IMAGE:-dynamo-vllm-efa}
 export TAG=${TAG:-":1.3.1-patched"}
 
 export DOLLAR='$'
-export NAMESPACE=default
-export DEPLOYMENT_NAME=nemotron3-ultra-550b-agg
+# ${VAR:-default} everywhere: an unconditional export here would silently clobber a
+# caller's environment override (run.sh/stop.sh source this file) - for NAMESPACE that
+# means stop.sh could render its deletes into somebody ELSE's namespace.
+export NAMESPACE=${NAMESPACE:-default}
+export DEPLOYMENT_NAME=${DEPLOYMENT_NAME:-nemotron3-ultra-550b-agg}
 
 # MANIFEST_TYPE=deployment|lws|lws-ep|dgd
 #   deployment : plain Deployment, 1 worker node, TP8/PP1 (simplest)
@@ -19,11 +22,20 @@ export DEPLOYMENT_NAME=nemotron3-ultra-550b-agg
 # expert-parallel shape (EP16 per role + a real KV transfer, 2 * EP_DP_SIZE nodes): the folder
 # decides the mode, MANIFEST_TYPE decides the topology within it. Do not compare across the two
 # except at equal GPU count and on ITL / p50 TTFT.
-export MANIFEST_TYPE=deployment
-export INSTANCE_TYPE_FRONTEND=m5.8xlarge
-export INSTANCE_TYPE_WORKER=p5en.48xlarge
-export GPU_PER_WORKER=8
-export EFA_PER_WORKER=16
+export MANIFEST_TYPE=${MANIFEST_TYPE:-deployment}
+# ---- Cluster shape ----
+# All ${VAR:-default} so a different accelerator is a one-liner and needs no edit here:
+#   INSTANCE_TYPE_WORKER=p6-b200.48xlarge EFA_PER_WORKER=<node allocatable> ./run.sh
+# INSTANCE_TYPE_FRONTEND is a *preference*, not a requirement: the frontend prefers this
+# instance type and falls back to any schedulable node (incl. a GPU node) when the cluster
+# has none, so an all-GPU cluster does not leave the router Pending.
+export INSTANCE_TYPE_FRONTEND=${INSTANCE_TYPE_FRONTEND:-m5.8xlarge}
+export INSTANCE_TYPE_WORKER=${INSTANCE_TYPE_WORKER:-p5en.48xlarge}
+export GPU_PER_WORKER=${GPU_PER_WORKER:-8}
+# EFA_PER_WORKER must match what the EFA device plugin advertises on YOUR instance type - read
+# it, do not assume it, or the GPU pods sit Pending on Insufficient vpc.amazonaws.com/efa:
+#   kubectl get node <node> -o jsonpath='{.status.allocatable.vpc\.amazonaws\.com/efa}{"\n"}'
+export EFA_PER_WORKER=${EFA_PER_WORKER:-16}
 
 # lws-ep only: data-parallel group size; EP degree = EP_DP_SIZE * GPU_PER_WORKER.
 # The model's expert count must be divisible by the EP degree (Nemotron-3-Ultra 512 experts
@@ -50,17 +62,26 @@ case "${MODEL_VARIANT}" in
   nvfp4|NVFP4|fp4) _PREC_SUFFIX="NVFP4" ;;
   bf16|BF16|*)     _PREC_SUFFIX="BF16"  ;;
 esac
-export MODEL_NAME="${MODEL_REPO}-${_PREC_SUFFIX}"
-export MODEL_PATH="/shared/models/hf/${MODEL_NAME}"
+# MODEL_NAME override escape hatch: models outside the -BF16/-NVFP4 suffix convention
+# (e.g. MODEL_NAME=meta-llama/Llama-3.1-8B-Instruct for a fast smoke test) skip the
+# suffix derivation entirely. Default stays the Nemotron variant logic above.
+# NOTE: unlike ../disagg, these templates HARDCODE `--mamba-cache-mode align`, so a
+# non-Nemotron MODEL_NAME still needs the ${MAMBA_FLAGS} treatment ../disagg/.env has
+# before it will serve. Overriding MODEL_PATH alone (same model, different mount) is safe.
+export MODEL_NAME="${MODEL_NAME:-${MODEL_REPO}-${_PREC_SUFFIX}}"
+export MODEL_PATH="${MODEL_PATH:-/shared/models/hf/${MODEL_NAME}}"
 
-# Weight loader. Default "auto" = vLLM's HF safetensors path (works everywhere, but a cold
-# ~1 TB BF16 load over Lustre is slow — mostly why the startup probe had to be raised).
-# Faster options when the image provides them (the 1.3.x vllm-runtime registers both):
-#   runai_streamer  - streams shards, overlaps download+load
+# Weight loader. Default runai_streamer - streams shards and overlaps download+load, which is
+# what you want for a cold ~1 TB BF16 load over Lustre (that load is mostly why the startup
+# probe had to be raised). Other values the 1.3.x vllm-runtime registers:
+#   auto            - vLLM's HF safetensors path (works everywhere, slowest cold start)
 #   mx              - modelexpress MxModelLoader
-# Override per deployment, e.g. export LOAD_FORMAT=runai_streamer
-export LOAD_FORMAT=runai_streamer
-export LOAD_FORMAT="${LOAD_FORMAT:-auto}"
+# Override per deployment, e.g. export LOAD_FORMAT=auto
+# This was two exports - an unconditional `=runai_streamer` followed by a `:-auto` default
+# that could never fire, because the line above it had already made the variable non-empty.
+# Net effect: runai_streamer always won and `LOAD_FORMAT=auto ./run.sh` was silently ignored.
+# One guarded export, keeping runai_streamer as the value that was actually in force.
+export LOAD_FORMAT="${LOAD_FORMAT:-runai_streamer}"
 
 # ---- NVFP4 cold-start warmup (identical block and identical knobs in ../disagg/.env) ----
 # A fresh pod's FIRST requests pay a one-time Triton JIT of the Mamba DECODE kernels


### PR DESCRIPTION
Follow-up to #72 (merged). Requested by @iankouls-aws: add the `${VAR:-default}` parity fix to `agg/.env`.

## Why

`agg/.env` exported `NAMESPACE`, `DEPLOYMENT_NAME`, `MANIFEST_TYPE` and the cluster-shape vars **unconditionally**, while `disagg/.env` guards all of them. `run.sh` and `stop.sh` do `source .env`, so the unconditional export won over the caller's environment:

```
MANIFEST_TYPE=lws ./run.sh      # in agg/ silently deployed `deployment`, not lws
NAMESPACE=antonai ./stop.sh     # in agg/ rendered its deletes into `default`
```

`disagg/.env` already carried a comment about this exact hazard ("stop.sh could render its deletes into somebody ELSE's namespace"); `agg/.env` never got the same treatment.

## What changed

One file, `agg/.env`. Nine variables guarded, comments mirrored from `disagg/.env` so the two files read the same:

`NAMESPACE` `DEPLOYMENT_NAME` `MANIFEST_TYPE` `INSTANCE_TYPE_FRONTEND` `INSTANCE_TYPE_WORKER` `GPU_PER_WORKER` `EFA_PER_WORKER` `MODEL_NAME` `MODEL_PATH`

Also collapses a `LOAD_FORMAT` pair that could not do what it looked like:

```sh
export LOAD_FORMAT=runai_streamer
export LOAD_FORMAT="${LOAD_FORMAT:-auto}"   # inert - already non-empty
```

The `:-auto` default could never fire, so `runai_streamer` was always in force and `LOAD_FORMAT=auto ./run.sh` was silently ignored. Now one guarded export keeping `runai_streamer` — the value that was actually in effect, so no default moves — and the block comment no longer claims the default is `auto`.

`ETCD_URL`/`NATS_URL` are left unconditional because `disagg/.env` has them that way too. This is parity, not a sweep.

## Verification

All local, `kubectl` stubbed, no cluster touched.

| Gate | Result |
|---|---|
| Render byte-identity | **8/8** — all 4 agg types x BF16/NVFP4 rendered before and after with a clean env, `diff -r` empty. Proves no default moved. |
| Override honored | **9/9**, verified in the *rendered* YAML (`namespace: antonai`, `p6-b200.48xlarge`, `efa: "32"`, `gpu: "4"`, `--load-format auto`, `--tensor-parallel-size 4`) |
| `run.sh` + `stop.sh` driven | **36/36** over every manifest type x precision x folder, each output YAML-parsed |
| `bash -n` | **28/28** scripts + `.env` |

## Known gap left alone

`agg`'s templates hardcode `--mamba-cache-mode align` where `disagg` derives `${MAMBA_FLAGS}` from `MODEL_NAME`, so a non-Nemotron `MODEL_NAME` needs that work before it will serve. That changes rendered YAML and is a functional fix rather than a `${VAR:-default}` one, so it is not in this PR; the caveat is noted next to the new `MODEL_NAME` escape hatch.