### PR TITLE
nemotron/ultra: pin Gloo to the routable NIC on every expert-parallel DP serve block

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws-ep.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws-ep.yaml-template
@@ -144,10 +144,15 @@ spec:
                   exit 1
                 fi
                 # Gloo needs a SINGLE concrete iface name (not NCCL's ^exclude list). Resolve the
-                # iface that routes to the leader IP (the primary VPC NIC) so Gloo advertises the
-                # routable 10.x IP instead of falling back to loopback.
-                export GLOO_SOCKET_IFNAME=${DOLLAR}(ip -4 route get "${DOLLAR}LEADER_IP" 2>/dev/null | awk '{for(i=1;i<=NF;i++) if(${DOLLAR}i=="dev"){print ${DOLLAR}(i+1); exit}}')
-                echo "[dp0/leader] GLOO_SOCKET_IFNAME=${DOLLAR}GLOO_SOCKET_IFNAME"
+                # `ip -4 route get ${DOLLAR}LEADER_IP` was WRONG on the leader: that target is this pod's
+                # OWN address, and Linux answers an own-address lookup with `local <ip> dev lo`, so it
+                # exported lo and Gloo advertised loopback. Derive from the DEFAULT ROUTE and assert.
+                export GLOO_SOCKET_IFNAME=${DOLLAR}{GLOO_SOCKET_IFNAME:-${DOLLAR}(ip -o -4 route show default | awk '{print ${DOLLAR}5; exit}')}
+                GLOO_BIND_IP=${DOLLAR}(ip -o -4 addr show dev "${DOLLAR}GLOO_SOCKET_IFNAME" 2>/dev/null | awk '{print ${DOLLAR}4; exit}' | cut -d/ -f1)
+                echo "[dp0/leader] GLOO_SOCKET_IFNAME=${DOLLAR}GLOO_SOCKET_IFNAME bind=${DOLLAR}GLOO_BIND_IP"
+                case "${DOLLAR}{GLOO_BIND_IP:-}" in
+                  ""|127.*) echo "[dp0/leader] FATAL: GLOO_SOCKET_IFNAME=${DOLLAR}GLOO_SOCKET_IFNAME has no routable IPv4 (got '${DOLLAR}GLOO_BIND_IP'); cross-node Gloo would bind loopback. Exiting for a clean restart."; exit 1 ;;
+                esac
                 # NVFP4 cold-start warmup (detached, non-fatal): first requests otherwise pay
                 # per-batch-size Mamba decode Triton JIT (~4 min). vLLM-native flavor of the
                 # lws.yaml warmer: the LEADER serves :8000 itself, so gate on its own /v1/models
@@ -304,10 +309,15 @@ spec:
                   exit 1
                 fi
                 # Gloo needs a SINGLE concrete iface name (not NCCL's ^exclude list). Resolve the
-                # iface that routes to the leader (the primary VPC NIC) so Gloo advertises the
-                # routable 10.x IP instead of falling back to loopback.
-                export GLOO_SOCKET_IFNAME=${DOLLAR}(ip -4 route get "${DOLLAR}LEADER_IP" 2>/dev/null | awk '{for(i=1;i<=NF;i++) if(${DOLLAR}i=="dev"){print ${DOLLAR}(i+1); exit}}')
-                echo "[dp1/worker] GLOO_SOCKET_IFNAME=${DOLLAR}GLOO_SOCKET_IFNAME"
+                # `ip -4 route get ${DOLLAR}LEADER_IP` was WRONG on the leader: that target is this pod's
+                # OWN address, and Linux answers an own-address lookup with `local <ip> dev lo`, so it
+                # exported lo and Gloo advertised loopback. Derive from the DEFAULT ROUTE and assert.
+                export GLOO_SOCKET_IFNAME=${DOLLAR}{GLOO_SOCKET_IFNAME:-${DOLLAR}(ip -o -4 route show default | awk '{print ${DOLLAR}5; exit}')}
+                GLOO_BIND_IP=${DOLLAR}(ip -o -4 addr show dev "${DOLLAR}GLOO_SOCKET_IFNAME" 2>/dev/null | awk '{print ${DOLLAR}4; exit}' | cut -d/ -f1)
+                echo "[dp1/worker] GLOO_SOCKET_IFNAME=${DOLLAR}GLOO_SOCKET_IFNAME bind=${DOLLAR}GLOO_BIND_IP"
+                case "${DOLLAR}{GLOO_BIND_IP:-}" in
+                  ""|127.*) echo "[dp1/worker] FATAL: GLOO_SOCKET_IFNAME=${DOLLAR}GLOO_SOCKET_IFNAME has no routable IPv4 (got '${DOLLAR}GLOO_BIND_IP'); cross-node Gloo would bind loopback. Exiting for a clean restart."; exit 1 ;;
+                esac
                 # wait for the leader's DP rpc port before joining
                 for i in ${DOLLAR}(seq 1 120); do
                   if (echo > /dev/tcp/${DOLLAR}LEADER_IP/29550) 2>/dev/null; then break; fi

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-ep.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-ep.yaml-template
@@ -52,6 +52,13 @@
 # part-of labels, the ../test gate). Run ../test/models-health.sh + a single request and check
 # the decode node's rdma_read_bytes delta before you attach benchmark numbers to it.
 #
