### PR TITLE
nemotron/ultra/disagg/lws-ep: decode EP16 cannot start at gpu-memory-utilization 0.98

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-ep.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-ep.yaml-template
@@ -120,7 +120,13 @@ spec:
                 # back to /tmp rather than losing every log line to EACCES.
                 LOG_DIR=/shared
                 if ! ( : > "${DOLLAR}LOG_DIR/.wtest-${DOLLAR}HOSTNAME" ) 2>/dev/null; then
-                  echo "[prefill-dp0] ${DOLLAR}LOG_DIR not writable; logging to /tmp instead"
+                  echo "[prefill-dp0] ${DOLLAR}LOG_DIR is not writable by uid ${DOLLAR}(id -u); logging to /tmp instead."
+                  echo "[prefill-dp0]   That log dies WITH THE POD, and this LWS sets restartPolicy"
+                  echo "[prefill-dp0]   RecreateGroupOnPodRestart, so a crash deletes the pod outright - kubectl logs"
+                  echo "[prefill-dp0]   --previous will not exist either, and the crash is unrecoverable after the"
+                  echo "[prefill-dp0]   fact. To keep crash logs, make the shared volume writable for uid"
+                  echo "[prefill-dp0]   ${DOLLAR}(id -u) (chown or chmod g+w on ${DOLLAR}LOG_DIR from a root pod), or follow the"
+                  echo "[prefill-dp0]   live log with: kubectl -n ${NAMESPACE} logs -f ${DOLLAR}HOSTNAME"
                   LOG_DIR=/tmp
                 else
                   rm -f "${DOLLAR}LOG_DIR/.wtest-${DOLLAR}HOSTNAME"
@@ -442,7 +448,13 @@ spec:
                 if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
                 LOG_DIR=/shared
                 if ! ( : > "${DOLLAR}LOG_DIR/.wtest-${DOLLAR}HOSTNAME" ) 2>/dev/null; then
-                  echo "[decode-dp0] ${DOLLAR}LOG_DIR not writable; logging to /tmp instead"
+                  echo "[decode-dp0] ${DOLLAR}LOG_DIR is not writable by uid ${DOLLAR}(id -u); logging to /tmp instead."
+                  echo "[decode-dp0]   That log dies WITH THE POD, and this LWS sets restartPolicy"
+                  echo "[decode-dp0]   RecreateGroupOnPodRestart, so a crash deletes the pod outright - kubectl logs"
+                  echo "[decode-dp0]   --previous will not exist either, and the crash is unrecoverable after the"
+                  echo "[decode-dp0]   fact. To keep crash logs, make the shared volume writable for uid"
+                  echo "[decode-dp0]   ${DOLLAR}(id -u) (chown or chmod g+w on ${DOLLAR}LOG_DIR from a root pod), or follow the"
+                  echo "[decode-dp0]   live log with: kubectl -n ${NAMESPACE} logs -f ${DOLLAR}HOSTNAME"
                   LOG_DIR=/tmp
                 else
                   rm -f "${DOLLAR}LOG_DIR/.wtest-${DOLLAR}HOSTNAME"
@@ -560,6 +572,28 @@ spec:
                     [ "${DOLLAR}warmed" = 1 ] || echo "[warmup] gave up after 30min waiting for ${DOLLAR}LH 200 + ${MODEL_NAME} in ${DOLLAR}FE/v1/models; the FIRST benchmark requests will pay the Mamba JIT (non-fatal)"
                   fi
                 ) &
