### PR TITLE
nemotron/ultra: make the duplicate-pod-address preflight hostNetwork-aware and cover every exposed pod

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/deployment.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/deployment.yaml-template
@@ -41,12 +41,48 @@ spec:
           # 1.3.x images ship plain python3 and have NO /opt/dynamo/venv - activate only when present.
           args:
             - |-
+              # ---- Node-fault preflight: duplicate pod address (mechanism: disagg/lws-2pp.yaml-template) ----
+              # When the CNI hands this sandbox the node's own kubelet InternalIP (status.podIP ==
+              # status.hostIP while hostNetwork is false), kube-proxy DNAT replies land in the host
+              # netns, cluster DNS never answers, and DistributedRuntime() dies with "Failed to
+              # connect to NATS: DNS error ... Temporary failure in name resolution". A container
+              # RESTART CANNOT CLEAR IT: restarts reuse the pod sandbox, so CNI ADD is not re-invoked
+              # and the address is pinned for the pod's lifetime - the pod object has to be deleted.
+              # Measured on a 4-node ml.p6-b200.48xlarge cluster (2026-08-15): ALL FOUR nodes carry
+              # their own InternalIP inside their ipamd assignable pool, so any hostNetwork:false pod
+              # in this file can draw it - not just the GPU workers. Fail in ~1s naming the remedy
+              # instead of CrashLooping on an opaque DNS error. No `say`/fd-3 indirection is needed
+              # here (unlike the worker templates): this container does not redirect its stdout into a
+              # `tee` process substitution, so a plain echo reaches `kubectl logs` before the exit.
+              if [ -n "${DOLLAR}{POD_IP:-}" ] && [ "${DOLLAR}{POD_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
+                echo "[frontend] FATAL: pod IP ${DOLLAR}POD_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                echo "[frontend]        Cluster DNS cannot answer for this pod, so NATS/etcd are unreachable."
+                echo "[frontend]        RESTARTING WILL NOT HELP - the sandbox keeps the address. Remedy:"
+                echo "[frontend]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                exit 1
+              fi
+              # dynamo.frontend calls DistributedRuntime() which connects to NATS immediately with NO
+              # retry, so a transient cold-start DNS miss (EAI_AGAIN, "Temporary failure in name
+              # resolution") is fatal and CrashLoops the pod even though NATS is healthy. The worker
+              # templates already guard their startup with a getent loop; agg/lws.yaml-template's
+              # frontend already carries this block - mirror it here so every frontend behaves the same.
+              NATS_HOST=${DOLLAR}{NATS_SERVER#*://}; NATS_HOST=${DOLLAR}{NATS_HOST%%:*}
+              for i in ${DOLLAR}(seq 1 60); do
+                if getent hosts "${DOLLAR}NATS_HOST" >/dev/null 2>&1; then break; fi
+                echo "[frontend] waiting for DNS NATS_HOST=${DOLLAR}NATS_HOST (${DOLLAR}i)"
+                sleep 2
+              done
               if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
               exec python3 -m dynamo.frontend --http-port 8000 --http-host 0.0.0.0
           env:
             - { name: DYNAMO_BACKEND, value: vllm }
             - { name: DYN_NAMESPACE, value: dynamo-agg }
             - { name: ETCD_ENDPOINTS, value: "${ETCD_URL}" }
+            # Read only by the duplicate-address preflight in args above. The worker templates
+            # call the same value MY_IP because vLLM/ray also consume it; nothing else reads it
+            # here, so it keeps the field's own name.
+            - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+            - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
             - { name: NATS_SERVER, value: "${NATS_URL}" }
           ports: [ { containerPort: 8000, name: http } ]
           readinessProbe: { tcpSocket: { port: 8000 }, periodSeconds: 10, failureThreshold: 30 }
@@ -97,6 +133,41 @@ spec:
               set -eu
               unset HPCX_DIR HPCX_MPI_DIR HPCX_HOME HPCX_UCX_DIR HPCX_SHARP_DIR \
                     HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
+              # ---- Node-fault preflight: duplicate pod address (mechanism: disagg/lws-2pp.yaml-template) ----
+              # When the CNI hands this sandbox the node's own kubelet InternalIP (status.podIP ==
+              # status.hostIP while hostNetwork is false), kube-proxy DNAT replies land in the host
+              # netns, cluster DNS never answers, and DistributedRuntime() dies with "Failed to
+              # connect to NATS: DNS error ... Temporary failure in name resolution". A container
+              # RESTART CANNOT CLEAR IT: restarts reuse the pod sandbox, so CNI ADD is not re-invoked
+              # and the address is pinned for the pod's lifetime - the pod object has to be deleted.
+              # Measured on a 4-node ml.p6-b200.48xlarge cluster (2026-08-15): ALL FOUR nodes carry
+              # their own InternalIP inside their ipamd assignable pool, so any hostNetwork:false pod
+              # in this file can draw it - not just the GPU workers. Fail in ~1s naming the remedy
+              # instead of CrashLooping on an opaque DNS error. No `say`/fd-3 indirection is needed
+              # here (unlike the worker templates): this container does not redirect its stdout into a
+              # `tee` process substitution, so a plain echo reaches `kubectl logs` before the exit.
+              if [ -n "${DOLLAR}{POD_IP:-}" ] && [ "${DOLLAR}{POD_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
+                echo "[worker] FATAL: pod IP ${DOLLAR}POD_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                echo "[worker]        Cluster DNS cannot answer for this pod, so NATS/etcd are unreachable."
+                echo "[worker]        RESTARTING WILL NOT HELP - the sandbox keeps the address. Remedy:"
+                echo "[worker]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                exit 1
+              fi
+              # dynamo.vllm also builds a DistributedRuntime() with no retry, so give cluster DNS
+              # a bounded chance on a cold node instead of CrashLooping on the first miss.
+              if command -v getent >/dev/null 2>&1; then
+                NATS_HOST=${DOLLAR}{NATS_SERVER#*://}; NATS_HOST=${DOLLAR}{NATS_HOST%%:*}
+                for i in ${DOLLAR}(seq 1 30); do
+                  if getent hosts "${DOLLAR}NATS_HOST" >/dev/null 2>&1; then break; fi
+                  if [ "${DOLLAR}i" = 30 ]; then
+                    echo "[worker] FATAL: cannot resolve ${DOLLAR}NATS_HOST after 60s - cluster DNS is broken"
+                    echo "[worker]        for this pod. Check CoreDNS and the CNI, then:"
+                    echo "[worker]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                    exit 1
+                  fi
+                  sleep 2
+                done
+              fi
               if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
               # Cold-start warmup (detached), same block and same knobs as the disagg templates -
               # aggregated pays the identical tax because it runs the same decode kernels. A fresh
@@ -178,6 +249,11 @@ spec:
             - { name: DYNAMO_BACKEND, value: vllm }
             - { name: DYN_NAMESPACE, value: dynamo-agg }
             - { name: ETCD_ENDPOINTS, value: "${ETCD_URL}" }
+            # Read only by the duplicate-address preflight in args above. The worker templates
+            # call the same value MY_IP because vLLM/ray also consume it; nothing else reads it
+            # here, so it keeps the field's own name.
+            - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+            - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
             - { name: NATS_SERVER, value: "${NATS_URL}" }
             - { name: DYN_SYSTEM_ENABLED, value: "true" }
             - { name: DYN_SYSTEM_PORT, value: "9090" }

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/dgd.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/dgd.yaml-template
@@ -65,8 +65,26 @@ spec:
           # 1.3.x images have no /opt/dynamo/venv — activate only when present.
           args:
             - |-
+              # ---- Node-fault preflight: duplicate pod address (podIP == hostIP) ----
+              # The CNI can hand this sandbox the node's own kubelet InternalIP; cluster DNS then
+              # never answers for the pod, so NATS/etcd are unreachable. A container RESTART CANNOT
+              # CLEAR IT (restarts reuse the sandbox, CNI ADD is not re-invoked) - the pod object has
+              # to be deleted. Measured 2026-08-15 on a 4-node ml.p6-b200.48xlarge cluster: all four
+              # nodes carry their own InternalIP inside their ipamd assignable pool, so ANY
+              # hostNetwork:false pod here can draw it. Mechanism + incident: disagg/lws-2pp.yaml-template.
+              if [ -n "${DOLLAR}{POD_IP:-}" ] && [ "${DOLLAR}{POD_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
+                echo "[frontend] FATAL: pod IP ${DOLLAR}POD_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                echo "[frontend]        Cluster DNS cannot answer for this pod, so NATS/etcd are unreachable."
+                echo "[frontend]        RESTARTING WILL NOT HELP - the sandbox keeps the address. Remedy:"
+                echo "[frontend]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                exit 1
+              fi
               if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
               exec python3 -m dynamo.frontend --http-port 8000 --http-host 0.0.0.0
+          env:
+            # Read only by the duplicate-address preflight in args above.
+            - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+            - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
           ports: [{ containerPort: 8000, name: http }]
           # NOTE: no readinessProbe here — the operator injects its own frontend probe;
           # adding ours makes the API server reject the generated pod
@@ -97,6 +115,20 @@ spec:
               unset HPCX_DIR HPCX_MPI_DIR HPCX_HOME HPCX_UCX_DIR HPCX_SHARP_DIR \
                     HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
               if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+              # ---- Node-fault preflight: duplicate pod address (podIP == hostIP) ----
+              # The CNI can hand this sandbox the node's own kubelet InternalIP; cluster DNS then
+              # never answers for the pod, so NATS/etcd are unreachable. A container RESTART CANNOT
+              # CLEAR IT (restarts reuse the sandbox, CNI ADD is not re-invoked) - the pod object has
+              # to be deleted. Measured 2026-08-15 on a 4-node ml.p6-b200.48xlarge cluster: all four
+              # nodes carry their own InternalIP inside their ipamd assignable pool, so ANY
+              # hostNetwork:false pod here can draw it. Mechanism + incident: disagg/lws-2pp.yaml-template.
+              if [ -n "${DOLLAR}{POD_IP:-}" ] && [ "${DOLLAR}{POD_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
+                echo "[worker] FATAL: pod IP ${DOLLAR}POD_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                echo "[worker]        Cluster DNS cannot answer for this pod, so NATS/etcd are unreachable."
+                echo "[worker]        RESTARTING WILL NOT HELP - the sandbox keeps the address. Remedy:"
+                echo "[worker]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                exit 1
+              fi
               # Cold-start warmup (detached), same block and same knobs as the disagg templates -
               # aggregated pays the identical tax because it runs the same decode kernels. A fresh
               # pod's FIRST request spends a one-time ~4min Triton JIT on the Mamba DECODE kernels
@@ -168,6 +200,9 @@ spec:
                 --trust-remote-code \
                 --mamba-cache-mode align
           env:
+            # Read only by the duplicate-address preflight in args above.
+            - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+            - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
             - { name: DYN_SYSTEM_ENABLED, value: "true" }
             - { name: DYN_SYSTEM_PORT, value: "9090" }
             # The warmer above reads these INSIDE the container, so they have to be passed

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws-ep.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws-ep.yaml-template
@@ -94,6 +94,11 @@ spec:
       metadata:
         labels: { app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}, app.kubernetes.io/component: agg-ep, dp-role: leader }
       spec:
+        # hostNetwork: true -> status.podIP IS status.hostIP for this pod, by definition. The
+        # duplicate-address preflight the hostNetwork:false pods in this tree carry (see
+        # disagg/lws-2pp.yaml-template) is therefore NOT applicable here and must not be
+        # copied in: it would fire on EVERY start. The fault it detects cannot occur under host
+        # networking either - there is no separate sandbox address to collide with the node's.
         hostNetwork: true
         dnsPolicy: ClusterFirstWithHostNet
         nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_WORKER} }
@@ -251,6 +256,11 @@ spec:
       metadata:
         labels: { app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}, app.kubernetes.io/component: agg-ep, dp-role: worker }
       spec:
+        # hostNetwork: true -> status.podIP IS status.hostIP for this pod, by definition. The
+        # duplicate-address preflight the hostNetwork:false pods in this tree carry (see
+        # disagg/lws-2pp.yaml-template) is therefore NOT applicable here and must not be
+        # copied in: it would fire on EVERY start. The fault it detects cannot occur under host
+        # networking either - there is no separate sandbox address to collide with the node's.
         hostNetwork: true
         dnsPolicy: ClusterFirstWithHostNet
         nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_WORKER} }

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws.yaml-template
@@ -27,6 +27,11 @@ spec:
           app.kubernetes.io/component: worker
           dynamo-role: leader
       spec:
+        # hostNetwork: true -> status.podIP IS status.hostIP for this pod, by definition. The
+        # duplicate-address preflight the hostNetwork:false pods in this tree carry (see
+        # disagg/lws-2pp.yaml-template) is therefore NOT applicable here and must not be
+        # copied in: it would fire on EVERY start. The fault it detects cannot occur under host
+        # networking either - there is no separate sandbox address to collide with the node's.
         hostNetwork: true
         dnsPolicy: ClusterFirstWithHostNet
         nodeSelector:
@@ -263,6 +268,11 @@ spec:
           app.kubernetes.io/component: worker
           dynamo-role: worker
       spec:
+        # hostNetwork: true -> status.podIP IS status.hostIP for this pod, by definition. The
+        # duplicate-address preflight the hostNetwork:false pods in this tree carry (see
+        # disagg/lws-2pp.yaml-template) is therefore NOT applicable here and must not be
+        # copied in: it would fire on EVERY start. The fault it detects cannot occur under host
+        # networking either - there is no separate sandbox address to collide with the node's.
         hostNetwork: true
         dnsPolicy: ClusterFirstWithHostNet
         nodeSelector:
@@ -417,6 +427,26 @@ spec:
           args:
             - |-
               set -eu
+              # ---- Node-fault preflight: duplicate pod address (mechanism: disagg/lws-2pp.yaml-template) ----
+              # When the CNI hands this sandbox the node's own kubelet InternalIP (status.podIP ==
+              # status.hostIP while hostNetwork is false), kube-proxy DNAT replies land in the host
+              # netns, cluster DNS never answers, and DistributedRuntime() dies with "Failed to
+              # connect to NATS: DNS error ... Temporary failure in name resolution". A container
+              # RESTART CANNOT CLEAR IT: restarts reuse the pod sandbox, so CNI ADD is not re-invoked
+              # and the address is pinned for the pod's lifetime - the pod object has to be deleted.
+              # Measured on a 4-node ml.p6-b200.48xlarge cluster (2026-08-15): ALL FOUR nodes carry
+              # their own InternalIP inside their ipamd assignable pool, so any hostNetwork:false pod
+              # in this file can draw it - not just the GPU workers. Fail in ~1s naming the remedy
+              # instead of CrashLooping on an opaque DNS error. No `say`/fd-3 indirection is needed
+              # here (unlike the worker templates): this container does not redirect its stdout into a
+              # `tee` process substitution, so a plain echo reaches `kubectl logs` before the exit.
+              if [ -n "${DOLLAR}{POD_IP:-}" ] && [ "${DOLLAR}{POD_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
+                echo "[frontend] FATAL: pod IP ${DOLLAR}POD_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                echo "[frontend]        Cluster DNS cannot answer for this pod, so NATS/etcd are unreachable."
+                echo "[frontend]        RESTARTING WILL NOT HELP - the sandbox keeps the address. Remedy:"
+                echo "[frontend]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                exit 1
+              fi
               # dynamo.frontend calls DistributedRuntime() which connects to NATS immediately
               # with NO retry, so a transient cold-start DNS miss (EAI_AGAIN, "Temporary failure
               # in name resolution") is fatal and CrashLoops the pod even though NATS is healthy.
@@ -433,6 +463,11 @@ spec:
             - { name: DYNAMO_BACKEND, value: vllm }
             - { name: DYN_NAMESPACE, value: dynamo }
             - { name: ETCD_ENDPOINTS, value: "${ETCD_URL}" }
+            # Read only by the duplicate-address preflight in args above. The worker templates
+            # call the same value MY_IP because vLLM/ray also consume it; nothing else reads it
+            # here, so it keeps the field's own name.
+            - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+            - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
             - { name: NATS_SERVER, value: "${NATS_URL}" }
           ports:
             - { containerPort: 8000, name: http }

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/deployment.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/deployment.yaml-template
@@ -26,6 +26,11 @@ spec:
   template:
     metadata: { labels: { app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}, app.kubernetes.io/component: prefill } }
     spec:
+      # hostNetwork: true -> status.podIP IS status.hostIP for this pod, by definition. The
+      # duplicate-address preflight the hostNetwork:false pods in this tree carry (see
+      # disagg/lws-2pp.yaml-template) is therefore NOT applicable here and must not be
+      # copied in: it would fire on EVERY start. The fault it detects cannot occur under host
+      # networking either - there is no separate sandbox address to collide with the node's.
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_WORKER} }
@@ -107,6 +112,11 @@ spec:
   template:
     metadata: { labels: { app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}, app.kubernetes.io/component: decode } }
     spec:
+      # hostNetwork: true -> status.podIP IS status.hostIP for this pod, by definition. The
+      # duplicate-address preflight the hostNetwork:false pods in this tree carry (see
+      # disagg/lws-2pp.yaml-template) is therefore NOT applicable here and must not be
+      # copied in: it would fire on EVERY start. The fault it detects cannot occur under host
+      # networking either - there is no separate sandbox address to collide with the node's.
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_WORKER} }
@@ -285,12 +295,48 @@ spec:
           # "no such file or directory" and the pod CrashLoops. Activate only when present.
           args:
             - |-
+              # ---- Node-fault preflight: duplicate pod address (mechanism: disagg/lws-2pp.yaml-template) ----
+              # When the CNI hands this sandbox the node's own kubelet InternalIP (status.podIP ==
+              # status.hostIP while hostNetwork is false), kube-proxy DNAT replies land in the host
+              # netns, cluster DNS never answers, and DistributedRuntime() dies with "Failed to
+              # connect to NATS: DNS error ... Temporary failure in name resolution". A container
+              # RESTART CANNOT CLEAR IT: restarts reuse the pod sandbox, so CNI ADD is not re-invoked
+              # and the address is pinned for the pod's lifetime - the pod object has to be deleted.
+              # Measured on a 4-node ml.p6-b200.48xlarge cluster (2026-08-15): ALL FOUR nodes carry
+              # their own InternalIP inside their ipamd assignable pool, so any hostNetwork:false pod
+              # in this file can draw it - not just the GPU workers. Fail in ~1s naming the remedy
+              # instead of CrashLooping on an opaque DNS error. No `say`/fd-3 indirection is needed
+              # here (unlike the worker templates): this container does not redirect its stdout into a
+              # `tee` process substitution, so a plain echo reaches `kubectl logs` before the exit.
+              if [ -n "${DOLLAR}{POD_IP:-}" ] && [ "${DOLLAR}{POD_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
+                echo "[frontend] FATAL: pod IP ${DOLLAR}POD_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                echo "[frontend]        Cluster DNS cannot answer for this pod, so NATS/etcd are unreachable."
+                echo "[frontend]        RESTARTING WILL NOT HELP - the sandbox keeps the address. Remedy:"
+                echo "[frontend]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                exit 1
+              fi
+              # dynamo.frontend calls DistributedRuntime() which connects to NATS immediately with NO
+              # retry, so a transient cold-start DNS miss (EAI_AGAIN, "Temporary failure in name
+              # resolution") is fatal and CrashLoops the pod even though NATS is healthy. The worker
+              # templates already guard their startup with a getent loop; agg/lws.yaml-template's
+              # frontend already carries this block - mirror it here so every frontend behaves the same.
+              NATS_HOST=${DOLLAR}{NATS_SERVER#*://}; NATS_HOST=${DOLLAR}{NATS_HOST%%:*}
+              for i in ${DOLLAR}(seq 1 60); do
+                if getent hosts "${DOLLAR}NATS_HOST" >/dev/null 2>&1; then break; fi
+                echo "[frontend] waiting for DNS NATS_HOST=${DOLLAR}NATS_HOST (${DOLLAR}i)"
+                sleep 2
+              done
               if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
               exec python3 -m dynamo.frontend --http-port 8000 --http-host 0.0.0.0
           env:
             - { name: DYNAMO_BACKEND, value: vllm }
             - { name: DYN_NAMESPACE, value: dynamo-disagg }
             - { name: ETCD_ENDPOINTS, value: "${ETCD_URL}" }
+            # Read only by the duplicate-address preflight in args above. The worker templates
+            # call the same value MY_IP because vLLM/ray also consume it; nothing else reads it
+            # here, so it keeps the field's own name.
+            - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+            - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
             - { name: NATS_SERVER, value: "${NATS_URL}" }
             - { name: HF_HOME, value: /tmp/hf_cache }
           ports: [ { containerPort: 8000, name: http } ]

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd.yaml-template
@@ -60,8 +60,26 @@ spec:
           # 1.3.0-era images have no /opt/dynamo/venv - activate only when present.
           args:
             - |-
+              # ---- Node-fault preflight: duplicate pod address (podIP == hostIP) ----
+              # The CNI can hand this sandbox the node's own kubelet InternalIP; cluster DNS then
+              # never answers for the pod, so NATS/etcd are unreachable. A container RESTART CANNOT
+              # CLEAR IT (restarts reuse the sandbox, CNI ADD is not re-invoked) - the pod object has
+              # to be deleted. Measured 2026-08-15 on a 4-node ml.p6-b200.48xlarge cluster: all four
+              # nodes carry their own InternalIP inside their ipamd assignable pool, so ANY
+              # hostNetwork:false pod here can draw it. Mechanism + incident: disagg/lws-2pp.yaml-template.
+              if [ -n "${DOLLAR}{POD_IP:-}" ] && [ "${DOLLAR}{POD_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
+                echo "[frontend] FATAL: pod IP ${DOLLAR}POD_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                echo "[frontend]        Cluster DNS cannot answer for this pod, so NATS/etcd are unreachable."
+                echo "[frontend]        RESTARTING WILL NOT HELP - the sandbox keeps the address. Remedy:"
+                echo "[frontend]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                exit 1
+              fi
               if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
               exec python3 -m dynamo.frontend --http-port 8000 --http-host 0.0.0.0
+          env:
+            # Read only by the duplicate-address preflight in args above.
+            - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+            - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
           ports: [{ containerPort: 8000, name: http }]
           # NOTE: no readinessProbe here - the operator injects its own frontend
           # probe; adding ours makes the API server reject the generated pod
@@ -100,6 +118,20 @@ spec:
               unset HPCX_DIR HPCX_MPI_DIR HPCX_HOME HPCX_UCX_DIR HPCX_SHARP_DIR \
                     HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
               if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+              # ---- Node-fault preflight: duplicate pod address (podIP == hostIP) ----
+              # The CNI can hand this sandbox the node's own kubelet InternalIP; cluster DNS then
+              # never answers for the pod, so NATS/etcd are unreachable. A container RESTART CANNOT
+              # CLEAR IT (restarts reuse the sandbox, CNI ADD is not re-invoked) - the pod object has
+              # to be deleted. Measured 2026-08-15 on a 4-node ml.p6-b200.48xlarge cluster: all four
+              # nodes carry their own InternalIP inside their ipamd assignable pool, so ANY
+              # hostNetwork:false pod here can draw it. Mechanism + incident: disagg/lws-2pp.yaml-template.
+              if [ -n "${DOLLAR}{POD_IP:-}" ] && [ "${DOLLAR}{POD_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
+                echo "[prefill] FATAL: pod IP ${DOLLAR}POD_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                echo "[prefill]        Cluster DNS cannot answer for this pod, so NATS/etcd are unreachable."
+                echo "[prefill]        RESTARTING WILL NOT HELP - the sandbox keeps the address. Remedy:"
+                echo "[prefill]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                exit 1
+              fi
               exec python3 -m dynamo.vllm \
                 --model ${MODEL_PATH} \
                 --served-model-name ${MODEL_NAME} \
@@ -110,6 +142,9 @@ spec:
                 --disaggregation-mode prefill \
                 --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}'
           env:
+            # Read only by the duplicate-address preflight in args above.
+            - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+            - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
             - { name: DYN_SYSTEM_ENABLED, value: "true" }
             - { name: DYN_SYSTEM_PORT, value: "9091" }
             # Same value as decode: a prefill-side compile under a concurrent opening must not
@@ -175,6 +210,20 @@ spec:
               unset HPCX_DIR HPCX_MPI_DIR HPCX_HOME HPCX_UCX_DIR HPCX_SHARP_DIR \
                     HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
               if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+              # ---- Node-fault preflight: duplicate pod address (podIP == hostIP) ----
+              # The CNI can hand this sandbox the node's own kubelet InternalIP; cluster DNS then
+              # never answers for the pod, so NATS/etcd are unreachable. A container RESTART CANNOT
+              # CLEAR IT (restarts reuse the sandbox, CNI ADD is not re-invoked) - the pod object has
+              # to be deleted. Measured 2026-08-15 on a 4-node ml.p6-b200.48xlarge cluster: all four
+              # nodes carry their own InternalIP inside their ipamd assignable pool, so ANY
+              # hostNetwork:false pod here can draw it. Mechanism + incident: disagg/lws-2pp.yaml-template.
+              if [ -n "${DOLLAR}{POD_IP:-}" ] && [ "${DOLLAR}{POD_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
+                echo "[decode] FATAL: pod IP ${DOLLAR}POD_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                echo "[decode]        Cluster DNS cannot answer for this pod, so NATS/etcd are unreachable."
+                echo "[decode]        RESTARTING WILL NOT HELP - the sandbox keeps the address. Remedy:"
+                echo "[decode]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                exit 1
+              fi
               # Cold-start warmup (detached). A fresh pod's FIRST request pays a one-time ~4min
               # Triton JIT compiling the Mamba DECODE kernels (_selective_scan_update,
               # _causal_conv1d_update): startup only warms the PREFILL SSD path, and
@@ -254,6 +303,9 @@ spec:
                 --disaggregation-mode decode \
                 --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}'
           env:
+            # Read only by the duplicate-address preflight in args above.
+            - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+            - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
             - { name: DYN_SYSTEM_ENABLED, value: "true" }
             - { name: DYN_SYSTEM_PORT, value: "9092" }
             # The warmer above reads these INSIDE the container, so they have to be passed

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-2pp.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-2pp.yaml-template
@@ -256,6 +256,20 @@ spec:
                 unset HPCX_DIR HPCX_MPI_DIR HPCX_HOME HPCX_UCX_DIR HPCX_SHARP_DIR \
                       HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
                 if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+                # ---- Node-fault preflight: duplicate pod address (podIP == hostIP) ----
+                # The CNI can hand this sandbox the node's own kubelet InternalIP; cluster DNS then
+                # never answers for the pod, so NATS/etcd are unreachable. A container RESTART CANNOT
+                # CLEAR IT (restarts reuse the sandbox, CNI ADD is not re-invoked) - the pod object has
+                # to be deleted. Measured 2026-08-15 on a 4-node ml.p6-b200.48xlarge cluster: all four
+                # nodes carry their own InternalIP inside their ipamd assignable pool, so ANY
+                # hostNetwork:false pod here can draw it. Mechanism + incident: the decode-worker block in this file.
+                if [ -n "${DOLLAR}{MY_IP:-}" ] && [ "${DOLLAR}{MY_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
+                  echo "[pp-worker] FATAL: pod IP ${DOLLAR}MY_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                  echo "[pp-worker]        Cluster DNS cannot answer for this pod, so NATS/etcd are unreachable."
+                  echo "[pp-worker]        RESTARTING WILL NOT HELP - the sandbox keeps the address. Remedy:"
+                  echo "[pp-worker]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                  exit 1
+                fi
                 # Resolve in ONE getent per attempt and break only on a NON-EMPTY address. The previous
                 # shape probed with one getent and captured the address with a second one, so a single
                 # empty capture immediately after a successful probe killed the pod ~2s in while printing
@@ -277,6 +291,7 @@ spec:
                 exec ray start --address="${DOLLAR}LEADER_IP:6379" --node-ip-address="${DOLLAR}MY_IP" --num-gpus=${GPU_PER_WORKER} --block
             env:
               - { name: MY_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+              - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
               - { name: HF_HOME, value: /shared/hf_cache }
               - { name: VLLM_SSM_CONV_STATE_LAYOUT, value: DS }
               - { name: FLASHINFER_DISABLE_VERSION_CHECK, value: "1" }
@@ -401,15 +416,27 @@ spec:
                 #     be deleted. Measured on a 4-node ml.p6-b200.48xlarge disagg run (2026-08-15): one decode
                 #     pod looped 6x on a byte-identical failure, 47s per attempt, while its sibling on another
                 #     node loaded normally. Fail in 1s and name the remedy instead of loading for 47s first.
-                #     FOLLOW-UP, measured 2026-08-15 22:14-22:40Z on that same cluster: this is a RECURRING node
-                #     fault, not a one-off. ipamd's reconciler re-adds the node's OWN kubelet InternalIP to the
-                #     pod-assignable datastore once a minute ("Trying to add <nodeIP>" then "Adding <nodeIP>/32 to
-                #     DS for eni-..."), because on a SageMaker HyperPod EKS node the device-number-0 ENI sits in
-                #     the SageMaker-managed VPC (172.16/16), so the customer-VPC ENI that carries the node IP is
-                #     treated as a secondary ENI and its primary address becomes assignable to pods. Verified on
-                #     2 of 4 nodes (3,527 re-adds on the second). So a FRESH pod object can draw the node IP
-                #     again: deleting the pod is the correct remedy and it worked here (the replacement drew a
-                #     clean address and loaded), but it is a retry, not a cure - hence the extra lines below.
+                #     FOLLOW-UP, measured 2026-08-15 22:14-23:30Z on that same cluster: this is a RECURRING
+                #     node fault, not a one-off, and it is present on ALL FOUR nodes - each node's ipamd
+                #     re-adds that node's OWN kubelet InternalIP to its pod-assignable datastore once a
+                #     minute ("Trying to add <nodeIP>" then "Adding <nodeIP>/32 to DS for eni-...").
+                #     The datastore itself is the evidence: 127.0.0.1:61679/v1/enis lists that address
+                #     under the node's PRIMARY ENI with an empty IPAddresses map - i.e. free to hand to a
+                #     pod - and "Reconcile skipping primary IP" never appears in ipamd.log (aws-node
+                #     v1.22.3-eksbuild.1, CUSTOM_NETWORK_CFG=false, PREFIX_DELEGATION=false). An earlier
+                #     revision of this comment blamed the SageMaker device-0 ENI for making the
+                #     customer-VPC ENI look like a secondary; ipamd refutes that - it flags the ENI
+                #     primary and hands the address out anyway. So a FRESH pod object can draw the node
+                #     IP again, and not rarely: 3 of the last 5 sandboxes on one node drew exactly it.
+                #     Deleting the pod is the correct remedy and it worked here (the replacement drew a
+                #     clean address and loaded), but it is a retry, not a cure - the cure is CNI-level.
+                #     Node-side confirmation is presence, NOT rank: every address in an ENI's pool shares
+                #     the same "Trying to add" count (it is one reconciler pass, not a per-address event),
+                #     so `... | sort -rn | head` ranks nothing and hides the node IP behind the tie-break
+                #     order. Use `grep -c "Trying to add <nodeIP>"`, or this, which needs no node access:
+                #       kubectl get pods -A -o json | jq -r '.items[]
+                #         | select(.spec.hostNetwork != true) | select(.status.podIP == .status.hostIP)
+                #         | "\(.metadata.namespace)/\(.metadata.name) \(.status.podIP) \(.spec.nodeName)"'
                 # (b) Cluster DNS not answering for this pod YET, which is transient on a fresh node - so retry
                 #     for 60s before giving up. That converts a crash-loop into a normal start.
                 if [ -n "${DOLLAR}{MY_IP:-}" ] && [ "${DOLLAR}{MY_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
@@ -623,12 +650,48 @@ spec:
           # 1.3.0-era images have no /opt/dynamo/venv - activate only when present.
           args:
             - |-
+              # ---- Node-fault preflight: duplicate pod address (mechanism: the decode block below) ----
+              # When the CNI hands this sandbox the node's own kubelet InternalIP (status.podIP ==
+              # status.hostIP while hostNetwork is false), kube-proxy DNAT replies land in the host
+              # netns, cluster DNS never answers, and DistributedRuntime() dies with "Failed to
+              # connect to NATS: DNS error ... Temporary failure in name resolution". A container
+              # RESTART CANNOT CLEAR IT: restarts reuse the pod sandbox, so CNI ADD is not re-invoked
+              # and the address is pinned for the pod's lifetime - the pod object has to be deleted.
+              # Measured on a 4-node ml.p6-b200.48xlarge cluster (2026-08-15): ALL FOUR nodes carry
+              # their own InternalIP inside their ipamd assignable pool, so any hostNetwork:false pod
+              # in this file can draw it - not just the GPU workers. Fail in ~1s naming the remedy
+              # instead of CrashLooping on an opaque DNS error. No `say`/fd-3 indirection is needed
+              # here (unlike the worker templates): this container does not redirect its stdout into a
+              # `tee` process substitution, so a plain echo reaches `kubectl logs` before the exit.
+              if [ -n "${DOLLAR}{POD_IP:-}" ] && [ "${DOLLAR}{POD_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
+                echo "[frontend] FATAL: pod IP ${DOLLAR}POD_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                echo "[frontend]        Cluster DNS cannot answer for this pod, so NATS/etcd are unreachable."
+                echo "[frontend]        RESTARTING WILL NOT HELP - the sandbox keeps the address. Remedy:"
+                echo "[frontend]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                exit 1
+              fi
+              # dynamo.frontend calls DistributedRuntime() which connects to NATS immediately with NO
+              # retry, so a transient cold-start DNS miss (EAI_AGAIN, "Temporary failure in name
+              # resolution") is fatal and CrashLoops the pod even though NATS is healthy. The worker
+              # templates already guard their startup with a getent loop; agg/lws.yaml-template's
+              # frontend already carries this block - mirror it here so every frontend behaves the same.
+              NATS_HOST=${DOLLAR}{NATS_SERVER#*://}; NATS_HOST=${DOLLAR}{NATS_HOST%%:*}
+              for i in ${DOLLAR}(seq 1 60); do
+                if getent hosts "${DOLLAR}NATS_HOST" >/dev/null 2>&1; then break; fi
+                echo "[frontend] waiting for DNS NATS_HOST=${DOLLAR}NATS_HOST (${DOLLAR}i)"
+                sleep 2
+              done
               if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
               exec python3 -m dynamo.frontend --http-port 8000 --http-host 0.0.0.0
           env:
             - { name: DYNAMO_BACKEND, value: vllm }
             - { name: DYN_NAMESPACE, value: dynamo-disagg }
             - { name: ETCD_ENDPOINTS, value: "${ETCD_URL}" }
+            # Read only by the duplicate-address preflight in args above. The worker templates
+            # call the same value MY_IP because vLLM/ray also consume it; nothing else reads it
+            # here, so it keeps the field's own name.
+            - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+            - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
             - { name: NATS_SERVER, value: "${NATS_URL}" }
             - { name: HF_HOME, value: /tmp/hf_cache }
           ports: [{ containerPort: 8000, name: http }]

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-ep.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-ep.yaml-template
@@ -804,12 +804,48 @@ spec:
           command: ["/bin/bash", "-c"]
           args:
             - |-
+              # ---- Node-fault preflight: duplicate pod address (mechanism: disagg/lws-2pp.yaml-template) ----
+              # When the CNI hands this sandbox the node's own kubelet InternalIP (status.podIP ==
+              # status.hostIP while hostNetwork is false), kube-proxy DNAT replies land in the host
+              # netns, cluster DNS never answers, and DistributedRuntime() dies with "Failed to
+              # connect to NATS: DNS error ... Temporary failure in name resolution". A container
+              # RESTART CANNOT CLEAR IT: restarts reuse the pod sandbox, so CNI ADD is not re-invoked
+              # and the address is pinned for the pod's lifetime - the pod object has to be deleted.
+              # Measured on a 4-node ml.p6-b200.48xlarge cluster (2026-08-15): ALL FOUR nodes carry
+              # their own InternalIP inside their ipamd assignable pool, so any hostNetwork:false pod
+              # in this file can draw it - not just the GPU workers. Fail in ~1s naming the remedy
+              # instead of CrashLooping on an opaque DNS error. No `say`/fd-3 indirection is needed
+              # here (unlike the worker templates): this container does not redirect its stdout into a
+              # `tee` process substitution, so a plain echo reaches `kubectl logs` before the exit.
+              if [ -n "${DOLLAR}{POD_IP:-}" ] && [ "${DOLLAR}{POD_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
+                echo "[frontend] FATAL: pod IP ${DOLLAR}POD_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                echo "[frontend]        Cluster DNS cannot answer for this pod, so NATS/etcd are unreachable."
+                echo "[frontend]        RESTARTING WILL NOT HELP - the sandbox keeps the address. Remedy:"
+                echo "[frontend]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                exit 1
+              fi
+              # dynamo.frontend calls DistributedRuntime() which connects to NATS immediately with NO
+              # retry, so a transient cold-start DNS miss (EAI_AGAIN, "Temporary failure in name
+              # resolution") is fatal and CrashLoops the pod even though NATS is healthy. The worker
+              # templates already guard their startup with a getent loop; agg/lws.yaml-template's
+              # frontend already carries this block - mirror it here so every frontend behaves the same.
+              NATS_HOST=${DOLLAR}{NATS_SERVER#*://}; NATS_HOST=${DOLLAR}{NATS_HOST%%:*}
+              for i in ${DOLLAR}(seq 1 60); do
+                if getent hosts "${DOLLAR}NATS_HOST" >/dev/null 2>&1; then break; fi
+                echo "[frontend] waiting for DNS NATS_HOST=${DOLLAR}NATS_HOST (${DOLLAR}i)"
+                sleep 2
+              done
               if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
               exec python3 -m dynamo.frontend --http-port 8000 --http-host 0.0.0.0
           env:
             - { name: DYNAMO_BACKEND, value: vllm }
             - { name: DYN_NAMESPACE, value: dynamo-disagg }
             - { name: ETCD_ENDPOINTS, value: "${ETCD_URL}" }
+            # Read only by the duplicate-address preflight in args above. The worker templates
+            # call the same value MY_IP because vLLM/ray also consume it; nothing else reads it
+            # here, so it keeps the field's own name.
+            - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+            - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
             - { name: NATS_SERVER, value: "${NATS_URL}" }
             - { name: HF_HOME, value: /tmp/hf_cache }
           ports: [{ containerPort: 8000, name: http }]

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-pp2.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-pp2.yaml-template
@@ -109,6 +109,11 @@ spec:
           app.kubernetes.io/component: prefill
           dynamo-role: leader
       spec:
+        # hostNetwork: true -> status.podIP IS status.hostIP for this pod, by definition. The
+        # duplicate-address preflight the hostNetwork:false pods in this tree carry (see
+        # disagg/lws-2pp.yaml-template) is therefore NOT applicable here and must not be
+        # copied in: it would fire on EVERY start. The fault it detects cannot occur under host
+        # networking either - there is no separate sandbox address to collide with the node's.
         hostNetwork: true
         dnsPolicy: ClusterFirstWithHostNet
         nodeSelector:
@@ -177,21 +182,8 @@ spec:
                 exec 3>&1
                 exec > >(tee -a "${DOLLAR}LOG") 2>&1
                 say() { printf '%s\n' "${DOLLAR}*"; printf '%s\n' "${DOLLAR}*" >&3; }
-                # Same node-fault preflight as disagg/lws-2pp.yaml-template - a duplicate pod address
-                # (podIP == hostIP) is fatal and un-restartable, then a bounded wait for cluster DNS.
-                # See that file for the mechanism and the measured incident.
-                if [ -n "${DOLLAR}{MY_IP:-}" ] && [ "${DOLLAR}{MY_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
-                  say "[prefill-leader p5en] FATAL: pod IP ${DOLLAR}MY_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
-                  say "[prefill-leader p5en]        The CNI gave this sandbox the node's primary ENI address, so cluster DNS"
-                  say "[prefill-leader p5en]        cannot answer and NATS/etcd are unreachable. RESTARTING WILL NOT HELP -"
-                  say "[prefill-leader p5en]        the sandbox keeps the address. Remedy:"
-                  say "[prefill-leader p5en]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
-                  say "[prefill-leader p5en]        If the REPLACEMENT pod lands on this node and draws ${DOLLAR}NODE_IP again,"
-                  say "[prefill-leader p5en]        the node's own address is inside the CNI's assignable pool - ipamd re-adds"
-                  say "[prefill-leader p5en]        it every 60s - so it is a NODE fault, not this manifest. Confirm on the node:"
-                  say "[prefill-leader p5en]          grep \"Trying to add ${DOLLAR}NODE_IP\" /var/log/aws-routed-eni/ipamd.log"
-                  exit 1
-                fi
+                # No duplicate-address preflight here - hostNetwork: true, see the note on this
+                # pod's hostNetwork line. Only the bounded wait for cluster DNS below applies.
                 if command -v getent >/dev/null 2>&1; then
                   NATS_HOST=${DOLLAR}{NATS_SERVER#*://}; NATS_HOST=${DOLLAR}{NATS_HOST%%:*}
                   for i in ${DOLLAR}(seq 1 30); do
@@ -253,8 +245,6 @@ spec:
                   --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}'
             env:
               - { name: MY_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
-              # NODE_IP is read only by the node-fault preflight in args above (podIP == hostIP).
-              - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
               - { name: DYNAMO_BACKEND, value: vllm }
               - { name: DYN_NAMESPACE, value: dynamo-disagg }
               - { name: ETCD_ENDPOINTS, value: "${ETCD_URL}" }
@@ -303,6 +293,11 @@ spec:
           app.kubernetes.io/component: prefill
           dynamo-role: worker
       spec:
+        # hostNetwork: true -> status.podIP IS status.hostIP for this pod, by definition. The
+        # duplicate-address preflight the hostNetwork:false pods in this tree carry (see
+        # disagg/lws-2pp.yaml-template) is therefore NOT applicable here and must not be
+        # copied in: it would fire on EVERY start. The fault it detects cannot occur under host
+        # networking either - there is no separate sandbox address to collide with the node's.
         hostNetwork: true
         dnsPolicy: ClusterFirstWithHostNet
         nodeSelector:
@@ -418,6 +413,11 @@ spec:
           app.kubernetes.io/component: decode
           dynamo-role: leader
       spec:
+        # hostNetwork: true -> status.podIP IS status.hostIP for this pod, by definition. The
+        # duplicate-address preflight the hostNetwork:false pods in this tree carry (see
+        # disagg/lws-2pp.yaml-template) is therefore NOT applicable here and must not be
+        # copied in: it would fire on EVERY start. The fault it detects cannot occur under host
+        # networking either - there is no separate sandbox address to collide with the node's.
         hostNetwork: true
         dnsPolicy: ClusterFirstWithHostNet
         nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_WORKER} }
@@ -482,21 +482,8 @@ spec:
                 exec 3>&1
                 exec > >(tee -a "${DOLLAR}LOG") 2>&1
                 say() { printf '%s\n' "${DOLLAR}*"; printf '%s\n' "${DOLLAR}*" >&3; }
-                # Same node-fault preflight as disagg/lws-2pp.yaml-template - a duplicate pod address
-                # (podIP == hostIP) is fatal and un-restartable, then a bounded wait for cluster DNS.
-                # See that file for the mechanism and the measured incident.
-                if [ -n "${DOLLAR}{MY_IP:-}" ] && [ "${DOLLAR}{MY_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
-                  say "[decode p5en] FATAL: pod IP ${DOLLAR}MY_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
-                  say "[decode p5en]        The CNI gave this sandbox the node's primary ENI address, so cluster DNS"
-                  say "[decode p5en]        cannot answer and NATS/etcd are unreachable. RESTARTING WILL NOT HELP -"
-                  say "[decode p5en]        the sandbox keeps the address. Remedy:"
-                  say "[decode p5en]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
-                  say "[decode p5en]        If the REPLACEMENT pod lands on this node and draws ${DOLLAR}NODE_IP again,"
-                  say "[decode p5en]        the node's own address is inside the CNI's assignable pool - ipamd re-adds"
-                  say "[decode p5en]        it every 60s - so it is a NODE fault, not this manifest. Confirm on the node:"
-                  say "[decode p5en]          grep \"Trying to add ${DOLLAR}NODE_IP\" /var/log/aws-routed-eni/ipamd.log"
-                  exit 1
-                fi
+                # No duplicate-address preflight here - hostNetwork: true, see the note on this
+                # pod's hostNetwork line. Only the bounded wait for cluster DNS below applies.
                 if command -v getent >/dev/null 2>&1; then
                   NATS_HOST=${DOLLAR}{NATS_SERVER#*://}; NATS_HOST=${DOLLAR}{NATS_HOST%%:*}
                   for i in ${DOLLAR}(seq 1 30); do
@@ -642,8 +629,6 @@ spec:
                   --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}'
             env:
               - { name: MY_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
-              # NODE_IP is read only by the node-fault preflight in args above (podIP == hostIP).
-              - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
               - { name: DYNAMO_BACKEND, value: vllm }
               - { name: DYN_NAMESPACE, value: dynamo-disagg }
               - { name: ETCD_ENDPOINTS, value: "${ETCD_URL}" }
@@ -695,6 +680,11 @@ spec:
           app.kubernetes.io/component: decode
           dynamo-role: worker
       spec:
+        # hostNetwork: true -> status.podIP IS status.hostIP for this pod, by definition. The
+        # duplicate-address preflight the hostNetwork:false pods in this tree carry (see
+        # disagg/lws-2pp.yaml-template) is therefore NOT applicable here and must not be
+        # copied in: it would fire on EVERY start. The fault it detects cannot occur under host
+        # networking either - there is no separate sandbox address to collide with the node's.
         hostNetwork: true
         dnsPolicy: ClusterFirstWithHostNet
         nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_WORKER} }
@@ -831,12 +821,48 @@ spec:
           # "no such file or directory" and the pod CrashLoops. Activate only when present.
           args:
             - |-
+              # ---- Node-fault preflight: duplicate pod address (mechanism: disagg/lws-2pp.yaml-template) ----
+              # When the CNI hands this sandbox the node's own kubelet InternalIP (status.podIP ==
+              # status.hostIP while hostNetwork is false), kube-proxy DNAT replies land in the host
+              # netns, cluster DNS never answers, and DistributedRuntime() dies with "Failed to
+              # connect to NATS: DNS error ... Temporary failure in name resolution". A container
+              # RESTART CANNOT CLEAR IT: restarts reuse the pod sandbox, so CNI ADD is not re-invoked
+              # and the address is pinned for the pod's lifetime - the pod object has to be deleted.
+              # Measured on a 4-node ml.p6-b200.48xlarge cluster (2026-08-15): ALL FOUR nodes carry
+              # their own InternalIP inside their ipamd assignable pool, so any hostNetwork:false pod
+              # in this file can draw it - not just the GPU workers. Fail in ~1s naming the remedy
+              # instead of CrashLooping on an opaque DNS error. No `say`/fd-3 indirection is needed
+              # here (unlike the worker templates): this container does not redirect its stdout into a
+              # `tee` process substitution, so a plain echo reaches `kubectl logs` before the exit.
+              if [ -n "${DOLLAR}{POD_IP:-}" ] && [ "${DOLLAR}{POD_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
+                echo "[frontend] FATAL: pod IP ${DOLLAR}POD_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                echo "[frontend]        Cluster DNS cannot answer for this pod, so NATS/etcd are unreachable."
+                echo "[frontend]        RESTARTING WILL NOT HELP - the sandbox keeps the address. Remedy:"
+                echo "[frontend]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                exit 1
+              fi
+              # dynamo.frontend calls DistributedRuntime() which connects to NATS immediately with NO
+              # retry, so a transient cold-start DNS miss (EAI_AGAIN, "Temporary failure in name
+              # resolution") is fatal and CrashLoops the pod even though NATS is healthy. The worker
+              # templates already guard their startup with a getent loop; agg/lws.yaml-template's
+              # frontend already carries this block - mirror it here so every frontend behaves the same.
+              NATS_HOST=${DOLLAR}{NATS_SERVER#*://}; NATS_HOST=${DOLLAR}{NATS_HOST%%:*}
+              for i in ${DOLLAR}(seq 1 60); do
+                if getent hosts "${DOLLAR}NATS_HOST" >/dev/null 2>&1; then break; fi
+                echo "[frontend] waiting for DNS NATS_HOST=${DOLLAR}NATS_HOST (${DOLLAR}i)"
+                sleep 2
+              done
               if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
               exec python3 -m dynamo.frontend --http-port 8000 --http-host 0.0.0.0
           env:
             - { name: DYNAMO_BACKEND, value: vllm }
             - { name: DYN_NAMESPACE, value: dynamo-disagg }
             - { name: ETCD_ENDPOINTS, value: "${ETCD_URL}" }
+            # Read only by the duplicate-address preflight in args above. The worker templates
+            # call the same value MY_IP because vLLM/ray also consume it; nothing else reads it
+            # here, so it keeps the field's own name.
+            - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+            - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
             - { name: NATS_SERVER, value: "${NATS_URL}" }
           ports:
             - { containerPort: 8000, name: http }


### PR DESCRIPTION
Follow-up to #75 and #76. Two things: the preflight those PRs added is in the wrong set of pods, and the node-level explanation #76 recorded turns out to be wrong. Both are fixed here.

## What is wrong today

#75 put the duplicate-address preflight (`status.podIP == status.hostIP` while `hostNetwork` is false) in three `disagg/` LWS templates. Coverage followed the *file*, and it should follow the *network namespace*.

**It is in two containers where it can only ever be wrong.** `disagg/lws-pp2` sets `hostNetwork: true` on all four of its GPU pod specs, and two of them (the prefill and decode leaders) carry the preflight. Under host networking `status.podIP` **is** `status.hostIP` by definition:

```console
$ kubectl get pods -A -o json | jq -r '.items[] | select(.spec.hostNetwork==true)
    | select(.status.podIP!=null) | (.status.podIP==.status.hostIP) | tostring' \
    | sort | uniq -c
     20 true      # this cluster
    107 true      # a second, unrelated EKS cluster, same command
```

127 of 127, no exceptions — so the merged manifest would have FATAL'd on **every** start of the symmetric-PP2 shape. The fault it looks for also cannot occur there: there is no separate sandbox address to collide with the node's.

**It is missing from every `hostNetwork: false` pod outside those three files.** On the 4-node `ml.p6-b200.48xlarge` cluster, *all four* nodes carry their own kubelet InternalIP inside their ipamd assignable pool, so any pod-netns pod in this tree can draw it. It was never specific to the decode role.

## What this PR changes

Removed from those 2 host-netns containers, along with the `NODE_IP` fieldRef they used only for it. Added to the 13 pod-netns containers that had no guard, taking the tree from 8 guarded containers to 19:

| template | containers gaining the preflight | note |
|---|---|---|
| `agg/deployment` | frontend, worker | |
| `agg/lws` | frontend | its 2 GPU pods are host-netns |
| `agg/dgd` | Frontend, VllmWorker | operator-managed |
| `disagg/deployment` | frontend | its 2 GPU pods are host-netns |
| `disagg/dgd` | Frontend, VllmPrefillWorker, VllmDecodeWorker | operator-managed |
| `disagg/lws-2pp` | prefill worker, frontend | worker **failed the wrong way** — see below |
| `disagg/lws-ep` | frontend | its 4 GPU pods were already guarded |
| `disagg/lws-pp2` | frontend | its 4 GPU pods are host-netns |

`disagg/lws-2pp`'s prefill worker is the one worth calling out. Its first act is `getent hosts $LWS_LEADER_ADDRESS`, which a duplicate address breaks, so it burned the full 300 s resolve budget and then blamed the leader address instead of the node. It now exits in about a second naming the node fault and the remedy.

The two DGD templates needed `env[].valueFrom.fieldRef` inside `extraPodSpec.mainContainer`. That is checked against the installed `dynamographdeployments.nvidia.com` v1alpha1 schema, not assumed — see the gate below.

Plain `echo` is correct in all thirteen of these bodies: none of them redirect stdout into a `tee` process substitution, so none needs the `say()`/fd-3 indirection #76 added. The bodies that *do* tee are untouched.

Comment-only in the same pass, so the rule is legible where it applies and not only where it fires: all 10 `hostNetwork: true` pod specs in the tree now carry the same one-paragraph note on the `hostNetwork` line saying why the preflight is deliberately absent and must not be copied in. `agg/lws-ep` changes for that reason alone — both of its pods are host-netns, so its coverage was already complete.

## Correction to #76

#76's body says the SageMaker device-number-0 ENI makes the customer-VPC ENI look like a *secondary* ENI, so its primary address becomes assignable. ipamd's own datastore refutes that — it flags that ENI **primary** and hands the address out anyway:

```
ipamd.log   "Discovered the instance primary IPv4 address: <node InternalIP>"
ipamd.log   "eni-07e6…  is the primary ENI of this instance"
IMDS        that ENI's local-ipv4s[0] (its primary) == the kubelet InternalIP
127.0.0.1:61679/v1/enis   TotalIPs 50, IsPrimary true,
                          "<node InternalIP>/32": {"IPAddresses":{}}   # in the pool, free to hand out
grep -c "Reconcile skipping primary IP" ipamd.log   ->  0               # the reserve path never logs
```

(`aws-node` v1.22.3-eksbuild.1, `CUSTOM_NETWORK_CFG=false`, `PREFIX_DELEGATION=false`.)

Also: #76 says two of four nodes were affected. It is four of four. And it is not a 1-in-50 lottery — 3 of the last 5 sandboxes on one node drew exactly that address.

The one-liner in #76 that looked like it cleared a node is misleading and should not be reused: `Trying to add <ip>` is ipamd's once-a-minute reconciler pass over the whole pool, so **every** address in the pool carries the same count. With all counts tied, `sort -rn | head` ranks nothing and cuts by tie-break byte order. Test presence, not rank — and this needs no node access at all:

```bash
kubectl get pods -A -o json | jq -r '.items[]
  | select(.spec.hostNetwork != true) | select(.status.podIP == .status.hostIP)
  | "\(.metadata.namespace)/\(.metadata.name) \(.status.podIP) \(.spec.nodeName)"'
```

None of this changes the remedy — `kubectl delete pod`, because a container **restart** reuses the sandbox and cannot draw a new address — but it does mean no manifest can prevent the fault. The sandbox IP is assigned before any container runs. The cure is CNI-level (the node's own InternalIP should not be in the pod pool); this PR is the fail-fast, and it now fails fast everywhere it can occur.

## Gates

All four run on the patched tree:

| gate | result |
|---|---|
| `envsubst` render + YAML parse | 9/9 templates |
| `bash -n` on every container shell body | 29/29 clean |
| coverage matrix over **every** pod spec in every rendered doc | 19/19 pod-netns containers guarded, 0 of 10 host-netns carrying it |
| `kubectl apply --dry-run=server` | 9/9 admitted, 0 objects created |

The coverage gate walks pod specs rather than shell bodies on purpose: a gate that only inspects containers with a non-empty `args[0]` scores a pod it cannot see as a pass, which is how the `agg/dgd` and `disagg/dgd` gaps stayed invisible. The `--dry-run=server` gate is server-side rather than client-side for the same reason — client dry-run would not have exercised the DGD CRD's acceptance of the fieldRefs. It renders under a throwaway `DEPLOYMENT_NAME` and leaves nothing behind.

No behaviour change for a healthy pod: the check is two string comparisons before any engine work.