+# Gloo (why every serve block pins GLOO_SOCKET_IFNAME): data_parallel_size > 1 + async
+# scheduling makes vLLM run the per-step DP-padding all-reduce on the Gloo CPU group
+# (dp_utils.py "Using CPU all reduce to synchronize DP padding between ranks"), so a cross-node
+# TCP barrier executes once per decode step. Gloo ignores NCCL_SOCKET_IFNAME; unpinned under
+# hostNetwork: true it can bind loopback. Each block derives the default-route iface and FATALs
+# if the bound address is empty or 127.*, the same guard lws-pp2 carries.
+#
 # Portability: podAntiAffinity matches GPU roles only (a bare part-of match also selects the
 # frontend pod and required anti-affinity is enforced against EXISTING pods, which pins the
 # frontend Pending on an all-GPU cluster); cpu/memory come from CPU_PER_WORKER /
@@ -181,6 +188,20 @@ spec:
                 fi
                 python3 -c "import vllm; print(f'vllm {vllm.__version__}')"
                 # DP rank 0 also hosts the DP coordinator + TCPStore on --data-parallel-address.
+                # ---- Gloo bind interface: REQUIRED whenever hostNetwork: true ----
+                # This is the only shape in the tree with data_parallel_size > 1, and vLLM routes the
+                # PER-STEP DP-padding all-reduce onto the Gloo CPU group whenever async scheduling is on
+                # ("Disabling NCCL for DP synchronization when using async scheduling" -> dp_utils.py
+                # "Using CPU all reduce to synchronize DP padding between ranks"). That barrier therefore
+                # runs cross-node on TCP once per decode step. NCCL_SOCKET_IFNAME does NOT apply to it -
+                # Gloo reads GLOO_SOCKET_IFNAME only - so unpinned it binds whatever Gloo guesses, which
+                # under hostNetwork: true is the loopback failure mode already fixed in lws-pp2 (#69/#77).
+                export GLOO_SOCKET_IFNAME=${DOLLAR}{GLOO_SOCKET_IFNAME:-${DOLLAR}(ip -o -4 route show default | awk '{print ${DOLLAR}5; exit}')}
+                GLOO_BIND_IP=${DOLLAR}(ip -o -4 addr show dev "${DOLLAR}GLOO_SOCKET_IFNAME" 2>/dev/null | awk '{print ${DOLLAR}4; exit}' | cut -d/ -f1)
+                say "[prefill-dp0] GLOO_SOCKET_IFNAME=${DOLLAR}GLOO_SOCKET_IFNAME bind=${DOLLAR}GLOO_BIND_IP"
+                case "${DOLLAR}{GLOO_BIND_IP:-}" in
+                  ""|127.*) say "[prefill-dp0] FATAL: GLOO_SOCKET_IFNAME=${DOLLAR}GLOO_SOCKET_IFNAME has no routable IPv4 (got '${DOLLAR}GLOO_BIND_IP'); the cross-node DP-padding all-reduce would bind loopback. Exiting for a clean restart."; exit 1 ;;
+                esac
                 exec python3 -m dynamo.vllm \
                   --model ${MODEL_PATH} \
                   --served-model-name ${MODEL_NAME} \