+                # --gpu-memory-utilization is 0.92 here, NOT the 0.98 the single-node decode blocks in
+                # disagg/lws-2pp and disagg/lws-pp2 use. vLLM 0.23's gpu_worker.init_device ->
+                # worker/utils.request_memory demands that utilization * total ALREADY BE FREE when the
+                # rank initialises, and by then a DP${EP_DP_SIZE} x TP${GPU_PER_WORKER} = EP$((${EP_DP_SIZE}*${GPU_PER_WORKER}))
+                # group already has 4.11-4.57 GiB resident on every B200 - CUDA context, the NCCL
+                # communicators (the node-local TP${GPU_PER_WORKER} one plus the CROSS-NODE DP/EP one) and the
+                # EFA rails. That total is what is measured; the per-component split is not. Measured on
+                # this template 2026-08-16: free was 173.78-174.24 of 178.35 GiB on all 16 GPUs (2 decode
+                # pods x 8) while 0.98 asks for 174.78, so all 16
+                # ranks raised "Free memory on device cuda:N (173.8/178.35 GiB) on startup is less than
+                # desired GPU memory utilization (0.98, 174.78 GiB)" 88s after the DP group leader
+                # announced itself (05:40:26 -> 05:41:54), inside a 3m28s pod lifetime, and the decode
+                # group crash-looped at that period indefinitely. The footprint is structural, not the
+                # loop measuring its own teardown: three pod generations on two nodes 25min apart gave
+                # byte-identical per-device figures, down to the cuda:7 outlier 0.46 GiB above its
+                # siblings, and no generation ever reached memory profiling or weight load. RecreateGroupOnPodRestart disguises that as
+                # a FRESH pod with restartCount=0, so it does not look like a crash loop in `get pods`.
+                # 0.92 is what the prefill blocks in this file and both agg/lws-ep blocks already use, and
+                # it leaves room for what allocates OUTSIDE this budget after the check - the flashinfer
+                # autotune workspace and the NIXL/EFA KV registration. 0.95/0.97 clear the init check but
+                # leave those only 4.4/0.8 GiB to share, which is not measured; do not raise this without
+                # re-measuring free memory at init on the EP topology.
                 exec python3 -m dynamo.vllm \
                   --model ${MODEL_PATH} \
                   --served-model-name ${MODEL_NAME} \
@@ -571,7 +605,7 @@ spec:
                   --enable-expert-parallel \
                   --pipeline-parallel-size 1 \
                   --max-model-len 8192 \
-                  --gpu-memory-utilization 0.98 \
+                  --gpu-memory-utilization 0.92 \
                   --enforce-eager \
                   --trust-remote-code \
                   ${MAMBA_FLAGS} \
@@ -708,6 +742,28 @@ spec:
                   if (echo > /dev/tcp/${DOLLAR}LEADER_IP/29551) 2>/dev/null; then break; fi
                   sleep 5
                 done
+                # --gpu-memory-utilization is 0.92 here, NOT the 0.98 the single-node decode blocks in
+                # disagg/lws-2pp and disagg/lws-pp2 use. vLLM 0.23's gpu_worker.init_device ->
+                # worker/utils.request_memory demands that utilization * total ALREADY BE FREE when the
+                # rank initialises, and by then a DP${EP_DP_SIZE} x TP${GPU_PER_WORKER} = EP$((${EP_DP_SIZE}*${GPU_PER_WORKER}))
+                # group already has 4.11-4.57 GiB resident on every B200 - CUDA context, the NCCL
+                # communicators (the node-local TP${GPU_PER_WORKER} one plus the CROSS-NODE DP/EP one) and the
+                # EFA rails. That total is what is measured; the per-component split is not. Measured on
+                # this template 2026-08-16: free was 173.78-174.24 of 178.35 GiB on all 16 GPUs (2 decode
+                # pods x 8) while 0.98 asks for 174.78, so all 16
+                # ranks raised "Free memory on device cuda:N (173.8/178.35 GiB) on startup is less than
+                # desired GPU memory utilization (0.98, 174.78 GiB)" 88s after the DP group leader
+                # announced itself (05:40:26 -> 05:41:54), inside a 3m28s pod lifetime, and the decode
+                # group crash-looped at that period indefinitely. The footprint is structural, not the
+                # loop measuring its own teardown: three pod generations on two nodes 25min apart gave
+                # byte-identical per-device figures, down to the cuda:7 outlier 0.46 GiB above its
+                # siblings, and no generation ever reached memory profiling or weight load. RecreateGroupOnPodRestart disguises that as
+                # a FRESH pod with restartCount=0, so it does not look like a crash loop in `get pods`.
+                # 0.92 is what the prefill blocks in this file and both agg/lws-ep blocks already use, and
+                # it leaves room for what allocates OUTSIDE this budget after the check - the flashinfer
+                # autotune workspace and the NIXL/EFA KV registration. 0.95/0.97 clear the init check but
+                # leave those only 4.4/0.8 GiB to share, which is not measured; do not raise this without
+                # re-measuring free memory at init on the EP topology.
                 exec python3 -m dynamo.vllm \
                   --model ${MODEL_PATH} \
                   --served-model-name ${MODEL_NAME} \
@@ -721,7 +777,7 @@ spec:
                   --enable-expert-parallel \
                   --pipeline-parallel-size 1 \
                   --max-model-len 8192 \
-                  --gpu-memory-utilization 0.98 \
+                  --gpu-memory-utilization 0.92 \
                   --enforce-eager \
                   --trust-remote-code \
                   ${MAMBA_FLAGS} \


### PR DESCRIPTION
## The bug

`disagg/lws-ep.yaml-template`'s decode LeaderWorkerSet **cannot start**. Both decode blocks ask for
`--gpu-memory-utilization 0.98`, and on the EP topology that value is unreachable, so every rank dies in
vLLM's startup memory check before the model is loaded:

```
ValueError: Free memory on device cuda:7 (174.24/178.35 GiB) on startup is less than desired
GPU memory utilization (0.98, 174.78 GiB). Decrease GPU memory utilization or reduce GPU memory
used by other processes.
  vllm/v1/worker/gpu_worker.py:314   init_device
  vllm/v1/worker/utils.py:415        request_memory
```

vLLM 0.23 requires `utilization × total` to **already be free** at the moment a rank initialises. By that
moment a `--data-parallel-size 2` × `--tensor-parallel-size 8` = **EP16** group already has **4.11–4.57 GiB
resident on every B200** — CUDA context, the NCCL communicators (the node-local TP8 one plus the cross-node
DP/EP one) and the EFA rails. Free memory was **173.78–174.24 of 178.35 GiB** on all 16 GPUs (2 decode pods
× 8); `0.98` asks for **174.78**.

That total is what is measured; the per-component split is not. The extra footprint is attributable to the
EP addition by **outcome**, not by byte accounting — the same image running single-node TP8 decode at 0.98
came up with 0 restarts, and vLLM only prints a free-memory figure when the check *fails*, so there is no
passing-topology number to subtract from.

The deficit is 0.54–1.0 GiB and it is not marginal or flaky — it is **deterministic**. No run of this
template has ever gotten decode past `init_device`.

**The competing explanation, tested and refuted.** A crash-looping group could inflate its own measurement:
if the dying cycle's CUDA contexts were still tearing down as the next pod initialised, the 4.11–4.57 GiB
would not be steady-state EP16 overhead and `0.98` would be a victim of the loop rather than its cause. It
isn't — **three pod generations on two different nodes, 25 minutes apart, produced byte-identical per-device
figures** (same md5 over the sorted set), reproducing even the `cuda:7` = 174.24 outlier that sits 0.46 GiB
above its seven siblings. Teardown overlap would jitter; a structural footprint does not. And no generation
ever reached the check-passing path — `grep -cE "Memory profiling|available KV cache|GPU KV cache size|Loading weights"`
= 0 in all of them, each ending `RuntimeError: Engine core initialization failed`.

Measured on a 4-node `ml.p6-b200.48xlarge` HyperPod run of this exact template, 2026-08-16:

| | |
|---|---|
| ranks that failed | **16 of 16**, byte-identical message, differing only in the free-memory digits |
| time to failure | **88 s** after the DP group leader announced itself (05:40:26 → 05:41:54), inside a 3m28s pod lifetime (`startTime 05:38:33Z`) |
| loop period | ~3.5 min, indefinitely — generations observed at `startTime` 05:38:33Z, 05:59:46Z, 06:03:53Z |
| cross-cycle reproduction | **3 generations, 2 nodes, 25 min apart → identical per-device figures to 0.01 GiB** |
| baseline GPU memory | **4 MiB used / 183359 MiB** — the node was clean; the 4.11–4.57 GiB is *our own* EP16 footprint |
| prefill on the same nodes, same run, at 0.92 | **healthy** — weights 100 %, `GPU KV cache size: 8,830,976 tokens` |

## Where the 0.98 came from

`git log -S` traces it to the **single-node TP8** decode blocks (`cef0841` → `f5e50cf`), copied into the EP
blocks when this template was added. Single-node TP8 decode does not pay the cross-node NCCL/EFA cost, and
`0.98` is measured working there — `disagg/lws-2pp`'s decode group came up with 0 restarts on 2026-08-15.
The EP topology is the only one that pays it, and the value was never re-measured after the copy.

## The fix

Both EP decode blocks → `--gpu-memory-utilization 0.92`, which is what the **prefill blocks in this same
file** and **both `agg/lws-ep` blocks** already use. The measurement is recorded in a comment above the
`exec` so the next person doesn't re-raise it.

Not a value that merely clears the check (0.95/0.97 do): the flashinfer autotune workspace and the NIXL/EFA
KV registration allocate from what is left **outside** this budget after the check passes, and 0.95/0.97
would leave those only 4.4/0.8 GiB to share — which is not measured. `0.92` is the only headroom on this
topology with evidence behind it.

`disagg/lws-2pp` and `disagg/lws-pp2` are deliberately **untouched**.

## What is and isn't verified

**Verified:** `0.98` can never work on EP16 — the failure is in a pre-load arithmetic check with measured
inputs, so it is provable rather than probabilistic. And `0.92` is the measured-good headroom for the other
role on the identical topology, hardware, and image, in the same run.

