### PR TITLE
nemotron/ultra/test: stop aiperf runs from overwriting each other's artifacts

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/README.md
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/README.md
@@ -124,3 +124,9 @@ Then run any or all of the following tests:
 * `./test-aiperf.sh` - runs aiperf against the model endpoint, reports benchmark results
 * `./aiperf-sweep-run.sh` - runs a sweep of aiperf tests with concurrency 1,4,8,16,32,64 to explore scalability
 
+`test-aiperf.sh` writes its artifacts to
+`${MODEL_PATH}/aiperf/${DEPLOYMENT_TYPE}/${MANIFEST_TYPE}/${AIPERF_RUN_ID}` and prints the path
+before it starts. `AIPERF_RUN_ID` defaults to a UTC timestamp, so comparing topologies or rerunning
+one of them keeps every report -- set `MANIFEST_TYPE` in `test/.env` to match the deployed topology
+so the folder is labelled correctly, and set `AIPERF_RUN_ID` to name a run (`AIPERF_RUN_ID=cold`).
+

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/test/.env
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/test/.env
@@ -2,8 +2,14 @@
 
 export DOLLAR='$'
 # DEPLOYMENT_TYPE=agg|disagg
-export DEPLOYMENT_TYPE=agg
+export DEPLOYMENT_TYPE="${DEPLOYMENT_TYPE:-agg}"
 export DEPLOYMENT_NAME=nemotron3-ultra-550b-${DEPLOYMENT_TYPE}
+
+# MANIFEST_TYPE mirrors ../${DEPLOYMENT_TYPE}/.env and is used here for one purpose only:
+# scoping the aiperf artifact directory. Nothing in test/ renders a manifest, so a value that
+# does not match the deployed topology only mislabels the results folder.
+# agg: deployment|lws|lws-ep|dgd   disagg: deployment|lws-2pp|lws-pp2|lws-ep|dgd
+export MANIFEST_TYPE="${MANIFEST_TYPE:-deployment}"
 export SERVICE_NAME=${DEPLOYMENT_NAME}-frontend
 export NAMESPACE=default
 export SERVICE_URL="http://${SERVICE_NAME}.${NAMESPACE}.svc.cluster.local:8000"

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/test/test-aiperf.sh
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/test/test-aiperf.sh
@@ -34,10 +34,23 @@ if [ "${_WARMUP_COUNT}" -gt 0 ] 2>/dev/null; then
   echo "NVFP4 model detected: adding ${_WARMUP_ARG} (excluded from the report)"
 fi
 
+# Artifact directory. ${MODEL_PATH}/aiperf/${DEPLOYMENT_TYPE} alone is not unique per run:
+# every topology in a folder shares one DEPLOYMENT_TYPE, so a lws-2pp run and the lws-pp2 run
+# after it land in the same directory and aiperf truncates profile_export.jsonl on start. The
+# per-request records of the earlier run are gone before its summary is read, and a repeat of
+# the SAME topology (a cold run then a warm rerun) overwrites the summary too. Observed on
+# p6-b200 2026-08-16: a completed disagg/lws-2pp report sat next to a zero-length
+# profile_export.jsonl written by the disagg/lws-pp2 run started 97 minutes later.
+# Scoping by MANIFEST_TYPE and run id keeps every run readable and comparable.
+# AIPERF_RUN_ID can be set to any label (a ticket id, "cold", "warm") to name a run.
+export AIPERF_RUN_ID="${AIPERF_RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)}"
+export ARTIFACT_DIR="${MODEL_PATH}/aiperf/${DEPLOYMENT_TYPE}/${MANIFEST_TYPE}/${AIPERF_RUN_ID}"
+echo "Artifacts: ${ARTIFACT_DIR}"
+
 # Execute the aiperf command interactively
 echo "Executing aiperf command in do-aiperf pod ..."
 
