### PR TITLE
nemotron/ultra/disagg: record why lws-ep decode is pinned at 0.92, and where its crash log goes

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-ep.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-ep.yaml-template
@@ -120,7 +120,14 @@ spec:
                 # back to /tmp rather than losing every log line to EACCES.
                 LOG_DIR=/shared
                 if ! ( : > "${DOLLAR}LOG_DIR/.wtest-${DOLLAR}HOSTNAME" ) 2>/dev/null; then
-                  echo "[prefill-dp0] ${DOLLAR}LOG_DIR not writable; logging to /tmp instead"
+                  echo "[prefill-dp0] ${DOLLAR}LOG_DIR is not writable by uid ${DOLLAR}(id -u); logging to /tmp instead."
+                  echo "[prefill-dp0]   /tmp dies WITH THE POD, and this LeaderWorkerSet sets restartPolicy:"
+                  echo "[prefill-dp0]   RecreateGroupOnPodRestart, so a crash DELETES the pod rather than restarting the"
+                  echo "[prefill-dp0]   container - 'kubectl logs --previous' has nothing to return either, and the"
+                  echo "[prefill-dp0]   traceback is unrecoverable after the fact."
+                  echo "[prefill-dp0]   To keep the log: make ${DOLLAR}LOG_DIR writable for uid ${DOLLAR}(id -u) (chown, or"
+                  echo "[prefill-dp0]   chmod g+w, from a root pod). To read a crash happening now, follow it live:"
+                  echo "[prefill-dp0]   kubectl -n ${NAMESPACE} logs -f ${DOLLAR}HOSTNAME"
                   LOG_DIR=/tmp
                 else
                   rm -f "${DOLLAR}LOG_DIR/.wtest-${DOLLAR}HOSTNAME"
@@ -442,7 +449,14 @@ spec:
                 if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
                 LOG_DIR=/shared
                 if ! ( : > "${DOLLAR}LOG_DIR/.wtest-${DOLLAR}HOSTNAME" ) 2>/dev/null; then
-                  echo "[decode-dp0] ${DOLLAR}LOG_DIR not writable; logging to /tmp instead"
+                  echo "[decode-dp0] ${DOLLAR}LOG_DIR is not writable by uid ${DOLLAR}(id -u); logging to /tmp instead."
+                  echo "[decode-dp0]   /tmp dies WITH THE POD, and this LeaderWorkerSet sets restartPolicy:"
+                  echo "[decode-dp0]   RecreateGroupOnPodRestart, so a crash DELETES the pod rather than restarting the"
+                  echo "[decode-dp0]   container - 'kubectl logs --previous' has nothing to return either, and the"
+                  echo "[decode-dp0]   traceback is unrecoverable after the fact."
+                  echo "[decode-dp0]   To keep the log: make ${DOLLAR}LOG_DIR writable for uid ${DOLLAR}(id -u) (chown, or"
+                  echo "[decode-dp0]   chmod g+w, from a root pod). To read a crash happening now, follow it live:"
+                  echo "[decode-dp0]   kubectl -n ${NAMESPACE} logs -f ${DOLLAR}HOSTNAME"
                   LOG_DIR=/tmp
                 else
                   rm -f "${DOLLAR}LOG_DIR/.wtest-${DOLLAR}HOSTNAME"
@@ -560,6 +574,30 @@ spec:
                     [ "${DOLLAR}warmed" = 1 ] || echo "[warmup] gave up after 30min waiting for ${DOLLAR}LH 200 + ${MODEL_NAME} in ${DOLLAR}FE/v1/models; the FIRST benchmark requests will pay the Mamba JIT (non-fatal)"
                   fi
                 ) &