**Also verified, on the cluster, after this patch was applied — the stack comes up.** This section
originally said the *full* EP16 decode bring-up at 0.92 was unverified, because every crash cycle died in
`init_device`. It has now been run: `0.92` was applied to both decode blocks and the disagg stack redeployed
(06:13:02Z), and by **06:34:02Z all 5 pods are `1/1 Running`, 0 restarts**, `startTime` never moving — versus
the 3m28s crash period before.

Decode passed, in order, every stage it had never previously reached:

```
06:16:22  Starting to load model .../NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4
06:22:12  Model loading took 31.11 GiB memory and 348.782115 seconds
06:31:21  Available KV cache memory: 128.37 GiB
06:31:21  GPU KV cache size: 8,808,857 tokens
06:31:21  Initializing NIXL worker c1cd7582-..._dp0
06:33:37  init engine (profile, create kv cache, warmup model) took 684.33 s
06:34:02  Ready=True
```

All four engine pods agree (init engine 684.33 / 685.16 / 685.17 / 684.64 s for decode leader, decode
worker, prefill leader, prefill worker), the frontend serves the model, and the **discriminator holds**:
`grep -c "Free memory on device"` = **0** on all four, as is `ValueError` / `Engine core initialization
failed`.

The headroom question answers itself in the numbers: at 0.92 the ask is `0.92 × 178.35 = 164.08 GiB` and the
actual use is `31.11` (weights) + `128.37` (KV) = **159.48 GiB**. A higher utilization would not have bought
capability here, only more KV on top of an already 8.8M-token cache.

**Still not claimed:** that KV bytes *move over EFA* between prefill and decode. That is a data-path
property; READY is a bring-up signal, and a request that returns is not evidence KV moved. This PR removes a
provably unconditional crash and is now measured to let the stack reach serving; it is not a claim about the
transfer path.

**One readiness-signal trap this surfaced** (not addressed by this PR, recorded for whoever reads the
template next): only the **leader** pods carry the `startupProbe` on `/health`. Both `-0-1` **worker** pods
reported `Ready=True` 3 seconds after start — ~21 minutes before their engines finished initialising. So
`4/5 Ready` during bring-up says nothing about the workers, and a worker whose engine had died would still
read `1/1`. Judge this stack by the leaders.

## Second change: the log-fallback message tells you where the crash log went

The container runs as uid 1000 and `/shared` is root-owned `0755`, so the writable-probe falls back to
in-pod `/tmp` — and that log **dies with the pod**. Because this LWS sets
`restartPolicy: RecreateGroupOnPodRestart`, a crash *deletes the pod*, so `kubectl logs --previous` does not
exist either, and the crash is unrecoverable after the fact. The only way I could read the traceback above
was racing `kubectl logs -f` against a pod that lived 3m28s.

The one-line `not writable; logging to /tmp instead` became 7 lines naming the uid, that consequence, and
the two remedies (make the volume writable for uid 1000, or follow the live log). Scoped to `lws-ep` only —
`lws-2pp`'s decode group and both `lws-pp2` groups are `restartPolicy: None`, where `--previous` *does*
survive, so the message would be false there.

## A diagnostic trap worth recording

`RecreateGroupOnPodRestart` deletes and recreates the pod, so `kubectl get pods` shows **`restartCount=0`
on a fresh pod** rather than `CrashLoopBackOff`. A group crash-looping every 3.5 min does not look like a
crash loop at all — the only signals are `startTime` moving and the `RecreateGroupOnPodRestart` events.

## Verification (no cluster required)

- 9/9 templates `envsubst`-render + YAML round-trip; 29/29 extracted container scripts `bash -n`;
  route-check → **0 failures**.
- **Semantic argv check**, because `bash -n` cannot catch the failure mode this diff risks: a `#` comment
  placed *inside* a backslash-continued command is valid bash that silently truncates the command (and
  would have dropped `--kv-transfer-config`). The rendered scripts were continuation-joined the way bash
  does and the flags read back off the real argv:

  ```
  disagg-lws-ep.0.sh  role=prefill dp=2 util=0.92 flags_on_cmd=18
  disagg-lws-ep.1.sh  role=prefill dp=2 util=0.92 flags_on_cmd=20
  disagg-lws-ep.2.sh  role=decode  dp=2 util=0.92 flags_on_cmd=18
  disagg-lws-ep.3.sh  role=decode  dp=2 util=0.92 flags_on_cmd=20
  ```
- Stub-executed the rendered decode script (fake `python3` exiting 42) — new messages render correctly and
  the engine's own status still propagates as the container's status (`rc=42`), the behaviour #75 added.
