### PR TITLE
nemotron/ultra/disagg: report the real engine exit code, and fail fast when the CNI gave the pod the node's own IP

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-2pp.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-2pp.yaml-template
@@ -95,7 +95,39 @@ spec:
                 fi
                 LOG=${DOLLAR}LOG_DIR/${DEPLOYMENT_NAME}-prefill-pp2-${DOLLAR}(date -u +%FT%TZ).log
                 echo "[prefill-leader] starting; piping to ${DOLLAR}LOG"
-                python3 -c "import vllm; print(f'vllm {vllm.__version__}')" 2>&1 | tee -a "${DOLLAR}LOG"
+                # One tee for the whole shell, then exec the engine with NO pipe, so the engine is the
+                # container's main process. Previously `exec python3 ... | tee -a "${DOLLAR}LOG"` left bash as the main
+                # process and made the container's status tee's - always 0 - so an engine that died on an
+                # unhandled exception reported "Reason: Completed / Exit Code: 0" in `kubectl describe` and
+                # only the startupProbe failure hinted otherwise; SIGTERM on pod delete also went to bash
+                # instead of the engine. Verified: the status propagates and the traceback still reaches both
+                # `kubectl logs` and "${DOLLAR}LOG" (10/10 runs).
+                exec > >(tee -a "${DOLLAR}LOG") 2>&1
+                # Same node-fault preflight as disagg/lws-2pp.yaml-template - a duplicate pod address
+                # (podIP == hostIP) is fatal and un-restartable, then a bounded wait for cluster DNS.
+                # See that file for the mechanism and the measured incident.
+                if [ -n "${DOLLAR}{MY_IP:-}" ] && [ "${DOLLAR}{MY_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
+                  echo "[prefill-leader] FATAL: pod IP ${DOLLAR}MY_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                  echo "[prefill-leader]        The CNI gave this sandbox the node's primary ENI address, so cluster DNS"
+                  echo "[prefill-leader]        cannot answer and NATS/etcd are unreachable. RESTARTING WILL NOT HELP -"
+                  echo "[prefill-leader]        the sandbox keeps the address. Remedy:"
+                  echo "[prefill-leader]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                  exit 1
+                fi
+                if command -v getent >/dev/null 2>&1; then
+                  NATS_HOST=${DOLLAR}{NATS_SERVER#*://}; NATS_HOST=${DOLLAR}{NATS_HOST%%:*}
+                  for i in ${DOLLAR}(seq 1 30); do
+                    if getent hosts "${DOLLAR}NATS_HOST" >/dev/null 2>&1; then break; fi
+                    if [ "${DOLLAR}i" = 30 ]; then
+                      echo "[prefill-leader] FATAL: cannot resolve ${DOLLAR}NATS_HOST after 60s - cluster DNS is broken for"
+                      echo "[prefill-leader]        this pod. Check CoreDNS and the CNI, then:"
+                      echo "[prefill-leader]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                      exit 1
+                    fi
+                    sleep 2
+                  done
+                fi
+                python3 -c "import vllm; print(f'vllm {vllm.__version__}')"
                 # Resolve in ONE getent per attempt and break only on a NON-EMPTY address. The previous
                 # shape probed with one getent and captured the address with a second one, so a single
                 # empty capture immediately after a successful probe killed the pod ~2s in while printing
@@ -106,12 +138,12 @@ spec:
                   if [ -n "${DOLLAR}LEADER_IP" ]; then break; fi
                   sleep 2
                 done
-                echo "[prefill-leader] LEADER_IP=${DOLLAR}LEADER_IP MY_IP=${DOLLAR}MY_IP" | tee -a "${DOLLAR}LOG"
+                echo "[prefill-leader] LEADER_IP=${DOLLAR}LEADER_IP MY_IP=${DOLLAR}MY_IP"
                 if [ -z "${DOLLAR}LEADER_IP" ]; then
                   echo "[prefill-leader] FATAL: ${DOLLAR}LWS_LEADER_ADDRESS did not resolve within 300s; exiting for a clean restart (do NOT proceed with an empty leader address)"
                   exit 1
                 fi
-                ray start --head --port=6379 --node-ip-address="${DOLLAR}LEADER_IP" --num-gpus=${GPU_PER_WORKER} 2>&1 | tee -a "${DOLLAR}LOG"
+                ray start --head --port=6379 --node-ip-address="${DOLLAR}LEADER_IP" --num-gpus=${GPU_PER_WORKER}
                 for i in ${DOLLAR}(seq 1 120); do
                   N=${DOLLAR}(ray status 2>/dev/null | awk '/Active:/{flag=1; next} /Pending:|Recent failures:|Resources/{flag=0} flag' | grep -c node_ || true)
                   if [ "${DOLLAR}{N:-0}" -ge 2 ]; then break; fi
@@ -130,9 +162,11 @@ spec:
                   ${MAMBA_FLAGS} \
                   --load-format runai_streamer \
                   --disaggregation-mode prefill \
-                  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}' 2>&1 | tee -a "${DOLLAR}LOG"
+                  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}'
             env:
               - { name: MY_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+              # NODE_IP is read only by the node-fault preflight in args above (podIP == hostIP).
+              - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
               - { name: DYNAMO_BACKEND, value: vllm }
               - { name: DYN_NAMESPACE, value: dynamo-disagg }
               - { name: ETCD_ENDPOINTS, value: "${ETCD_URL}" }
@@ -326,7 +360,49 @@ spec:
                 fi
                 LOG=${DOLLAR}LOG_DIR/${DEPLOYMENT_NAME}-decode-pp1-${DOLLAR}(date -u +%FT%TZ).log
                 echo "[decode] starting; piping to ${DOLLAR}LOG"
-                python3 -c "import vllm; print(f'vllm {vllm.__version__}')" 2>&1 | tee -a "${DOLLAR}LOG"
+                # One tee for the whole shell, then exec the engine with NO pipe, so the engine is the
+                # container's main process. Previously `exec python3 ... | tee -a "${DOLLAR}LOG"` left bash as the main
+                # process and made the container's status tee's - always 0 - so an engine that died on an
+                # unhandled exception reported "Reason: Completed / Exit Code: 0" in `kubectl describe` and
+                # only the startupProbe failure hinted otherwise; SIGTERM on pod delete also went to bash
+                # instead of the engine. Verified: the status propagates and the traceback still reaches both
+                # `kubectl logs` and "${DOLLAR}LOG" (10/10 runs).
+                exec > >(tee -a "${DOLLAR}LOG") 2>&1
+                # Preflight for the two node-local faults that otherwise surface ~40s from now as a Python
+                # traceback at the BOTTOM of the log instead of a diagnosis at the top.
+                # (a) Duplicate pod address. When the CNI hands this sandbox the node's own primary ENI
+                #     address (status.podIP == status.hostIP while hostNetwork is false), kube-proxy DNAT
+                #     replies land in the host netns, cluster DNS never answers, and DistributedRuntime dies
+                #     with "Failed to connect to NATS: DNS error ... Temporary failure in name resolution".
+                #     A container RESTART CANNOT CLEAR THIS: restarts reuse the pod sandbox, so CNI ADD is
+                #     not re-invoked and the address is pinned for the pod's lifetime - the pod object has to
+                #     be deleted. Measured on a 4-node ml.p6-b200.48xlarge disagg run (2026-08-15): one decode
+                #     pod looped 6x on a byte-identical failure, 47s per attempt, while its sibling on another
+                #     node loaded normally. Fail in 1s and name the remedy instead of loading for 47s first.
+                # (b) Cluster DNS not answering for this pod YET, which is transient on a fresh node - so retry
+                #     for 60s before giving up. That converts a crash-loop into a normal start.
+                if [ -n "${DOLLAR}{MY_IP:-}" ] && [ "${DOLLAR}{MY_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
+                  echo "[decode] FATAL: pod IP ${DOLLAR}MY_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                  echo "[decode]        The CNI gave this sandbox the node's primary ENI address, so cluster DNS"
+                  echo "[decode]        cannot answer and NATS/etcd are unreachable. RESTARTING WILL NOT HELP -"
+                  echo "[decode]        the sandbox keeps the address. Remedy:"
+                  echo "[decode]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                  exit 1
+                fi
+                if command -v getent >/dev/null 2>&1; then
+                  NATS_HOST=${DOLLAR}{NATS_SERVER#*://}; NATS_HOST=${DOLLAR}{NATS_HOST%%:*}
+                  for i in ${DOLLAR}(seq 1 30); do
+                    if getent hosts "${DOLLAR}NATS_HOST" >/dev/null 2>&1; then break; fi
+                    if [ "${DOLLAR}i" = 30 ]; then
+                      echo "[decode] FATAL: cannot resolve ${DOLLAR}NATS_HOST after 60s - cluster DNS is broken for"
+                      echo "[decode]        this pod. Check CoreDNS and the CNI, then:"
+                      echo "[decode]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                      exit 1
+                    fi
+                    sleep 2
+                  done
+                fi
+                python3 -c "import vllm; print(f'vllm {vllm.__version__}')"
                 # Cold-start warmup (detached) - same block as the sibling templates in this
                 # folder and in ../agg; see .env for the WARMUP_* knobs. A fresh pod's FIRST
                 # request pays a one-time ~4min Triton JIT compiling the Mamba DECODE kernels
@@ -419,9 +495,11 @@ spec:
                   ${MAMBA_FLAGS} \
                   --load-format runai_streamer \
                   --disaggregation-mode decode \
-                  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}' 2>&1 | tee -a "${DOLLAR}LOG"
+                  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}'
             env:
               - { name: MY_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+              # NODE_IP is read only by the node-fault preflight in args above (podIP == hostIP).
+              - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
               - { name: DYNAMO_BACKEND, value: vllm }
               - { name: DYN_NAMESPACE, value: dynamo-disagg }
               - { name: ETCD_ENDPOINTS, value: "${ETCD_URL}" }

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-ep.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-ep.yaml-template
@@ -127,7 +127,39 @@ spec:
                 fi
                 LOG=${DOLLAR}LOG_DIR/${DEPLOYMENT_NAME}-prefill-ep-${DOLLAR}(date -u +%FT%TZ).log
                 echo "[prefill-dp0] MY_IP=${DOLLAR}MY_IP EP=$((${EP_DP_SIZE}*${GPU_PER_WORKER})); piping to ${DOLLAR}LOG"
-                python3 -c "import vllm; print(f'vllm {vllm.__version__}')" 2>&1 | tee -a "${DOLLAR}LOG"
+                # One tee for the whole shell, then exec the engine with NO pipe, so the engine is the
+                # container's main process. Previously `exec python3 ... | tee -a "${DOLLAR}LOG"` left bash as the main
+                # process and made the container's status tee's - always 0 - so an engine that died on an
+                # unhandled exception reported "Reason: Completed / Exit Code: 0" in `kubectl describe` and
+                # only the startupProbe failure hinted otherwise; SIGTERM on pod delete also went to bash
+                # instead of the engine. Verified: the status propagates and the traceback still reaches both
+                # `kubectl logs` and "${DOLLAR}LOG" (10/10 runs).
+                exec > >(tee -a "${DOLLAR}LOG") 2>&1
+                # Same node-fault preflight as disagg/lws-2pp.yaml-template - a duplicate pod address
+                # (podIP == hostIP) is fatal and un-restartable, then a bounded wait for cluster DNS.
+                # See that file for the mechanism and the measured incident.
+                if [ -n "${DOLLAR}{MY_IP:-}" ] && [ "${DOLLAR}{MY_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
+                  echo "[prefill-dp0] FATAL: pod IP ${DOLLAR}MY_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                  echo "[prefill-dp0]        The CNI gave this sandbox the node's primary ENI address, so cluster DNS"
+                  echo "[prefill-dp0]        cannot answer and NATS/etcd are unreachable. RESTARTING WILL NOT HELP -"
+                  echo "[prefill-dp0]        the sandbox keeps the address. Remedy:"
+                  echo "[prefill-dp0]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                  exit 1
+                fi
+                if command -v getent >/dev/null 2>&1; then
+                  NATS_HOST=${DOLLAR}{NATS_SERVER#*://}; NATS_HOST=${DOLLAR}{NATS_HOST%%:*}
+                  for i in ${DOLLAR}(seq 1 30); do
+                    if getent hosts "${DOLLAR}NATS_HOST" >/dev/null 2>&1; then break; fi
+                    if [ "${DOLLAR}i" = 30 ]; then
+                      echo "[prefill-dp0] FATAL: cannot resolve ${DOLLAR}NATS_HOST after 60s - cluster DNS is broken for"
+                      echo "[prefill-dp0]        this pod. Check CoreDNS and the CNI, then:"
+                      echo "[prefill-dp0]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                      exit 1
+                    fi
+                    sleep 2
+                  done
+                fi
+                python3 -c "import vllm; print(f'vllm {vllm.__version__}')"
                 # DP rank 0 also hosts the DP coordinator + TCPStore on --data-parallel-address.
                 exec python3 -m dynamo.vllm \
                   --model ${MODEL_PATH} \
@@ -146,9 +178,11 @@ spec:
                   ${MAMBA_FLAGS} \
                   --load-format runai_streamer \
                   --disaggregation-mode prefill \
-                  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}' 2>&1 | tee -a "${DOLLAR}LOG"
+                  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}'
             env:
               - { name: MY_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+              # NODE_IP is read only by the node-fault preflight in args above (podIP == hostIP).
+              - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
               - { name: DYNAMO_BACKEND, value: vllm }
               - { name: DYN_NAMESPACE, value: dynamo-disagg }
               - { name: ETCD_ENDPOINTS, value: "${ETCD_URL}" }
@@ -233,6 +267,30 @@ spec:
                 unset HPCX_DIR HPCX_MPI_DIR HPCX_HOME HPCX_UCX_DIR HPCX_SHARP_DIR \
                       HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
                 if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+                # Same node-fault preflight as disagg/lws-2pp.yaml-template - a duplicate pod address
+                # (podIP == hostIP) is fatal and un-restartable, then a bounded wait for cluster DNS.
+                # See that file for the mechanism and the measured incident.
+                if [ -n "${DOLLAR}{MY_IP:-}" ] && [ "${DOLLAR}{MY_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
+                  echo "[prefill-dp${DOLLAR}{LWS_WORKER_INDEX}] FATAL: pod IP ${DOLLAR}MY_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                  echo "[prefill-dp${DOLLAR}{LWS_WORKER_INDEX}]        The CNI gave this sandbox the node's primary ENI address, so cluster DNS"
+                  echo "[prefill-dp${DOLLAR}{LWS_WORKER_INDEX}]        cannot answer and NATS/etcd are unreachable. RESTARTING WILL NOT HELP -"
+                  echo "[prefill-dp${DOLLAR}{LWS_WORKER_INDEX}]        the sandbox keeps the address. Remedy:"
+                  echo "[prefill-dp${DOLLAR}{LWS_WORKER_INDEX}]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                  exit 1
+                fi
+                if command -v getent >/dev/null 2>&1; then
+                  NATS_HOST=${DOLLAR}{NATS_SERVER#*://}; NATS_HOST=${DOLLAR}{NATS_HOST%%:*}
+                  for i in ${DOLLAR}(seq 1 30); do
+                    if getent hosts "${DOLLAR}NATS_HOST" >/dev/null 2>&1; then break; fi
+                    if [ "${DOLLAR}i" = 30 ]; then
+                      echo "[prefill-dp${DOLLAR}{LWS_WORKER_INDEX}] FATAL: cannot resolve ${DOLLAR}NATS_HOST after 60s - cluster DNS is broken for"
+                      echo "[prefill-dp${DOLLAR}{LWS_WORKER_INDEX}]        this pod. Check CoreDNS and the CNI, then:"
+                      echo "[prefill-dp${DOLLAR}{LWS_WORKER_INDEX}]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                      exit 1
+                    fi
+                    sleep 2
+                  done
+                fi
                 # ONE getent per attempt, break only on a NON-EMPTY address: probing with one
                 # getent and capturing with a second let a single empty capture kill the pod ~2s
                 # in while printing a 300s timeout it never waited. NR==1 keeps a multi-record
@@ -277,6 +335,8 @@ spec:
                   --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}'
             env:
               - { name: MY_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+              # NODE_IP is read only by the node-fault preflight in args above (podIP == hostIP).
+              - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
               - { name: DYNAMO_BACKEND, value: vllm }
               - { name: DYN_NAMESPACE, value: dynamo-disagg }
               - { name: ETCD_ENDPOINTS, value: "${ETCD_URL}" }
@@ -372,7 +432,39 @@ spec:
                 fi
                 LOG=${DOLLAR}LOG_DIR/${DEPLOYMENT_NAME}-decode-ep-${DOLLAR}(date -u +%FT%TZ).log
                 echo "[decode-dp0] MY_IP=${DOLLAR}MY_IP EP=$((${EP_DP_SIZE}*${GPU_PER_WORKER})); piping to ${DOLLAR}LOG"
-                python3 -c "import vllm; print(f'vllm {vllm.__version__}')" 2>&1 | tee -a "${DOLLAR}LOG"
+                # One tee for the whole shell, then exec the engine with NO pipe, so the engine is the
+                # container's main process. Previously `exec python3 ... | tee -a "${DOLLAR}LOG"` left bash as the main
+                # process and made the container's status tee's - always 0 - so an engine that died on an
+                # unhandled exception reported "Reason: Completed / Exit Code: 0" in `kubectl describe` and
+                # only the startupProbe failure hinted otherwise; SIGTERM on pod delete also went to bash
+                # instead of the engine. Verified: the status propagates and the traceback still reaches both
+                # `kubectl logs` and "${DOLLAR}LOG" (10/10 runs).
+                exec > >(tee -a "${DOLLAR}LOG") 2>&1
+                # Same node-fault preflight as disagg/lws-2pp.yaml-template - a duplicate pod address
+                # (podIP == hostIP) is fatal and un-restartable, then a bounded wait for cluster DNS.
+                # See that file for the mechanism and the measured incident.
+                if [ -n "${DOLLAR}{MY_IP:-}" ] && [ "${DOLLAR}{MY_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
+                  echo "[decode-dp0] FATAL: pod IP ${DOLLAR}MY_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                  echo "[decode-dp0]        The CNI gave this sandbox the node's primary ENI address, so cluster DNS"
+                  echo "[decode-dp0]        cannot answer and NATS/etcd are unreachable. RESTARTING WILL NOT HELP -"
+                  echo "[decode-dp0]        the sandbox keeps the address. Remedy:"
+                  echo "[decode-dp0]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                  exit 1
+                fi
+                if command -v getent >/dev/null 2>&1; then
+                  NATS_HOST=${DOLLAR}{NATS_SERVER#*://}; NATS_HOST=${DOLLAR}{NATS_HOST%%:*}
+                  for i in ${DOLLAR}(seq 1 30); do
+                    if getent hosts "${DOLLAR}NATS_HOST" >/dev/null 2>&1; then break; fi
+                    if [ "${DOLLAR}i" = 30 ]; then
+                      echo "[decode-dp0] FATAL: cannot resolve ${DOLLAR}NATS_HOST after 60s - cluster DNS is broken for"
+                      echo "[decode-dp0]        this pod. Check CoreDNS and the CNI, then:"
+                      echo "[decode-dp0]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                      exit 1
+                    fi
+                    sleep 2
+                  done
+                fi
+                python3 -c "import vllm; print(f'vllm {vllm.__version__}')"
                 # Cold-start warmup (detached) - identical block to the other templates in this
                 # folder and in ../agg; see ../.env for the WARMUP_* knobs. A fresh pod's FIRST
                 # request pays a one-time ~4min Triton JIT compiling the Mamba DECODE kernels
@@ -455,9 +547,11 @@ spec:
                   ${MAMBA_FLAGS} \
                   --load-format runai_streamer \
                   --disaggregation-mode decode \
-                  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}' 2>&1 | tee -a "${DOLLAR}LOG"
+                  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}'
             env:
               - { name: MY_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+              # NODE_IP is read only by the node-fault preflight in args above (podIP == hostIP).
+              - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
               - { name: DYNAMO_BACKEND, value: vllm }
               - { name: DYN_NAMESPACE, value: dynamo-disagg }
               - { name: ETCD_ENDPOINTS, value: "${ETCD_URL}" }
@@ -541,6 +635,30 @@ spec:
                 unset HPCX_DIR HPCX_MPI_DIR HPCX_HOME HPCX_UCX_DIR HPCX_SHARP_DIR \
                       HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
                 if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+                # Same node-fault preflight as disagg/lws-2pp.yaml-template - a duplicate pod address
+                # (podIP == hostIP) is fatal and un-restartable, then a bounded wait for cluster DNS.
+                # See that file for the mechanism and the measured incident.
+                if [ -n "${DOLLAR}{MY_IP:-}" ] && [ "${DOLLAR}{MY_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
+                  echo "[decode-dp${DOLLAR}{LWS_WORKER_INDEX}] FATAL: pod IP ${DOLLAR}MY_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                  echo "[decode-dp${DOLLAR}{LWS_WORKER_INDEX}]        The CNI gave this sandbox the node's primary ENI address, so cluster DNS"
+                  echo "[decode-dp${DOLLAR}{LWS_WORKER_INDEX}]        cannot answer and NATS/etcd are unreachable. RESTARTING WILL NOT HELP -"
+                  echo "[decode-dp${DOLLAR}{LWS_WORKER_INDEX}]        the sandbox keeps the address. Remedy:"
+                  echo "[decode-dp${DOLLAR}{LWS_WORKER_INDEX}]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                  exit 1
+                fi
+                if command -v getent >/dev/null 2>&1; then
+                  NATS_HOST=${DOLLAR}{NATS_SERVER#*://}; NATS_HOST=${DOLLAR}{NATS_HOST%%:*}
+                  for i in ${DOLLAR}(seq 1 30); do
+                    if getent hosts "${DOLLAR}NATS_HOST" >/dev/null 2>&1; then break; fi
+                    if [ "${DOLLAR}i" = 30 ]; then
+                      echo "[decode-dp${DOLLAR}{LWS_WORKER_INDEX}] FATAL: cannot resolve ${DOLLAR}NATS_HOST after 60s - cluster DNS is broken for"
+                      echo "[decode-dp${DOLLAR}{LWS_WORKER_INDEX}]        this pod. Check CoreDNS and the CNI, then:"
+                      echo "[decode-dp${DOLLAR}{LWS_WORKER_INDEX}]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                      exit 1
+                    fi
+                    sleep 2
+                  done
+                fi
                 # One getent per attempt, break only on a NON-EMPTY address - see the prefill worker.
                 for i in ${DOLLAR}(seq 1 150); do
                   LEADER_IP=${DOLLAR}(getent hosts "${DOLLAR}LWS_LEADER_ADDRESS" | awk 'NR==1{print ${DOLLAR}1; exit}')
@@ -578,6 +696,8 @@ spec:
                   --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}'
             env:
               - { name: MY_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+              # NODE_IP is read only by the node-fault preflight in args above (podIP == hostIP).
+              - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
               - { name: DYNAMO_BACKEND, value: vllm }
               - { name: DYN_NAMESPACE, value: dynamo-disagg }
               - { name: ETCD_ENDPOINTS, value: "${ETCD_URL}" }

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-pp2.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-pp2.yaml-template
@@ -160,10 +160,42 @@ spec:
                 fi
                 LOG=${DOLLAR}LOG_DIR/disagg-prefill-p5en-$(date -u +%FT%TZ).log
                 echo "[prefill-leader p5en] starting; piping to ${DOLLAR}LOG"
-                python3 -c "import vllm; print(f'vllm {vllm.__version__}')" 2>&1 | tee -a "${DOLLAR}LOG"
+                # One tee for the whole shell, then exec the engine with NO pipe, so the engine is the
+                # container's main process. Previously `exec python3 ... | tee -a "${DOLLAR}LOG"` left bash as the main
+                # process and made the container's status tee's - always 0 - so an engine that died on an
+                # unhandled exception reported "Reason: Completed / Exit Code: 0" in `kubectl describe` and
+                # only the startupProbe failure hinted otherwise; SIGTERM on pod delete also went to bash
+                # instead of the engine. Verified: the status propagates and the traceback still reaches both
+                # `kubectl logs` and "${DOLLAR}LOG" (10/10 runs).
+                exec > >(tee -a "${DOLLAR}LOG") 2>&1
+                # Same node-fault preflight as disagg/lws-2pp.yaml-template - a duplicate pod address
+                # (podIP == hostIP) is fatal and un-restartable, then a bounded wait for cluster DNS.
+                # See that file for the mechanism and the measured incident.
+                if [ -n "${DOLLAR}{MY_IP:-}" ] && [ "${DOLLAR}{MY_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
+                  echo "[prefill-leader p5en] FATAL: pod IP ${DOLLAR}MY_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                  echo "[prefill-leader p5en]        The CNI gave this sandbox the node's primary ENI address, so cluster DNS"
+                  echo "[prefill-leader p5en]        cannot answer and NATS/etcd are unreachable. RESTARTING WILL NOT HELP -"
+                  echo "[prefill-leader p5en]        the sandbox keeps the address. Remedy:"
+                  echo "[prefill-leader p5en]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                  exit 1
+                fi
+                if command -v getent >/dev/null 2>&1; then
+                  NATS_HOST=${DOLLAR}{NATS_SERVER#*://}; NATS_HOST=${DOLLAR}{NATS_HOST%%:*}
+                  for i in ${DOLLAR}(seq 1 30); do
+                    if getent hosts "${DOLLAR}NATS_HOST" >/dev/null 2>&1; then break; fi
+                    if [ "${DOLLAR}i" = 30 ]; then
+                      echo "[prefill-leader p5en] FATAL: cannot resolve ${DOLLAR}NATS_HOST after 60s - cluster DNS is broken for"
+                      echo "[prefill-leader p5en]        this pod. Check CoreDNS and the CNI, then:"
+                      echo "[prefill-leader p5en]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                      exit 1
+                    fi
+                    sleep 2
+                  done
+                fi
+                python3 -c "import vllm; print(f'vllm {vllm.__version__}')"
                 # Verify the PR #42522 patch is present
                 VLLM_DIR=${DOLLAR}(python3 -c "import vllm, os; print(os.path.dirname(vllm.__file__))")
-                grep -A2 "is_kv_consumer" "${DOLLAR}VLLM_DIR/model_executor/models/config.py" 2>&1 | tee -a "${DOLLAR}LOG"
+                grep -A2 "is_kv_consumer" "${DOLLAR}VLLM_DIR/model_executor/models/config.py"
                 # Resolve in ONE getent per attempt and break only on a NON-EMPTY address. The previous
                 # shape probed with one getent and captured the address with a second one, so a single
                 # empty capture immediately after a successful probe killed the pod ~2s in while printing
@@ -174,7 +206,7 @@ spec:
                   if [ -n "${DOLLAR}LEADER_IP" ]; then break; fi
                   sleep 2
                 done
-                echo "[prefill-leader p5en] LEADER_IP=${DOLLAR}LEADER_IP" | tee -a "${DOLLAR}LOG"
+                echo "[prefill-leader p5en] LEADER_IP=${DOLLAR}LEADER_IP"
                 if [ -z "${DOLLAR}LEADER_IP" ]; then
                   echo "[prefill-leader] FATAL: ${DOLLAR}LWS_LEADER_ADDRESS did not resolve within 300s; exiting for a clean restart (do NOT proceed with an empty leader address)"
                   exit 1
@@ -182,11 +214,11 @@ spec:
                 # ---- Gloo bind interface: REQUIRED whenever hostNetwork: true (see header note 6) ----
                 export GLOO_SOCKET_IFNAME=${DOLLAR}{GLOO_SOCKET_IFNAME:-${DOLLAR}(ip -o -4 route show default | awk '{print ${DOLLAR}5; exit}')}
                 GLOO_BIND_IP=${DOLLAR}(ip -o -4 addr show dev "${DOLLAR}GLOO_SOCKET_IFNAME" 2>/dev/null | awk '{print ${DOLLAR}4; exit}' | cut -d/ -f1)
-                echo "[prefill-leader] GLOO_SOCKET_IFNAME=${DOLLAR}GLOO_SOCKET_IFNAME bind=${DOLLAR}GLOO_BIND_IP" | tee -a "${DOLLAR}LOG"
+                echo "[prefill-leader] GLOO_SOCKET_IFNAME=${DOLLAR}GLOO_SOCKET_IFNAME bind=${DOLLAR}GLOO_BIND_IP"
                 case "${DOLLAR}{GLOO_BIND_IP:-}" in
-                  ""|127.*) echo "[prefill-leader] FATAL: GLOO_SOCKET_IFNAME=${DOLLAR}GLOO_SOCKET_IFNAME has no routable IPv4 (got '${DOLLAR}GLOO_BIND_IP'); cross-node Gloo would bind loopback and connectFullMesh would fail. Exiting for a clean restart." | tee -a "${DOLLAR}LOG"; exit 1 ;;
+                  ""|127.*) echo "[prefill-leader] FATAL: GLOO_SOCKET_IFNAME=${DOLLAR}GLOO_SOCKET_IFNAME has no routable IPv4 (got '${DOLLAR}GLOO_BIND_IP'); cross-node Gloo would bind loopback and connectFullMesh would fail. Exiting for a clean restart."; exit 1 ;;
                 esac
-                ray start --head --port=6379 --node-ip-address="${DOLLAR}LEADER_IP" --num-gpus=${GPU_PER_WORKER} 2>&1 | tee -a "${DOLLAR}LOG"
+                ray start --head --port=6379 --node-ip-address="${DOLLAR}LEADER_IP" --num-gpus=${GPU_PER_WORKER}
                 for i in ${DOLLAR}(seq 1 120); do
                   N=${DOLLAR}(ray status 2>/dev/null | awk '/Active:/{flag=1; next} /Pending:|Recent failures:|Resources/{flag=0} flag' | grep -c node_ || true)
                   if [ "${DOLLAR}{N:-0}" -ge 2 ]; then break; fi
@@ -205,9 +237,11 @@ spec:
                   ${MAMBA_FLAGS} \
                   --load-format runai_streamer \
                   --disaggregation-mode prefill \
-                  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}' 2>&1 | tee -a "${DOLLAR}LOG"
+                  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}'
             env:
               - { name: MY_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+              # NODE_IP is read only by the node-fault preflight in args above (podIP == hostIP).
+              - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
               - { name: DYNAMO_BACKEND, value: vllm }
               - { name: DYN_NAMESPACE, value: dynamo-disagg }
               - { name: ETCD_ENDPOINTS, value: "${ETCD_URL}" }
@@ -418,9 +452,41 @@ spec:
                 fi
                 LOG=${DOLLAR}LOG_DIR/disagg-decode-p5en-$(date -u +%FT%TZ).log
                 echo "[decode p5en] starting; piping to ${DOLLAR}LOG"
-                python3 -c "import vllm; print(f'vllm {vllm.__version__}')" 2>&1 | tee -a "${DOLLAR}LOG"
+                # One tee for the whole shell, then exec the engine with NO pipe, so the engine is the
+                # container's main process. Previously `exec python3 ... | tee -a "${DOLLAR}LOG"` left bash as the main
+                # process and made the container's status tee's - always 0 - so an engine that died on an
+                # unhandled exception reported "Reason: Completed / Exit Code: 0" in `kubectl describe` and
+                # only the startupProbe failure hinted otherwise; SIGTERM on pod delete also went to bash
+                # instead of the engine. Verified: the status propagates and the traceback still reaches both
+                # `kubectl logs` and "${DOLLAR}LOG" (10/10 runs).
+                exec > >(tee -a "${DOLLAR}LOG") 2>&1
+                # Same node-fault preflight as disagg/lws-2pp.yaml-template - a duplicate pod address
+                # (podIP == hostIP) is fatal and un-restartable, then a bounded wait for cluster DNS.
+                # See that file for the mechanism and the measured incident.
+                if [ -n "${DOLLAR}{MY_IP:-}" ] && [ "${DOLLAR}{MY_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
+                  echo "[decode p5en] FATAL: pod IP ${DOLLAR}MY_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                  echo "[decode p5en]        The CNI gave this sandbox the node's primary ENI address, so cluster DNS"
+                  echo "[decode p5en]        cannot answer and NATS/etcd are unreachable. RESTARTING WILL NOT HELP -"
+                  echo "[decode p5en]        the sandbox keeps the address. Remedy:"
+                  echo "[decode p5en]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                  exit 1
+                fi
+                if command -v getent >/dev/null 2>&1; then
+                  NATS_HOST=${DOLLAR}{NATS_SERVER#*://}; NATS_HOST=${DOLLAR}{NATS_HOST%%:*}
+                  for i in ${DOLLAR}(seq 1 30); do
+                    if getent hosts "${DOLLAR}NATS_HOST" >/dev/null 2>&1; then break; fi
+                    if [ "${DOLLAR}i" = 30 ]; then
+                      echo "[decode p5en] FATAL: cannot resolve ${DOLLAR}NATS_HOST after 60s - cluster DNS is broken for"
+                      echo "[decode p5en]        this pod. Check CoreDNS and the CNI, then:"
+                      echo "[decode p5en]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                      exit 1
+                    fi
+                    sleep 2
+                  done
+                fi
+                python3 -c "import vllm; print(f'vllm {vllm.__version__}')"
                 VLLM_DIR=${DOLLAR}(python3 -c "import vllm, os; print(os.path.dirname(vllm.__file__))")
-                grep -A2 "is_kv_consumer" "${DOLLAR}VLLM_DIR/model_executor/models/config.py" 2>&1 | tee -a "${DOLLAR}LOG"
+                grep -A2 "is_kv_consumer" "${DOLLAR}VLLM_DIR/model_executor/models/config.py"
                 # Resolve in ONE getent per attempt and break only on a NON-EMPTY address. The previous
                 # shape probed with one getent and captured the address with a second one, so a single
                 # empty capture immediately after a successful probe killed the pod ~2s in while printing
@@ -438,11 +504,11 @@ spec:
                 # ---- Gloo bind interface: REQUIRED whenever hostNetwork: true (see header note 6) ----
                 export GLOO_SOCKET_IFNAME=${DOLLAR}{GLOO_SOCKET_IFNAME:-${DOLLAR}(ip -o -4 route show default | awk '{print ${DOLLAR}5; exit}')}
                 GLOO_BIND_IP=${DOLLAR}(ip -o -4 addr show dev "${DOLLAR}GLOO_SOCKET_IFNAME" 2>/dev/null | awk '{print ${DOLLAR}4; exit}' | cut -d/ -f1)
-                echo "[decode-leader] GLOO_SOCKET_IFNAME=${DOLLAR}GLOO_SOCKET_IFNAME bind=${DOLLAR}GLOO_BIND_IP" | tee -a "${DOLLAR}LOG"
+                echo "[decode-leader] GLOO_SOCKET_IFNAME=${DOLLAR}GLOO_SOCKET_IFNAME bind=${DOLLAR}GLOO_BIND_IP"
                 case "${DOLLAR}{GLOO_BIND_IP:-}" in
-                  ""|127.*) echo "[decode-leader] FATAL: GLOO_SOCKET_IFNAME=${DOLLAR}GLOO_SOCKET_IFNAME has no routable IPv4 (got '${DOLLAR}GLOO_BIND_IP'); cross-node Gloo would bind loopback and connectFullMesh would fail. Exiting for a clean restart." | tee -a "${DOLLAR}LOG"; exit 1 ;;
+                  ""|127.*) echo "[decode-leader] FATAL: GLOO_SOCKET_IFNAME=${DOLLAR}GLOO_SOCKET_IFNAME has no routable IPv4 (got '${DOLLAR}GLOO_BIND_IP'); cross-node Gloo would bind loopback and connectFullMesh would fail. Exiting for a clean restart."; exit 1 ;;
                 esac
-                ray start --head --port=6379 --node-ip-address="${DOLLAR}LEADER_IP" --num-gpus=8 2>&1 | tee -a "${DOLLAR}LOG"
+                ray start --head --port=6379 --node-ip-address="${DOLLAR}LEADER_IP" --num-gpus=8
                 for i in ${DOLLAR}(seq 1 120); do
                   N=${DOLLAR}(ray status 2>/dev/null | awk '/Active:/{flag=1; next} /Pending:|Recent failures:|Resources/{flag=0} flag' | grep -c node_ || true)
                   if [ "${DOLLAR}{N:-0}" -ge 2 ]; then break; fi
@@ -547,9 +613,11 @@ spec:
                   ${MAMBA_FLAGS} \
                   --load-format runai_streamer \
                   --disaggregation-mode decode \
-                  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}' 2>&1 | tee -a "${DOLLAR}LOG"
+                  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}'
             env:
               - { name: MY_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+              # NODE_IP is read only by the node-fault preflight in args above (podIP == hostIP).
+              - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
               - { name: DYNAMO_BACKEND, value: vllm }
               - { name: DYN_NAMESPACE, value: dynamo-disagg }
               - { name: ETCD_ENDPOINTS, value: "${ETCD_URL}" }


### PR DESCRIPTION
Follow-up to #72, from a live 4-node `ml.p6-b200.48xlarge` run of `disagg/lws-2pp` (2026-08-15). One decode
pod crash-looped 6 times, ~47s per attempt, while its sibling on another node loaded normally. Diagnosing it
turned up two problems: the real one was **node-local, not the manifest** — but the manifest actively hid it.

## 1. The container lied about why it died

`kubectl describe` reported this for a container that had just died on an unhandled Python exception:

```
Last State:  Terminated
  Reason:    Completed
  Exit Code: 0
```

Cause is the launch line:

```bash
exec python3 -m dynamo.vllm ... 2>&1 | tee -a "$LOG"
```

`exec` inside a pipeline replaces only the **left subshell**. bash stays the container's main process, so the
container's status is **`tee`'s** — always 0. Two consequences:

* a crash is indistinguishable from a clean exit in `describe` and in events; the `CrashLoopBackOff` only
  appears at all because the startupProbe on `:9092` fails. This is what sent the first look at OOM and the
  probe instead of at the traceback.
* `SIGTERM` on pod delete is delivered to bash, not to the engine.

Fixed by keeping `exec` real — one redirection for the whole shell up front, then a bare `exec`:

```bash
exec > >(tee -a "$LOG") 2>&1
...
exec python3 -m dynamo.vllm ...
```

Now the engine *is* the container's main process: its exit status and signals propagate, and the log still
receives everything. The per-line `| tee -a "$LOG"` in the same blocks are removed — the redirection already
captures them, and leaving them would double-write every line. (`set -o pipefail` would surface the status
but leaves bash as the main process, so the signal half stays broken.)

All 8 patched containers are `command: ["/bin/bash", "-c"]`, so process substitution is available.

## 2. The real failure took 47s to surface, at the bottom of the log

```
Exception: Failed to connect to NATS: DNS error: failed to lookup address information:
           Temporary failure in name resolution.
  dynamo/vllm/main.py:213 worker() -> dynamo/common/utils/runtime.py:77 create_runtime()
```

The CNI had given that sandbox **the node's own primary ENI address**:

| pod | hostNetwork | podIP | hostIP |
|---|---|---|---|
| decode-0 | false | 10.1.47.138 | 10.1.230.174 |
| **decode-1** | **false** | **10.1.239.200** | **10.1.239.200** |
| prefill-0 | false | 10.1.1.57 | 10.1.242.12 |
| prefill-0-1 | false | 10.1.179.182 | 10.1.127.228 |

`podIP == hostIP` with `hostNetwork: false` is a duplicate address: the pod veth carries the IP the node uses
on its primary interface, so DNAT'd replies from CoreDNS land in the host netns and every lookup times out.
Confirmed real inside the netns, not just a status field — the engine self-reported the same address from
`/etc/hosts` (`NIXL side-channel host determined via hostname resolution: 10.1.239.200`), that address is
what `kubectl get nodes` lists for the node, and a sweep of every pod in every namespace found decode-1 to be
the only pod cluster-wide with the collision. `DistributedRuntime` needs NATS + etcd at startup, before any
model load, so the pod can never get anywhere.

**A container restart cannot clear this.** Restarts reuse the pod sandbox, so `CNI ADD` is not re-invoked and
the address stays pinned for the pod's lifetime — which is exactly why it looped 6× on a byte-identical
error. The pod object has to be deleted so a fresh `CNI ADD` allocates a real secondary IP.

So the preflight, on the 8 `dynamo.vllm` containers:

```bash
if [ -n "${MY_IP:-}" ] && [ "${MY_IP:-}" = "${NODE_IP:-}" ]; then
  echo "[decode] FATAL: pod IP $MY_IP == node IP $NODE_IP with hostNetwork=false."
  ...
  echo "[decode]        kubectl -n default delete pod $HOSTNAME"
  exit 1
fi
if command -v getent >/dev/null 2>&1; then          # then wait up to 60s for cluster DNS
  ...
fi
```

`NODE_IP` (downward API `status.hostIP`) is added next to the existing `MY_IP` solely for that comparison.

**Being straight about what this does and doesn't do:** no manifest change can *prevent* the CNI from handing
out a duplicate address. What changes is that the pod fails in 1s naming the remedy instead of after a 47s
model load with a NATS traceback, every other crash becomes truthfully reported (part 1), and the *transient*
DNS variant — cluster DNS simply not answering for a fresh pod yet — is genuinely fixed by the bounded wait
instead of crash-looping.

## Scope

`disagg/{lws-2pp,lws-ep,lws-pp2}` only — the 8 containers that run `dynamo.vllm`. `agg/*` and
`disagg/{deployment,dgd}` already use a bare `exec python3` and are correct. The 3 ray-only workers and the
frontends are untouched. The long mechanism comment lives once in `disagg/lws-2pp.yaml-template`; the other
blocks cross-reference it, the way these templates already cross-reference each other.

## Verification (no cluster needed)

The rendered decode script stub-executed **six ways** with a fake `python3` that exits **42** (a distinctive
nonzero), fake `sleep`, and the DNS loop shortened to 3 iterations:

```
IP collision            -> exit 1   FATAL + `kubectl -n default delete pod <name>`, engine never launched
DNS never resolves      -> exit 1   FATAL after the bounded wait, names CoreDNS/CNI + the remedy
real resolver, bad name -> exit 1   same diagnosis
happy path              -> exit 42  <- the engine's own status is now the container's status
getent absent from PATH -> exit 42  DNS check skipped entirely
MY_IP/NODE_IP unset     -> exit 42  no false positive on unset env
```

`$LOG` holds each line exactly once (no double-write from removing the per-line tees) and is byte-identical
to stdout from the `exec` redirection onward; the two echoes before it stay stdout-only, as on `main`.

Static sweep, unchanged from #72: 9/9 templates `envsubst`-render + YAML round-trip, 29/29 extracted
container scripts `bash -n`, `WARMUP_*`/1800s parity on every template in both folders, exactly one warmer
per role, `run.sh`/`stop.sh` route-check over every template with `kubectl` stubbed → **0 failures**.