@@ -337,6 +358,13 @@ spec:
                 # (the leader is index 0 = DP rank 0), so it IS the DP start rank. Every engine
                 # arg must match the leader's - each DP rank builds its own EngineCore, so the
                 # kv-transfer-config and --disaggregation-mode belong here too.
+                # ---- Gloo bind interface: REQUIRED whenever hostNetwork: true (see header note "Gloo") ----
+                export GLOO_SOCKET_IFNAME=${DOLLAR}{GLOO_SOCKET_IFNAME:-${DOLLAR}(ip -o -4 route show default | awk '{print ${DOLLAR}5; exit}')}
+                GLOO_BIND_IP=${DOLLAR}(ip -o -4 addr show dev "${DOLLAR}GLOO_SOCKET_IFNAME" 2>/dev/null | awk '{print ${DOLLAR}4; exit}' | cut -d/ -f1)
+                echo "[prefill-dp${DOLLAR}{LWS_WORKER_INDEX}] GLOO_SOCKET_IFNAME=${DOLLAR}GLOO_SOCKET_IFNAME bind=${DOLLAR}GLOO_BIND_IP"
+                case "${DOLLAR}{GLOO_BIND_IP:-}" in
+                  ""|127.*) echo "[prefill-dp${DOLLAR}{LWS_WORKER_INDEX}] FATAL: GLOO_SOCKET_IFNAME=${DOLLAR}GLOO_SOCKET_IFNAME has no routable IPv4 (got '${DOLLAR}GLOO_BIND_IP'); the cross-node DP-padding all-reduce would bind loopback. Exiting for a clean restart."; exit 1 ;;
+                esac
                 exec python3 -m dynamo.vllm \
                   --model ${MODEL_PATH} \
                   --served-model-name ${MODEL_NAME} \
@@ -574,6 +602,13 @@ spec:
                     [ "${DOLLAR}warmed" = 1 ] || echo "[warmup] gave up after 30min waiting for ${DOLLAR}LH 200 + ${MODEL_NAME} in ${DOLLAR}FE/v1/models; the FIRST benchmark requests will pay the Mamba JIT (non-fatal)"
                   fi
                 ) &
+                # ---- Gloo bind interface: REQUIRED whenever hostNetwork: true (see header note "Gloo") ----
+                export GLOO_SOCKET_IFNAME=${DOLLAR}{GLOO_SOCKET_IFNAME:-${DOLLAR}(ip -o -4 route show default | awk '{print ${DOLLAR}5; exit}')}
+                GLOO_BIND_IP=${DOLLAR}(ip -o -4 addr show dev "${DOLLAR}GLOO_SOCKET_IFNAME" 2>/dev/null | awk '{print ${DOLLAR}4; exit}' | cut -d/ -f1)
+                say "[decode-dp0] GLOO_SOCKET_IFNAME=${DOLLAR}GLOO_SOCKET_IFNAME bind=${DOLLAR}GLOO_BIND_IP"
+                case "${DOLLAR}{GLOO_BIND_IP:-}" in
+                  ""|127.*) say "[decode-dp0] FATAL: GLOO_SOCKET_IFNAME=${DOLLAR}GLOO_SOCKET_IFNAME has no routable IPv4 (got '${DOLLAR}GLOO_BIND_IP'); the cross-node DP-padding all-reduce would bind loopback. Exiting for a clean restart."; exit 1 ;;
+                esac
                 # --gpu-memory-utilization must stay at 0.92 on the EP decode blocks. It is NOT
                 # interchangeable with the 0.98 that the single-node decode groups in disagg/lws-2pp and
                 # disagg/lws-pp2 use. vLLM 0.23's gpu_worker.init_device -> worker/utils.request_memory
@@ -746,6 +781,13 @@ spec:
                   if (echo > /dev/tcp/${DOLLAR}LEADER_IP/29551) 2>/dev/null; then break; fi
                   sleep 5
                 done