+                # --gpu-memory-utilization must stay at 0.92 on the EP decode blocks. It is NOT
+                # interchangeable with the 0.98 that the single-node decode groups in disagg/lws-2pp and
+                # disagg/lws-pp2 use. vLLM 0.23's gpu_worker.init_device -> worker/utils.request_memory
+                # demands that utilization * total ALREADY BE FREE when the rank initialises, and by then a
+                # DP x TP = EP group already holds 4.11-4.57 GiB on every B200: the CUDA context, the NCCL
+                # communicators (the node-local TP one PLUS the cross-node DP/EP one) and the EFA rails.
+                # That total is what was measured; the per-component split was not.
+                # At 0.98 decode could never start. Measured 2026-08-16 on a 4-node ml.p6-b200.48xlarge run:
+                # free was 173.78-174.24 of 178.35 GiB on all 16 GPUs (2 decode pods x 8) while 0.98 asks for
+                # 174.78, so all 16 ranks raised "Free memory on device cuda:N (173.8/178.35 GiB) on startup
+                # is less than desired GPU memory utilization (0.98, 174.78 GiB)" 88s after the DP group
+                # leader announced itself, inside a 3m28s pod lifetime, and the group crash-looped at that
+                # period indefinitely, never reaching weight load. Structural, not the loop measuring its own
+                # teardown: three pod generations on two nodes 25min apart gave byte-identical per-device
+                # figures, down to the cuda:7 outlier sitting 0.46 GiB above its siblings.
+                # 0.92 is then CONFIRMED end-to-end on that same cluster (06:13-06:34Z): all 5 disagg pods
+                # 1/1 with 0 restarts, "Free memory on device" absent from all 4 engine pods, and decode
+                # through the whole chain it had never reached - weights 31.11 GiB in 348.8s, "Available KV
+                # cache memory: 128.37 GiB", "GPU KV cache size: 8,808,857 tokens", NIXL worker up,
+                # "init engine (profile, create kv cache, warmup model) took 684.33 s", Ready 21m after start.
+                # The ask (0.92 x 178.35 = 164.08 GiB) against the actual use (31.11 weights + 128.37 KV =
+                # 159.48 GiB) is why raising this buys no capability here, only more KV on top of an already
+                # 8.8M-token cache. Do not raise it without re-measuring free memory at init ON THE EP
+                # TOPOLOGY - and note vLLM only prints a free-memory figure when the check FAILS.
                 exec python3 -m dynamo.vllm \
                   --model ${MODEL_PATH} \
                   --served-model-name ${MODEL_NAME} \
@@ -708,6 +746,30 @@ spec:
                   if (echo > /dev/tcp/${DOLLAR}LEADER_IP/29551) 2>/dev/null; then break; fi
                   sleep 5
                 done
+                # --gpu-memory-utilization must stay at 0.92 on the EP decode blocks. It is NOT
+                # interchangeable with the 0.98 that the single-node decode groups in disagg/lws-2pp and
+                # disagg/lws-pp2 use. vLLM 0.23's gpu_worker.init_device -> worker/utils.request_memory
+                # demands that utilization * total ALREADY BE FREE when the rank initialises, and by then a
+                # DP x TP = EP group already holds 4.11-4.57 GiB on every B200: the CUDA context, the NCCL
+                # communicators (the node-local TP one PLUS the cross-node DP/EP one) and the EFA rails.
+                # That total is what was measured; the per-component split was not.
+                # At 0.98 decode could never start. Measured 2026-08-16 on a 4-node ml.p6-b200.48xlarge run:
+                # free was 173.78-174.24 of 178.35 GiB on all 16 GPUs (2 decode pods x 8) while 0.98 asks for
+                # 174.78, so all 16 ranks raised "Free memory on device cuda:N (173.8/178.35 GiB) on startup
+                # is less than desired GPU memory utilization (0.98, 174.78 GiB)" 88s after the DP group
+                # leader announced itself, inside a 3m28s pod lifetime, and the group crash-looped at that
+                # period indefinitely, never reaching weight load. Structural, not the loop measuring its own
+                # teardown: three pod generations on two nodes 25min apart gave byte-identical per-device
+                # figures, down to the cuda:7 outlier sitting 0.46 GiB above its siblings.
+                # 0.92 is then CONFIRMED end-to-end on that same cluster (06:13-06:34Z): all 5 disagg pods
+                # 1/1 with 0 restarts, "Free memory on device" absent from all 4 engine pods, and decode
+                # through the whole chain it had never reached - weights 31.11 GiB in 348.8s, "Available KV
+                # cache memory: 128.37 GiB", "GPU KV cache size: 8,808,857 tokens", NIXL worker up,
+                # "init engine (profile, create kv cache, warmup model) took 684.33 s", Ready 21m after start.
+                # The ask (0.92 x 178.35 = 164.08 GiB) against the actual use (31.11 weights + 128.37 KV =
+                # 159.48 GiB) is why raising this buys no capability here, only more KV on top of an already
+                # 8.8M-token cache. Do not raise it without re-measuring free memory at init ON THE EP
+                # TOPOLOGY - and note vLLM only prints a free-memory figure when the check FAILS.
                 exec python3 -m dynamo.vllm \
                   --model ${MODEL_PATH} \
                   --served-model-name ${MODEL_NAME} \


### PR DESCRIPTION
Follow-up to #80, which is the code fix. **No behaviour change here** — this records the
measurement behind the constant #80 set, and fixes a message that made the crash unreadable.

## Why this is worth a second PR

#80 changed the two EP decode `--gpu-memory-utilization` values from `0.98` to `0.92` and nothing
else, so the file now carries a bare constant with no record of why it cannot go back up. That is
precisely how the bug got in: `0.98` is correct for the **single-node TP8** decode groups in
`disagg/lws-2pp` and `disagg/lws-pp2`, was copied onto the EP blocks, and the EP blocks are the only
ones that pay for a cross-node communicator. Nothing in the file warned against it. Nothing in the
file warns now — so the next person who wants KV headroom will raise it back and lose another day.

## What the comment records

