### PR TITLE
nemotron/ultra/disagg: make the preflight's diagnosis survive the container's exit

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-2pp.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-2pp.yaml-template
@@ -102,16 +102,29 @@ spec:
                 # only the startupProbe failure hinted otherwise; SIGTERM on pod delete also went to bash
                 # instead of the engine. Verified: the status propagates and the traceback still reaches both
                 # `kubectl logs` and "${DOLLAR}LOG" (10/10 runs).
+                # Save the container's REAL stdout before the tee takes over. bash does not wait for a
+                # process substitution to drain, and when this shell exits PID 1 goes with it - so a line
+                # echoed into the tee microseconds before `exit 1` never reaches `kubectl logs`. Measured
+                # 2026-08-15 on the 4-node p6-b200 disagg run: the preflight below fired correctly and the
+                # container exited 1 in under a second, but `kubectl logs` AND --previous showed only the
+                # two lines printed BEFORE this redirect, so the operator saw a bare crash-loop with no
+                # diagnosis at all. `say` writes each fatal line to the log file AND to fd 3 (real stdout).
+                exec 3>&1
                 exec > >(tee -a "${DOLLAR}LOG") 2>&1
+                say() { printf '%s\n' "${DOLLAR}*"; printf '%s\n' "${DOLLAR}*" >&3; }
                 # Same node-fault preflight as disagg/lws-2pp.yaml-template - a duplicate pod address
                 # (podIP == hostIP) is fatal and un-restartable, then a bounded wait for cluster DNS.
                 # See that file for the mechanism and the measured incident.
                 if [ -n "${DOLLAR}{MY_IP:-}" ] && [ "${DOLLAR}{MY_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
-                  echo "[prefill-leader] FATAL: pod IP ${DOLLAR}MY_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
-                  echo "[prefill-leader]        The CNI gave this sandbox the node's primary ENI address, so cluster DNS"
-                  echo "[prefill-leader]        cannot answer and NATS/etcd are unreachable. RESTARTING WILL NOT HELP -"
-                  echo "[prefill-leader]        the sandbox keeps the address. Remedy:"
-                  echo "[prefill-leader]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                  say "[prefill-leader] FATAL: pod IP ${DOLLAR}MY_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                  say "[prefill-leader]        The CNI gave this sandbox the node's primary ENI address, so cluster DNS"
+                  say "[prefill-leader]        cannot answer and NATS/etcd are unreachable. RESTARTING WILL NOT HELP -"
+                  say "[prefill-leader]        the sandbox keeps the address. Remedy:"
+                  say "[prefill-leader]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                  say "[prefill-leader]        If the REPLACEMENT pod lands on this node and draws ${DOLLAR}NODE_IP again,"
+                  say "[prefill-leader]        the node's own address is inside the CNI's assignable pool - ipamd re-adds"
+                  say "[prefill-leader]        it every 60s - so it is a NODE fault, not this manifest. Confirm on the node:"
+                  say "[prefill-leader]          grep \"Trying to add ${DOLLAR}NODE_IP\" /var/log/aws-routed-eni/ipamd.log"
                   exit 1
                 fi
                 if command -v getent >/dev/null 2>&1; then
@@ -119,9 +132,9 @@ spec:
                   for i in ${DOLLAR}(seq 1 30); do
                     if getent hosts "${DOLLAR}NATS_HOST" >/dev/null 2>&1; then break; fi
                     if [ "${DOLLAR}i" = 30 ]; then
-                      echo "[prefill-leader] FATAL: cannot resolve ${DOLLAR}NATS_HOST after 60s - cluster DNS is broken for"
-                      echo "[prefill-leader]        this pod. Check CoreDNS and the CNI, then:"
-                      echo "[prefill-leader]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                      say "[prefill-leader] FATAL: cannot resolve ${DOLLAR}NATS_HOST after 60s - cluster DNS is broken for"
+                      say "[prefill-leader]        this pod. Check CoreDNS and the CNI, then:"
+                      say "[prefill-leader]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
                       exit 1
                     fi
                     sleep 2
@@ -140,7 +153,7 @@ spec:
                 done
                 echo "[prefill-leader] LEADER_IP=${DOLLAR}LEADER_IP MY_IP=${DOLLAR}MY_IP"
                 if [ -z "${DOLLAR}LEADER_IP" ]; then
-                  echo "[prefill-leader] FATAL: ${DOLLAR}LWS_LEADER_ADDRESS did not resolve within 300s; exiting for a clean restart (do NOT proceed with an empty leader address)"
+                  say "[prefill-leader] FATAL: ${DOLLAR}LWS_LEADER_ADDRESS did not resolve within 300s; exiting for a clean restart (do NOT proceed with an empty leader address)"
                   exit 1
                 fi
                 ray start --head --port=6379 --node-ip-address="${DOLLAR}LEADER_IP" --num-gpus=${GPU_PER_WORKER}
@@ -367,7 +380,16 @@ spec:
                 # only the startupProbe failure hinted otherwise; SIGTERM on pod delete also went to bash
                 # instead of the engine. Verified: the status propagates and the traceback still reaches both
                 # `kubectl logs` and "${DOLLAR}LOG" (10/10 runs).
+                # Save the container's REAL stdout before the tee takes over. bash does not wait for a
+                # process substitution to drain, and when this shell exits PID 1 goes with it - so a line
+                # echoed into the tee microseconds before `exit 1` never reaches `kubectl logs`. Measured
+                # 2026-08-15 on the 4-node p6-b200 disagg run: the preflight below fired correctly and the
+                # container exited 1 in under a second, but `kubectl logs` AND --previous showed only the
+                # two lines printed BEFORE this redirect, so the operator saw a bare crash-loop with no
+                # diagnosis at all. `say` writes each fatal line to the log file AND to fd 3 (real stdout).
+                exec 3>&1
                 exec > >(tee -a "${DOLLAR}LOG") 2>&1
+                say() { printf '%s\n' "${DOLLAR}*"; printf '%s\n' "${DOLLAR}*" >&3; }
                 # Preflight for the two node-local faults that otherwise surface ~40s from now as a Python
                 # traceback at the BOTTOM of the log instead of a diagnosis at the top.
                 # (a) Duplicate pod address. When the CNI hands this sandbox the node's own primary ENI
@@ -379,14 +401,27 @@ spec:
                 #     be deleted. Measured on a 4-node ml.p6-b200.48xlarge disagg run (2026-08-15): one decode
                 #     pod looped 6x on a byte-identical failure, 47s per attempt, while its sibling on another
                 #     node loaded normally. Fail in 1s and name the remedy instead of loading for 47s first.
+                #     FOLLOW-UP, measured 2026-08-15 22:14-22:40Z on that same cluster: this is a RECURRING node
+                #     fault, not a one-off. ipamd's reconciler re-adds the node's OWN kubelet InternalIP to the
+                #     pod-assignable datastore once a minute ("Trying to add <nodeIP>" then "Adding <nodeIP>/32 to
+                #     DS for eni-..."), because on a SageMaker HyperPod EKS node the device-number-0 ENI sits in
+                #     the SageMaker-managed VPC (172.16/16), so the customer-VPC ENI that carries the node IP is
+                #     treated as a secondary ENI and its primary address becomes assignable to pods. Verified on
+                #     2 of 4 nodes (3,527 re-adds on the second). So a FRESH pod object can draw the node IP
+                #     again: deleting the pod is the correct remedy and it worked here (the replacement drew a
+                #     clean address and loaded), but it is a retry, not a cure - hence the extra lines below.
                 # (b) Cluster DNS not answering for this pod YET, which is transient on a fresh node - so retry
                 #     for 60s before giving up. That converts a crash-loop into a normal start.
                 if [ -n "${DOLLAR}{MY_IP:-}" ] && [ "${DOLLAR}{MY_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
-                  echo "[decode] FATAL: pod IP ${DOLLAR}MY_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
-                  echo "[decode]        The CNI gave this sandbox the node's primary ENI address, so cluster DNS"
-                  echo "[decode]        cannot answer and NATS/etcd are unreachable. RESTARTING WILL NOT HELP -"
-                  echo "[decode]        the sandbox keeps the address. Remedy:"
-                  echo "[decode]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                  say "[decode] FATAL: pod IP ${DOLLAR}MY_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                  say "[decode]        The CNI gave this sandbox the node's primary ENI address, so cluster DNS"
+                  say "[decode]        cannot answer and NATS/etcd are unreachable. RESTARTING WILL NOT HELP -"
+                  say "[decode]        the sandbox keeps the address. Remedy:"
+                  say "[decode]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                  say "[decode]        If the REPLACEMENT pod lands on this node and draws ${DOLLAR}NODE_IP again,"
+                  say "[decode]        the node's own address is inside the CNI's assignable pool - ipamd re-adds"
+                  say "[decode]        it every 60s - so it is a NODE fault, not this manifest. Confirm on the node:"
+                  say "[decode]          grep \"Trying to add ${DOLLAR}NODE_IP\" /var/log/aws-routed-eni/ipamd.log"
                   exit 1
                 fi
                 if command -v getent >/dev/null 2>&1; then
@@ -394,9 +429,9 @@ spec:
                   for i in ${DOLLAR}(seq 1 30); do
                     if getent hosts "${DOLLAR}NATS_HOST" >/dev/null 2>&1; then break; fi
                     if [ "${DOLLAR}i" = 30 ]; then
-                      echo "[decode] FATAL: cannot resolve ${DOLLAR}NATS_HOST after 60s - cluster DNS is broken for"
-                      echo "[decode]        this pod. Check CoreDNS and the CNI, then:"
-                      echo "[decode]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                      say "[decode] FATAL: cannot resolve ${DOLLAR}NATS_HOST after 60s - cluster DNS is broken for"
+                      say "[decode]        this pod. Check CoreDNS and the CNI, then:"
+                      say "[decode]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
                       exit 1
                     fi
                     sleep 2

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-ep.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-ep.yaml-template
@@ -134,16 +134,29 @@ spec:
                 # only the startupProbe failure hinted otherwise; SIGTERM on pod delete also went to bash
                 # instead of the engine. Verified: the status propagates and the traceback still reaches both
                 # `kubectl logs` and "${DOLLAR}LOG" (10/10 runs).
+                # Save the container's REAL stdout before the tee takes over. bash does not wait for a
+                # process substitution to drain, and when this shell exits PID 1 goes with it - so a line
+                # echoed into the tee microseconds before `exit 1` never reaches `kubectl logs`. Measured
+                # 2026-08-15 on the 4-node p6-b200 disagg run: the preflight below fired correctly and the
+                # container exited 1 in under a second, but `kubectl logs` AND --previous showed only the
+                # two lines printed BEFORE this redirect, so the operator saw a bare crash-loop with no
+                # diagnosis at all. `say` writes each fatal line to the log file AND to fd 3 (real stdout).
+                exec 3>&1
                 exec > >(tee -a "${DOLLAR}LOG") 2>&1
+                say() { printf '%s\n' "${DOLLAR}*"; printf '%s\n' "${DOLLAR}*" >&3; }
                 # Same node-fault preflight as disagg/lws-2pp.yaml-template - a duplicate pod address
                 # (podIP == hostIP) is fatal and un-restartable, then a bounded wait for cluster DNS.
                 # See that file for the mechanism and the measured incident.
                 if [ -n "${DOLLAR}{MY_IP:-}" ] && [ "${DOLLAR}{MY_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
-                  echo "[prefill-dp0] FATAL: pod IP ${DOLLAR}MY_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
-                  echo "[prefill-dp0]        The CNI gave this sandbox the node's primary ENI address, so cluster DNS"
-                  echo "[prefill-dp0]        cannot answer and NATS/etcd are unreachable. RESTARTING WILL NOT HELP -"
-                  echo "[prefill-dp0]        the sandbox keeps the address. Remedy:"
-                  echo "[prefill-dp0]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                  say "[prefill-dp0] FATAL: pod IP ${DOLLAR}MY_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                  say "[prefill-dp0]        The CNI gave this sandbox the node's primary ENI address, so cluster DNS"
+                  say "[prefill-dp0]        cannot answer and NATS/etcd are unreachable. RESTARTING WILL NOT HELP -"
+                  say "[prefill-dp0]        the sandbox keeps the address. Remedy:"
+                  say "[prefill-dp0]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                  say "[prefill-dp0]        If the REPLACEMENT pod lands on this node and draws ${DOLLAR}NODE_IP again,"
+                  say "[prefill-dp0]        the node's own address is inside the CNI's assignable pool - ipamd re-adds"
+                  say "[prefill-dp0]        it every 60s - so it is a NODE fault, not this manifest. Confirm on the node:"
+                  say "[prefill-dp0]          grep \"Trying to add ${DOLLAR}NODE_IP\" /var/log/aws-routed-eni/ipamd.log"
                   exit 1
                 fi
                 if command -v getent >/dev/null 2>&1; then
@@ -151,9 +164,9 @@ spec:
                   for i in ${DOLLAR}(seq 1 30); do
                     if getent hosts "${DOLLAR}NATS_HOST" >/dev/null 2>&1; then break; fi
                     if [ "${DOLLAR}i" = 30 ]; then
-                      echo "[prefill-dp0] FATAL: cannot resolve ${DOLLAR}NATS_HOST after 60s - cluster DNS is broken for"
-                      echo "[prefill-dp0]        this pod. Check CoreDNS and the CNI, then:"
-                      echo "[prefill-dp0]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                      say "[prefill-dp0] FATAL: cannot resolve ${DOLLAR}NATS_HOST after 60s - cluster DNS is broken for"
+                      say "[prefill-dp0]        this pod. Check CoreDNS and the CNI, then:"
+                      say "[prefill-dp0]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
                       exit 1
                     fi
                     sleep 2
@@ -276,6 +289,10 @@ spec:
                   echo "[prefill-dp${DOLLAR}{LWS_WORKER_INDEX}]        cannot answer and NATS/etcd are unreachable. RESTARTING WILL NOT HELP -"
                   echo "[prefill-dp${DOLLAR}{LWS_WORKER_INDEX}]        the sandbox keeps the address. Remedy:"
                   echo "[prefill-dp${DOLLAR}{LWS_WORKER_INDEX}]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                  echo "[prefill-dp${DOLLAR}{LWS_WORKER_INDEX}]        If the REPLACEMENT pod lands on this node and draws ${DOLLAR}NODE_IP again,"
+                  echo "[prefill-dp${DOLLAR}{LWS_WORKER_INDEX}]        the node's own address is inside the CNI's assignable pool - ipamd re-adds"
+                  echo "[prefill-dp${DOLLAR}{LWS_WORKER_INDEX}]        it every 60s - so it is a NODE fault, not this manifest. Confirm on the node:"
+                  echo "[prefill-dp${DOLLAR}{LWS_WORKER_INDEX}]          grep \"Trying to add ${DOLLAR}NODE_IP\" /var/log/aws-routed-eni/ipamd.log"
                   exit 1
                 fi
                 if command -v getent >/dev/null 2>&1; then
@@ -439,16 +456,29 @@ spec:
                 # only the startupProbe failure hinted otherwise; SIGTERM on pod delete also went to bash
                 # instead of the engine. Verified: the status propagates and the traceback still reaches both
                 # `kubectl logs` and "${DOLLAR}LOG" (10/10 runs).
+                # Save the container's REAL stdout before the tee takes over. bash does not wait for a
+                # process substitution to drain, and when this shell exits PID 1 goes with it - so a line
+                # echoed into the tee microseconds before `exit 1` never reaches `kubectl logs`. Measured
+                # 2026-08-15 on the 4-node p6-b200 disagg run: the preflight below fired correctly and the
+                # container exited 1 in under a second, but `kubectl logs` AND --previous showed only the
+                # two lines printed BEFORE this redirect, so the operator saw a bare crash-loop with no
+                # diagnosis at all. `say` writes each fatal line to the log file AND to fd 3 (real stdout).
+                exec 3>&1
                 exec > >(tee -a "${DOLLAR}LOG") 2>&1
+                say() { printf '%s\n' "${DOLLAR}*"; printf '%s\n' "${DOLLAR}*" >&3; }
                 # Same node-fault preflight as disagg/lws-2pp.yaml-template - a duplicate pod address
                 # (podIP == hostIP) is fatal and un-restartable, then a bounded wait for cluster DNS.
                 # See that file for the mechanism and the measured incident.
                 if [ -n "${DOLLAR}{MY_IP:-}" ] && [ "${DOLLAR}{MY_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
-                  echo "[decode-dp0] FATAL: pod IP ${DOLLAR}MY_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
-                  echo "[decode-dp0]        The CNI gave this sandbox the node's primary ENI address, so cluster DNS"
-                  echo "[decode-dp0]        cannot answer and NATS/etcd are unreachable. RESTARTING WILL NOT HELP -"
-                  echo "[decode-dp0]        the sandbox keeps the address. Remedy:"
-                  echo "[decode-dp0]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                  say "[decode-dp0] FATAL: pod IP ${DOLLAR}MY_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                  say "[decode-dp0]        The CNI gave this sandbox the node's primary ENI address, so cluster DNS"
+                  say "[decode-dp0]        cannot answer and NATS/etcd are unreachable. RESTARTING WILL NOT HELP -"
+                  say "[decode-dp0]        the sandbox keeps the address. Remedy:"
+                  say "[decode-dp0]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                  say "[decode-dp0]        If the REPLACEMENT pod lands on this node and draws ${DOLLAR}NODE_IP again,"
+                  say "[decode-dp0]        the node's own address is inside the CNI's assignable pool - ipamd re-adds"
+                  say "[decode-dp0]        it every 60s - so it is a NODE fault, not this manifest. Confirm on the node:"
+                  say "[decode-dp0]          grep \"Trying to add ${DOLLAR}NODE_IP\" /var/log/aws-routed-eni/ipamd.log"
                   exit 1
                 fi
                 if command -v getent >/dev/null 2>&1; then
@@ -456,9 +486,9 @@ spec:
                   for i in ${DOLLAR}(seq 1 30); do
                     if getent hosts "${DOLLAR}NATS_HOST" >/dev/null 2>&1; then break; fi
                     if [ "${DOLLAR}i" = 30 ]; then
-                      echo "[decode-dp0] FATAL: cannot resolve ${DOLLAR}NATS_HOST after 60s - cluster DNS is broken for"
-                      echo "[decode-dp0]        this pod. Check CoreDNS and the CNI, then:"
-                      echo "[decode-dp0]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                      say "[decode-dp0] FATAL: cannot resolve ${DOLLAR}NATS_HOST after 60s - cluster DNS is broken for"
+                      say "[decode-dp0]        this pod. Check CoreDNS and the CNI, then:"
+                      say "[decode-dp0]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
                       exit 1
                     fi
                     sleep 2
@@ -644,6 +674,10 @@ spec:
                   echo "[decode-dp${DOLLAR}{LWS_WORKER_INDEX}]        cannot answer and NATS/etcd are unreachable. RESTARTING WILL NOT HELP -"
                   echo "[decode-dp${DOLLAR}{LWS_WORKER_INDEX}]        the sandbox keeps the address. Remedy:"
                   echo "[decode-dp${DOLLAR}{LWS_WORKER_INDEX}]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                  echo "[decode-dp${DOLLAR}{LWS_WORKER_INDEX}]        If the REPLACEMENT pod lands on this node and draws ${DOLLAR}NODE_IP again,"
+                  echo "[decode-dp${DOLLAR}{LWS_WORKER_INDEX}]        the node's own address is inside the CNI's assignable pool - ipamd re-adds"
+                  echo "[decode-dp${DOLLAR}{LWS_WORKER_INDEX}]        it every 60s - so it is a NODE fault, not this manifest. Confirm on the node:"
+                  echo "[decode-dp${DOLLAR}{LWS_WORKER_INDEX}]          grep \"Trying to add ${DOLLAR}NODE_IP\" /var/log/aws-routed-eni/ipamd.log"
                   exit 1
                 fi
                 if command -v getent >/dev/null 2>&1; then

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-pp2.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-pp2.yaml-template
@@ -167,16 +167,29 @@ spec:
                 # only the startupProbe failure hinted otherwise; SIGTERM on pod delete also went to bash
                 # instead of the engine. Verified: the status propagates and the traceback still reaches both
                 # `kubectl logs` and "${DOLLAR}LOG" (10/10 runs).
+                # Save the container's REAL stdout before the tee takes over. bash does not wait for a
+                # process substitution to drain, and when this shell exits PID 1 goes with it - so a line
+                # echoed into the tee microseconds before `exit 1` never reaches `kubectl logs`. Measured
+                # 2026-08-15 on the 4-node p6-b200 disagg run: the preflight below fired correctly and the
+                # container exited 1 in under a second, but `kubectl logs` AND --previous showed only the
+                # two lines printed BEFORE this redirect, so the operator saw a bare crash-loop with no
+                # diagnosis at all. `say` writes each fatal line to the log file AND to fd 3 (real stdout).
+                exec 3>&1
                 exec > >(tee -a "${DOLLAR}LOG") 2>&1
+                say() { printf '%s\n' "${DOLLAR}*"; printf '%s\n' "${DOLLAR}*" >&3; }
                 # Same node-fault preflight as disagg/lws-2pp.yaml-template - a duplicate pod address
                 # (podIP == hostIP) is fatal and un-restartable, then a bounded wait for cluster DNS.
                 # See that file for the mechanism and the measured incident.
                 if [ -n "${DOLLAR}{MY_IP:-}" ] && [ "${DOLLAR}{MY_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
-                  echo "[prefill-leader p5en] FATAL: pod IP ${DOLLAR}MY_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
-                  echo "[prefill-leader p5en]        The CNI gave this sandbox the node's primary ENI address, so cluster DNS"
-                  echo "[prefill-leader p5en]        cannot answer and NATS/etcd are unreachable. RESTARTING WILL NOT HELP -"
-                  echo "[prefill-leader p5en]        the sandbox keeps the address. Remedy:"
-                  echo "[prefill-leader p5en]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                  say "[prefill-leader p5en] FATAL: pod IP ${DOLLAR}MY_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                  say "[prefill-leader p5en]        The CNI gave this sandbox the node's primary ENI address, so cluster DNS"
+                  say "[prefill-leader p5en]        cannot answer and NATS/etcd are unreachable. RESTARTING WILL NOT HELP -"
+                  say "[prefill-leader p5en]        the sandbox keeps the address. Remedy:"
+                  say "[prefill-leader p5en]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                  say "[prefill-leader p5en]        If the REPLACEMENT pod lands on this node and draws ${DOLLAR}NODE_IP again,"
+                  say "[prefill-leader p5en]        the node's own address is inside the CNI's assignable pool - ipamd re-adds"
+                  say "[prefill-leader p5en]        it every 60s - so it is a NODE fault, not this manifest. Confirm on the node:"
+                  say "[prefill-leader p5en]          grep \"Trying to add ${DOLLAR}NODE_IP\" /var/log/aws-routed-eni/ipamd.log"
                   exit 1
                 fi
                 if command -v getent >/dev/null 2>&1; then
@@ -184,9 +197,9 @@ spec:
                   for i in ${DOLLAR}(seq 1 30); do
                     if getent hosts "${DOLLAR}NATS_HOST" >/dev/null 2>&1; then break; fi
                     if [ "${DOLLAR}i" = 30 ]; then
-                      echo "[prefill-leader p5en] FATAL: cannot resolve ${DOLLAR}NATS_HOST after 60s - cluster DNS is broken for"
-                      echo "[prefill-leader p5en]        this pod. Check CoreDNS and the CNI, then:"
-                      echo "[prefill-leader p5en]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                      say "[prefill-leader p5en] FATAL: cannot resolve ${DOLLAR}NATS_HOST after 60s - cluster DNS is broken for"
+                      say "[prefill-leader p5en]        this pod. Check CoreDNS and the CNI, then:"
+                      say "[prefill-leader p5en]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
                       exit 1
                     fi
                     sleep 2
@@ -208,7 +221,7 @@ spec:
                 done
                 echo "[prefill-leader p5en] LEADER_IP=${DOLLAR}LEADER_IP"
                 if [ -z "${DOLLAR}LEADER_IP" ]; then
-                  echo "[prefill-leader] FATAL: ${DOLLAR}LWS_LEADER_ADDRESS did not resolve within 300s; exiting for a clean restart (do NOT proceed with an empty leader address)"
+                  say "[prefill-leader] FATAL: ${DOLLAR}LWS_LEADER_ADDRESS did not resolve within 300s; exiting for a clean restart (do NOT proceed with an empty leader address)"
                   exit 1
                 fi
                 # ---- Gloo bind interface: REQUIRED whenever hostNetwork: true (see header note 6) ----
@@ -459,16 +472,29 @@ spec:
                 # only the startupProbe failure hinted otherwise; SIGTERM on pod delete also went to bash
                 # instead of the engine. Verified: the status propagates and the traceback still reaches both
                 # `kubectl logs` and "${DOLLAR}LOG" (10/10 runs).
+                # Save the container's REAL stdout before the tee takes over. bash does not wait for a
+                # process substitution to drain, and when this shell exits PID 1 goes with it - so a line
+                # echoed into the tee microseconds before `exit 1` never reaches `kubectl logs`. Measured
+                # 2026-08-15 on the 4-node p6-b200 disagg run: the preflight below fired correctly and the
+                # container exited 1 in under a second, but `kubectl logs` AND --previous showed only the
+                # two lines printed BEFORE this redirect, so the operator saw a bare crash-loop with no
+                # diagnosis at all. `say` writes each fatal line to the log file AND to fd 3 (real stdout).
+                exec 3>&1
                 exec > >(tee -a "${DOLLAR}LOG") 2>&1
+                say() { printf '%s\n' "${DOLLAR}*"; printf '%s\n' "${DOLLAR}*" >&3; }
                 # Same node-fault preflight as disagg/lws-2pp.yaml-template - a duplicate pod address
                 # (podIP == hostIP) is fatal and un-restartable, then a bounded wait for cluster DNS.
                 # See that file for the mechanism and the measured incident.
                 if [ -n "${DOLLAR}{MY_IP:-}" ] && [ "${DOLLAR}{MY_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
-                  echo "[decode p5en] FATAL: pod IP ${DOLLAR}MY_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
-                  echo "[decode p5en]        The CNI gave this sandbox the node's primary ENI address, so cluster DNS"
-                  echo "[decode p5en]        cannot answer and NATS/etcd are unreachable. RESTARTING WILL NOT HELP -"
-                  echo "[decode p5en]        the sandbox keeps the address. Remedy:"
-                  echo "[decode p5en]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                  say "[decode p5en] FATAL: pod IP ${DOLLAR}MY_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                  say "[decode p5en]        The CNI gave this sandbox the node's primary ENI address, so cluster DNS"
+                  say "[decode p5en]        cannot answer and NATS/etcd are unreachable. RESTARTING WILL NOT HELP -"
+                  say "[decode p5en]        the sandbox keeps the address. Remedy:"
+                  say "[decode p5en]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                  say "[decode p5en]        If the REPLACEMENT pod lands on this node and draws ${DOLLAR}NODE_IP again,"
+                  say "[decode p5en]        the node's own address is inside the CNI's assignable pool - ipamd re-adds"
+                  say "[decode p5en]        it every 60s - so it is a NODE fault, not this manifest. Confirm on the node:"
+                  say "[decode p5en]          grep \"Trying to add ${DOLLAR}NODE_IP\" /var/log/aws-routed-eni/ipamd.log"
                   exit 1
                 fi
                 if command -v getent >/dev/null 2>&1; then
@@ -476,9 +502,9 @@ spec:
                   for i in ${DOLLAR}(seq 1 30); do
                     if getent hosts "${DOLLAR}NATS_HOST" >/dev/null 2>&1; then break; fi
                     if [ "${DOLLAR}i" = 30 ]; then
-                      echo "[decode p5en] FATAL: cannot resolve ${DOLLAR}NATS_HOST after 60s - cluster DNS is broken for"
-                      echo "[decode p5en]        this pod. Check CoreDNS and the CNI, then:"
-                      echo "[decode p5en]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                      say "[decode p5en] FATAL: cannot resolve ${DOLLAR}NATS_HOST after 60s - cluster DNS is broken for"
+                      say "[decode p5en]        this pod. Check CoreDNS and the CNI, then:"
+                      say "[decode p5en]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
                       exit 1
                     fi
                     sleep 2
@@ -498,7 +524,7 @@ spec:
                   sleep 2
                 done
                 if [ -z "${DOLLAR}LEADER_IP" ]; then
-                  echo "[decode-leader] FATAL: ${DOLLAR}LWS_LEADER_ADDRESS did not resolve within 300s; exiting for a clean restart (do NOT proceed with an empty leader address)"
+                  say "[decode-leader] FATAL: ${DOLLAR}LWS_LEADER_ADDRESS did not resolve within 300s; exiting for a clean restart (do NOT proceed with an empty leader address)"
                   exit 1
                 fi
                 # ---- Gloo bind interface: REQUIRED whenever hostNetwork: true (see header note 6) ----
@@ -566,7 +592,7 @@ spec:
                     0|false|no) echo "[warmup] WARMUP_ENABLED=${DOLLAR}WARMUP_ENABLED; skipping (non-fatal)"; exit 0 ;;
                   esac
                   if ! command -v curl >/dev/null 2>&1; then
-                    echo "[warmup] curl not present; skipping cold-start warmup (non-fatal)"
+                    say "[warmup] curl not present; skipping cold-start warmup (non-fatal)"
                   else
                     warmed=0
                     for i in ${DOLLAR}(seq 1 360); do
@@ -574,7 +600,7 @@ spec:
                       # (the model only appears in /v1/models once the backend has registered).
                       if curl -sf -o /dev/null --max-time 5 "${DOLLAR}LH" 2>/dev/null \
                          && curl -sf --max-time 5 "${DOLLAR}FE/v1/models" 2>/dev/null | grep -q "${MODEL_NAME}"; then
-                        echo "[warmup] engine ready (leader /health 200 + model registered); priming batch=1 Mamba decode kernel (one-time JIT, ~4min)"
+                        say "[warmup] engine ready (leader /health 200 + model registered); priming batch=1 Mamba decode kernel (one-time JIT, ~4min)"
                         curl -s -o /dev/null --max-time 900 "${DOLLAR}FE/v1/completions" \
                           -H 'Content-Type: application/json' \
                           -d "{\"model\":\"${MODEL_NAME}\",\"prompt\":\"warmup\",\"max_tokens\":4,\"temperature\":0}" \
@@ -588,7 +614,7 @@ spec:
                             -d "{\"model\":\"${MODEL_NAME}\",\"prompt\":\"warmup\",\"max_tokens\":4,\"temperature\":0}" &
                         done
                         wait
-                        echo "[warmup] concurrent batch buckets warm; benchmark opening will be fast"
+                        say "[warmup] concurrent batch buckets warm; benchmark opening will be fast"
                         warmed=1
                         break
                       fi


### PR DESCRIPTION
Follow-up to #75. That PR's preflight works — it just cannot be read.

## What happened

On the 4-node `ml.p6-b200.48xlarge` HyperPod EKS run, `disagg-decode-1` kept crash-looping after #75 merged. The preflight fired exactly as designed:

```
lastState.terminated.exitCode   1
startedAt / finishedAt          22:31:12Z / 22:31:12Z   (under one second)
```

Before #75 the same pod reported `Reason: Completed, Exit Code: 0` after ~47s of model loading, so the truthful-exit-code half of #75 is doing its job. But `kubectl logs` **and** `kubectl logs --previous` showed only the two lines printed before this redirect:

```bash
exec > >(tee -a "$LOG") 2>&1
```

bash does not wait for a process substitution to drain. The FATAL lines are echoed into the tee's pipe, the shell exits, container PID 1 goes with it, the runtime tears the process down, and the `tee` is killed before it copies anything through. The operator sees a bare crash-loop with no diagnosis at all.

## Measured

With bash as PID 1 in a fresh PID namespace, so the kernel kills the remaining processes when it exits — the same teardown a container gets:

| pattern | FATAL line missing from stdout |
|---|---|
| `#75` (`echo` after the tee redirect) | **40/40** |
| this PR (`exec 3>&1` + `say()`)      | **0/40**  |

```bash
sudo unshare -pf --mount-proc bash broken.sh   # x40
sudo unshare -pf --mount-proc bash fixed.sh    # x40
```

Negative control: without the PID-1 teardown (`setsid bash broken.sh`, 200 runs) the line is **never** lost — `tee` outlives the parent and flushes. That is why this is invisible to a local test and why it shipped.

## The fix

Keep the tee (the on-disk log is still wanted) and save the container's real stdout on fd 3 before the redirect takes over:

```bash
exec 3>&1
exec > >(tee -a "$LOG") 2>&1
say() { printf '%s\n' "$*"; printf '%s\n' "$*" >&3; }
```

Every fatal line now goes through `say`, landing in the log file *and* directly on the container's stdout, bypassing the tee. It does not depend on winning a race. Applied at all 6 tee sites across the three disagg templates; the two `lws-ep` worker blocks have no tee before their fatal block and keep plain `echo`.

## Why the fault repeated (node-level, not this manifest)

Worth recording in the preflight text, because the next operator will hit it. A pod object created *after* #75 merged drew the same bad address as the one before it. The node's own kubelet InternalIP is inside the CNI's assignable pool, and ipamd's reconciler re-adds it about once a minute:

```
ipamd.go:1647  ... metadata does not match datastore
ipamd.go:1724  Trying to add 10.1.239.200
ipamd.go:1848  Adding 10.1.239.200/32 to DS for eni-0a2dfc96c5af22453
```

On a SageMaker HyperPod EKS node the device-number-0 ENI is the SageMaker-managed one in `172.16/16`, so the customer-VPC ENI carrying the node IP is treated as a *secondary* ENI and its primary address becomes assignable to pods. Two of the four nodes showed it — 3,527 re-adds on the second, for its own InternalIP. So deleting the pod is the correct remedy and it worked here (the replacement drew `10.1.180.64`, went Running with 0 restarts, and loaded normally) but it is a retry, not a cure. The preflight now says exactly that and gives the check to run on the node:

```bash
grep "Trying to add $NODE_IP" /var/log/aws-routed-eni/ipamd.log
```

## Verification

- `bash -n` on every inline container script in all three rendered templates: 14/14 pass (pristine templates as control, also 14/14).
- No behavioural change when the preflight does not fire — the added lines are inside fatal blocks that already ended in `exit 1`.
