### PR TITLE
nemotron/ultra/disagg: stop the lws-ep decode group from crash-looping on an unreachable memory target

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-ep.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-ep.yaml-template
@@ -571,7 +571,7 @@ spec:
                   --enable-expert-parallel \
                   --pipeline-parallel-size 1 \
                   --max-model-len 8192 \
-                  --gpu-memory-utilization 0.98 \
+                  --gpu-memory-utilization 0.92 \
                   --enforce-eager \
                   --trust-remote-code \
                   ${MAMBA_FLAGS} \
@@ -721,7 +721,7 @@ spec:
                   --enable-expert-parallel \
                   --pipeline-parallel-size 1 \
                   --max-model-len 8192 \
-                  --gpu-memory-utilization 0.98 \
+                  --gpu-memory-utilization 0.92 \
                   --enforce-eager \
                   --trust-remote-code \
                   ${MAMBA_FLAGS} \


### PR DESCRIPTION
## What

`nemotron/ultra/disagg/lws-ep.yaml-template` asks the **decode** roles for
`--gpu-memory-utilization 0.98` while the **prefill** roles in the same file ask for `0.92`.
On p6-b200 (178.35 GiB/GPU) `0.98` is not reachable at the point vLLM takes its snapshot, so the
decode group crash-loops on startup and never serves.

## The failure, measured on all 8 GPUs of both decode pods, every generation

```
ValueError: Free memory on device cuda:3 (173.8/178.35 GiB) on startup is less than
desired GPU memory utilization (0.98, 174.78 GiB). Decrease GPU memory utilization or
reduce GPU memory used by other processes.
  vllm/v1/worker/utils.py:415  request_memory
  vllm/v1/worker/gpu_worker.py:314  init_device
```

| | value |
|---|---|
| free HBM at snapshot, cuda:0-7 | 173.78 – 174.24 GiB |
| total | 178.35 GiB |
| reachable ceiling | 173.78 / 178.35 = **0.9744** |
| requested by decode | 0.98 → **174.78 GiB** |
| engine init footprint at the snapshot | ~4.57 GiB |

`nvidia-smi` on those nodes reports 4 MiB used and no compute apps, so the gap is the engine's own
init footprint, not another tenant — **waiting or restarting can never satisfy 0.98 on this shape.**

Observed decode generations on 2026-08-16: `05:46:47Z`, `05:50:55Z`, `05:51:32Z`, `05:55:38Z`
— identical ValueError each time, ~3.5 min period.

## Why it looks unexplainable

The leader exits 1 and the worker exits 0, and because the LeaderWorkerSet uses
`RecreateGroupOnPodRestart` the controller **deletes the leader pod**, so `kubectl logs --previous`
returns `BadRequest: previous terminated container "vllm" not found` within seconds of the crash.
The group recreates with no surviving explanation. (Both roles also print
`/shared not writable; logging to /tmp instead` — the container runs as uid 1000 `dynamo` and
`/shared` is `root:root 755` — so the per-run diagnostic log dies with the pod too.)

## The change

Decode `0.98` → `0.92`, at the two decode `--gpu-memory-utilization` sites (leader + worker).

`0.92` is not a guess: it is what the **prefill** roles in this same file already use — and prefill
initializes cleanly on the very same nodes (`VllmWorker ... has been initialized`, endpoints
registered) — and what **both** sides of the sibling `lws-pp2.yaml-template` use.

`lws-2pp.yaml-template` keeps its `0.98` decode value on purpose: that value is measurably reachable
in its (single-node TP8, no EP) shape, which completed a full aiperf run. Only the EP shape in
`lws-ep` overshoots, consistent with the DP-coordinator / EP buffers costing ~1 GiB more at init.

## Scope

Two lines, one file. No behaviour change for `lws-2pp`, `lws-pp2`, `deployment`, `dgd`, or the `agg/` templates.