+                # ---- Gloo bind interface: REQUIRED whenever hostNetwork: true (see header note "Gloo") ----
+                export GLOO_SOCKET_IFNAME=${DOLLAR}{GLOO_SOCKET_IFNAME:-${DOLLAR}(ip -o -4 route show default | awk '{print ${DOLLAR}5; exit}')}
+                GLOO_BIND_IP=${DOLLAR}(ip -o -4 addr show dev "${DOLLAR}GLOO_SOCKET_IFNAME" 2>/dev/null | awk '{print ${DOLLAR}4; exit}' | cut -d/ -f1)
+                echo "[decode-dp${DOLLAR}{LWS_WORKER_INDEX}] GLOO_SOCKET_IFNAME=${DOLLAR}GLOO_SOCKET_IFNAME bind=${DOLLAR}GLOO_BIND_IP"
+                case "${DOLLAR}{GLOO_BIND_IP:-}" in
+                  ""|127.*) echo "[decode-dp${DOLLAR}{LWS_WORKER_INDEX}] FATAL: GLOO_SOCKET_IFNAME=${DOLLAR}GLOO_SOCKET_IFNAME has no routable IPv4 (got '${DOLLAR}GLOO_BIND_IP'); the cross-node DP-padding all-reduce would bind loopback. Exiting for a clean restart."; exit 1 ;;
+                esac
                 # --gpu-memory-utilization must stay at 0.92 on the EP decode blocks. It is NOT
                 # interchangeable with the 0.98 that the single-node decode groups in disagg/lws-2pp and
                 # disagg/lws-pp2 use. vLLM 0.23's gpu_worker.init_device -> worker/utils.request_memory


### PR DESCRIPTION
## What

`disagg/lws-ep` is the only shape in this tree with `data_parallel_size > 1`, and with async scheduling on, vLLM moves the **per-step** DP-padding all-reduce off NCCL onto the **Gloo CPU** group. From a live 4-node NVFP4 run (2026-08-16), on **both** roles:

```
vllm.__post_init__: Disabling NCCL for DP synchronization when using async scheduling.
dp_utils.py:28] Using CPU all reduce to synchronize DP padding between ranks.   # prefill 06:22:12Z, decode 06:22:13Z
```

So a cross-node TCP barrier runs once per decode step. Gloo does **not** read `NCCL_SOCKET_IFNAME` — only `GLOO_SOCKET_IFNAME` — and `disagg/lws-ep` set neither. Unpinned Gloo under `hostNetwork: true` is the failure mode already fixed for the PP shapes in #69 / #77.

## Changes

**1. `disagg/lws-ep.yaml-template`** — add the derivation + fail-loud assert to all four serve blocks (prefill dp0 / prefill worker / decode dp0 / decode worker), plus a header note. Was 0 pins, now 4.

**2. `agg/lws-ep.yaml-template`** — the pin existed but derived the interface with `ip -4 route get $LEADER_IP`. On the leader that target **is this pod's own address**, and Linux answers an own-address lookup with `local <ip> dev lo` — so the leader exported `GLOO_SOCKET_IFNAME=lo`, the exact thing its comment said it was avoiding:

```
$ ip -4 route get 172.31.18.239        # own address
local 172.31.18.239 dev lo src 172.31.18.239
$ ... | awk '{for(i=1;i<=NF;i++) if($i=="dev"){print $(i+1); exit}}'
lo
```

Both blocks now use the default-route derivation `lws-pp2` already carries, and assert the bound address is routable. The worker block was incidentally correct (its target is the peer); it is switched for consistency and to gain the assert.

The assert is the load-bearing part — it turns this class of mistake into a named FATAL instead of a downstream `connectFullMesh` timeout.

## Gates (all run on this branch)

| gate | result |
|---|---|
| `envsubst` render | 9/9 templates; YAML doc counts unchanged (`disagg/lws-ep` still 4) |
| `bash -n` | 24/24 container scripts |
| coverage | 6/6 `DP>1` serve blocks pinned **and** asserted, 0 missing |
| executed derivation | unset → `ens5` / routable, exit 0 · forced `lo` → FATAL exit 1 · bogus iface → FATAL exit 1 |
| `kubectl apply --dry-run=client` | both rendered manifests accepted |

Server-side dry-run deliberately skipped: the cluster those names belong to has a different run live right now, and this change is a shell-body change, not an API-shape one.

## What this does not claim

It does **not** claim to explain the multi-second inter-token gaps measured on that `lws-ep` run (825 of 51,028 token gaps over 2 s, ~26% of decode wall time, absent from the `DP=1` siblings). That attribution needs the A/B. This change is correct independently — the interface should be pinned and asserted either way.