**Why `0.98` cannot work.** vLLM 0.23's `gpu_worker.init_device` → `worker/utils.request_memory`
requires `utilization × total` to **already be free** when a rank initialises. By then a `DP × TP =
EP` group holds **4.11–4.57 GiB** on every B200 — CUDA context, the NCCL communicators (the
node-local TP one *plus* the cross-node DP/EP one) and the EFA rails. That total is what was
measured; the per-component split was not.

Measured on a 4-node `ml.p6-b200.48xlarge` run, 2026-08-16: free was **173.78–174.24 of 178.35 GiB
on all 16 GPUs** (2 decode pods × 8) while `0.98` asks for **174.78**, so all 16 ranks raised

```
ValueError: Free memory on device cuda:7 (174.24/178.35 GiB) on startup is less than desired
GPU memory utilization (0.98, 174.78 GiB).
```

88 s after the DP group leader announced itself, inside a **3m28s** pod lifetime, looping at that
period indefinitely and never reaching weight load.

It is structural, not the crash loop measuring its own teardown — **three pod generations on two
nodes 25 minutes apart produced byte-identical per-device figures**, down to the `cuda:7` outlier
sitting 0.46 GiB above its seven siblings. Teardown overlap would jitter.

**Why `0.92` specifically** — which #80 could not yet state, because at the time every cycle had
died in `init_device` and nothing downstream had ever been exercised on the decode path. It has now
run on that same cluster (06:13–06:34Z): **all 5 disagg pods `1/1`, 0 restarts**, `startTime` never
moving, `Free memory on device` absent from all 4 engine pods, and decode through every stage it had
never reached:

```
06:16:22  Starting to load model .../NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4
06:22:12  Model loading took 31.11 GiB memory and 348.782115 seconds
06:31:21  Available KV cache memory: 128.37 GiB
06:31:21  GPU KV cache size: 8,808,857 tokens
06:31:21  Initializing NIXL worker
06:33:37  init engine (profile, create kv cache, warmup model) took 684.33 s
06:34:02  Ready=True
```

All four engine pods agree (684.33 / 685.16 / 685.17 / 684.64 s). The ask — `0.92 × 178.35 = 164.08
GiB` — against the actual use — `31.11` weights + `128.37` KV = **159.48 GiB** — is why raising this
buys no capability here, only more KV on top of an already 8.8M-token cache.

## Second change: the log fallback says where the crash log went

The writable-log-dir fallback said only `not writable; logging to /tmp instead`. `/tmp` **dies with
the pod**, and because both groups in this file set `restartPolicy: RecreateGroupOnPodRestart`, a
crash *deletes* the pod — so `kubectl logs --previous` has nothing either, and the traceback is
unrecoverable after the fact. Reading the traceback quoted above meant racing `kubectl logs -f`
against a pod that lived 3m28s.

The message now names the uid, that consequence, and the two remedies (make the dir writable for the
container's uid, or follow the live log). **Scoped to `lws-ep` on purpose:** `lws-2pp`'s decode group
and both `lws-pp2` groups are `restartPolicy: None`, where `--previous` *does* survive and this
message would be false.

## Verification (no cluster required)

- 9/9 templates `envsubst`-render + YAML round-trip; 29/29 extracted container scripts `bash -n`;
  route-check → **TOTAL FAILURES: 0**.
- **Semantic argv check**, because `bash -n` cannot catch what a comment-only diff to this file
  risks: a `#` comment placed *inside* a backslash-continued command is valid bash that silently
  **truncates** the command, and would have dropped `--kv-transfer-config` with both the YAML and
  `bash -n` still passing. The rendered scripts were continuation-joined the way bash does and the
  flags read back off the real argv — unchanged from before this commit:

  ```
  disagg-lws-ep.0.sh  role=prefill util=0.92 kv=yes flags=18
  disagg-lws-ep.1.sh  role=prefill util=0.92 kv=yes flags=20
  disagg-lws-ep.2.sh  role=decode  util=0.92 kv=yes flags=18
  disagg-lws-ep.3.sh  role=decode  util=0.92 kv=yes flags=20
  ```
- Continuation-comment violations across the file: **0**. All four `0.92` values intact, no `0.98`
  remaining.

## Not claimed

That KV bytes *move over EFA* between prefill and decode. `Ready` is a bring-up signal, and a
request that returns is not evidence KV moved. This is a documentation change on top of a fix that
is measured to let the stack reach serving — not a claim about the transfer path.

## Aside, for whoever reads this template next (not changed here)

Only the **leader** pods carry the `startupProbe` on `/health` (`:9092` decode, `:9091` prefill).
Both `-0-1` **worker** pods reported `Ready=True` at `06:13:05Z` — 3 seconds after start, ~21 minutes
before their engines finished initialising. So `4/5 Ready` during bring-up says nothing about the
workers, and a worker whose engine had died would still read `1/1`. Judge this stack by the leaders.