-export CMD="kubectl exec -it do-aiperf -- aiperf profile --model \"${MODEL_NAME}\" --tokenizer \"${MODEL_PATH}\" --artifact-dir \"${MODEL_PATH}/aiperf/${DEPLOYMENT_TYPE}\" --url \"${SERVICE_URL}\" --transport http --endpoint-type chat --streaming --concurrency 10 --request-count 100 ${_WARMUP_ARG} --synthetic-input-tokens-mean 1024 --synthetic-input-tokens-stddev 0 --output-tokens-mean 512 --extra-inputs \"ignore_eos:true\" --random-seed 42"
+export CMD="kubectl exec -it do-aiperf -- aiperf profile --model \"${MODEL_NAME}\" --tokenizer \"${MODEL_PATH}\" --artifact-dir \"${ARTIFACT_DIR}\" --url \"${SERVICE_URL}\" --transport http --endpoint-type chat --streaming --concurrency 10 --request-count 100 ${_WARMUP_ARG} --synthetic-input-tokens-mean 1024 --synthetic-input-tokens-stddev 0 --output-tokens-mean 512 --extra-inputs \"ignore_eos:true\" --random-seed 42"
 
 if [ ! "$VERBOSE" == "false" ]; then echo -e "\n${CMD}\n"; fi
 


### PR DESCRIPTION
### What

`test/test-aiperf.sh` wrote every run to `${MODEL_PATH}/aiperf/${DEPLOYMENT_TYPE}`. That path is not unique per run:

- all topologies in a folder share one `DEPLOYMENT_TYPE`, so a `disagg/lws-2pp` run and the `disagg/lws-pp2` run after it land in the same directory
- a repeat of the **same** topology (a cold run, then a warm rerun) lands there too

aiperf truncates `profile_export.jsonl` when it starts, so the earlier run's per-request records are gone before anyone reads its summary, and the summary itself is overwritten when the later run finishes.

### Observed

p6-b200, 2026-08-16. A completed `disagg/lws-2pp` NVFP4 report — `profile_export_aiperf.{csv,json}` and `server_metrics_export.{csv,json}`, benchmark_id `0901ab86a8a7`, ended `02:01:37Z` — sat in `.../NVFP4/aiperf/disagg/` next to a **zero-length** `profile_export.jsonl` dated `03:38`, written by the `disagg/lws-pp2` run started 97 minutes later. The per-request records needed to order requests by start time (the check that separates a first-wave JIT tail from a steady-state one) were already unrecoverable, and the summary would have gone the same way when the second run finished.

Comparing topologies, which is the point of having five of them, destroys the evidence it is comparing.

### Fix

Artifacts go to `${MODEL_PATH}/aiperf/${DEPLOYMENT_TYPE}/${MANIFEST_TYPE}/${AIPERF_RUN_ID}`, printed before the run starts:

```
Artifacts: /shared/models/hf/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4/aiperf/disagg/lws-2pp/20260816T040204Z
```

`AIPERF_RUN_ID` defaults to a UTC timestamp and takes any label (`AIPERF_RUN_ID=cold`) — same idiom as `AIPERF_WARMUP_REQUESTS` and `WARMUP_ENABLED`.

`test/.env` gains `MANIFEST_TYPE`, mirroring `agg/.env` and `disagg/.env`. Nothing in `test/` renders a manifest, so it only labels the results folder. `DEPLOYMENT_TYPE` becomes `${VAR:-default}` for the same reason it did in `agg/.env` in #74: selecting disagg for a benchmark should not require editing a tracked file.

3 files, README documents the path and both knobs.

### Gates (all cluster-free)

- `bash -n` on `test/.env` and `test/test-aiperf.sh`
- artifact path rendered for all four disagg topologies and for two run ids of one topology — confirmed distinct
- defaults with no exports still resolve to `agg` / `deployment` / `BF16`
- `test-aiperf.sh` **stub-executed** against a `PATH`-shimmed `kubectl` in three configurations: NVFP4 disagg lws-2pp emits `--warmup-request-count 30`, BF16 agg default emits none, `AIPERF_RUN_ID=cold` with `AIPERF_WARMUP_REQUESTS=0` honours both

### Not in this PR

The `lws-2pp` NVFP4 tail itself. That run used both warmup layers — the manifest warmer and `--warmup-request-count 30` (3 waves at `--concurrency 10`, excluded from the report, confirmed in the export's `run_info`) — and still reported TTFT p90 100,539 ms against a p50 of 742 ms. Its `server_metrics_export.csv` shows the two decode replicas measurably asymmetric: `dynamo_frontend_worker_last_inter_token_latency_seconds` max 4.44 s on one worker, 62.99 s (p99 62.63 s) on the other. That points at warmup coverage on `replicas: 2` behind a round-robin frontend, which the template's own comment already flags — but those pods are gone, so it is a hypothesis, not a verified finding, and it does not belong in a fix PR yet.