### PR TITLE
nemotron/ultra/test: separate a disagg aiperf report's stalled tail from its steady state

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/README.md
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/README.md
@@ -150,6 +150,7 @@ Then run any or all of the following tests:
 ./test-chat-completions.sh
 ./test-aiperf.sh
 ./aiperf-sweep-run.sh
+./aiperf-clean-tail.sh
 ./kv-lease-check.sh
 ```
 
@@ -159,6 +160,7 @@ Then run any or all of the following tests:
 * `./test-chat-completions.sh` - tests a single request to the /v1/chat/completions API
 * `./test-aiperf.sh` - runs aiperf against the model endpoint, reports benchmark results
 * `./aiperf-sweep-run.sh` - runs a sweep of aiperf tests with concurrency 1,4,8,16,32,64 to explore scalability
+* `./aiperf-clean-tail.sh` - splits an aiperf export into its stalled tail and its steady state
 * `./kv-lease-check.sh` - checks a disagg run for requests served on KV blocks the prefill side had already freed
 
 `test-aiperf.sh` writes its artifacts to
@@ -178,6 +180,17 @@ them. Note what the namespace can and cannot prove: `agg/dgd`, `agg/dgd-v1beta1`
 `disagg/dgd` and `disagg/dgd-v1beta1` set no `DYN_NAMESPACE` and dynamo defaults it to the literal
 `dynamo`, so for those the check reports `not discriminating` and the `workloads` field is what
 identifies the run.
+
+Read a disagg report through `./aiperf-clean-tail.sh <artifact-dir>/profile_export.jsonl` before
+quoting a TTFT mean or an upper percentile. Both 100-request NVFP4 disagg runs on 2026-08-16
+released batches of requests at single instants - at the script's default cutoff of TTFT > 5s that
+is 20 of 100 on `lws-pp2` and 16 of 100 on `lws-ep` - which puts the mean and every percentile above
+p50 an order of magnitude above the steady state and makes two runs that stalled a different number
+of times incomparable. Always state the cutoff a count was taken at; the count is a function of the
+cut, so two counts taken at different cuts are not a comparison. The script reports the two
+populations separately and how much wall clock the stall cost. The unconditional warmup phase in
+`test-aiperf.sh` prevents the class of stall that is confined to the opening concurrency wave; this
+script is for reading the class that recurs mid-run, which a warmup cannot remove.
 
 Run `./kv-lease-check.sh` after any disagg benchmark. In vLLM's NixlConnector the prefill side holds
 each request's KV blocks under a lease and frees them when it elapses; a later read by the decode

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/test/aiperf-clean-tail.py
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/test/aiperf-clean-tail.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Split an aiperf profile_export.jsonl into its stalled tail and its steady state.
+
+WHY THIS EXISTS
+A disagg run on this stack does not produce one population of requests. Two runs on
+p6-b200 (2026-08-16, Nemotron-3-Ultra-550B-A55B-NVFP4, 100 requests @ --concurrency 10,
+ISL 1024 / OSL 512, 0 errors) both released batches of requests at single instants
+(counts at this script's default cutoff of TTFT > 5000ms):
+
+  disagg/lws-pp2  20 of 100 requests, first tokens clustered at t=229.2-229.5s (10)
+                                                            and t=461.8-462.2s (10)
+  disagg/lws-ep   16 of 100 requests, first tokens at t=92.96s (6) and t=311.24s (8),
+                                      plus singletons at t=143.5s and t=734.9s
+
+A count is a function of the cut, so state the cutoff whenever you quote one - the same
+lws-ep export read at TTFT > 2000ms is 23 of 100 rather than 16.
+
+Inside each instant the first-token timestamps agree to under a millisecond, which a
+queue cannot produce - a queue staggers. The prefill worker log for the lws-ep run shows
+what those requests were doing: held in the running set with "Avg prompt throughput:
+0.0 tokens/s, Waiting: 0 reqs, GPU KV cache usage: 0.2%" for ~70s, then a burst at
+311-415 tokens/s that hands the whole group off at once. So the wait is upstream of
+decode, it is not a queue, and it is not memory pressure.
+
+The consequence for reporting: with 16 of 100 requests stalled, aiperf reports TTFT
+avg 12,295ms / p90 54,193ms / p99 92,963ms against a p50 of 1,145ms. The mean and the
+upper percentiles describe the stall, not the serving path, and they are not comparable
+between two runs that stalled a different number of times. The steady-state percentiles
+are comparable. Report both, separately, and say how many requests stalled.
+
+WHAT THIS IS NOT
+It is not a substitute for the warmup phase test-aiperf.sh runs. That phase prevents the
+class of hold confined to the OPENING concurrency wave, at the source: on the BF16
+disagg/lws-ep run of 2026-08-17T06:01:40Z all 10 slow requests (TTFT > 2000ms) were the
+10 issued at t=0, and excluding them moves TTFT p50 704.28 -> 703.28ms and leaves ITL p50
+at 114.58ms - under 0.2%, so there is nothing for a post-hoc split to recover. This script
+is for the class that RECURS mid-run, which no warmup can remove: on the NVFP4 lws-ep
+export above, 13 of the 23 slow requests were ISSUED between t=136.5s and t=729.6s, long
+after any warmup phase has ended.
+
+USAGE
+  ./aiperf-clean-tail.sh <artifact-dir>/profile_export.jsonl [ttft_cutoff_ms]
+
+A cutoff of 5000ms is far above every steady-state TTFT observed on this model
+(max 4,065ms over 84 clean requests) and far below every stalled one (min 5,346ms).
+Raise it if your model's warm TTFT is genuinely slower than 5s.
+"""
+import json
+import statistics as st
+import sys
+
+
+def pct(values, q):
+    ordered = sorted(values)
+    if len(ordered) < 3:
+        return float("nan")
+    return st.quantiles(ordered, n=100)[q - 1]
+
+
+def main():
+    if len(sys.argv) < 2:
+        sys.exit(__doc__)
+    path = sys.argv[1]
+    cutoff = float(sys.argv[2]) if len(sys.argv) > 2 else 5000.0
+
+    rows = [json.loads(line) for line in open(path) if line.strip()]
+    if not rows:
+        sys.exit(f"{path}: no records (an aiperf run that was still writing, or overwritten)")
+    origin = min(r["metadata"]["request_start_ns"] for r in rows)
+    last = max(r["metadata"]["request_end_ns"] for r in rows)
+
+    recs = []
+    for idx, r in enumerate(rows):
+        m = r["metrics"]
+        recs.append({
+            "idx": idx,
+            "start_s": (r["metadata"]["request_start_ns"] - origin) / 1e9,
+            "ttft": m["time_to_first_token"]["value"],
+            "ttst": m["time_to_second_token"]["value"],
+            "itl": m["inter_token_latency"]["value"],
+            "latency_s": m["request_latency"]["value"] / 1000.0,
+            "tps_per_user": m["output_token_throughput_per_user"]["value"],
+            "osl": m["output_sequence_length"]["value"],
+        })
+
+    stalled = [r for r in recs if r["ttft"] > cutoff]
+    steady = [r for r in recs if r["ttft"] <= cutoff]
+    span_s = (last - origin) / 1e9
+    tokens = sum(r["osl"] for r in recs)
+
+    print(f"{path}")
+    print(f"  requests {len(recs)}  phase {span_s:.1f}s  output tokens {tokens}"
+          f"  aggregate {tokens / span_s:.2f} tok/s")
+    print(f"  stalled (TTFT > {cutoff:.0f}ms) {len(stalled)}   steady {len(steady)}")
+
+    if stalled:
+        print(f"\n  STALLED - grouped by the instant the first token arrived")
+        print(f"  {'request':>8} {'started_s':>10} {'ttft_ms':>12} {'first_token_at_s':>17}")
+        for r in sorted(stalled, key=lambda r: r["start_s"] + r["ttft"] / 1000.0):
+            print(f"  {r['idx']:>8} {r['start_s']:>10.2f} {r['ttft']:>12.2f}"
+                  f" {r['start_s'] + r['ttft'] / 1000.0:>17.2f}")
+        print("  Timestamps that agree to the millisecond are one release, not a queue.")
+        print("  Check the prefill worker for that wall-clock window before reporting a")
+        print("  TTFT mean: kubectl logs <prefill-pod> | grep -E 'prompt throughput|shm_broadcast'")
+
+    if steady:
+        print(f"\n  STEADY STATE over {len(steady)} requests")
+        print(f"  {'metric':<16} {'min':>10} {'p50':>10} {'p90':>10} {'max':>10}")
+        for key, label in (("ttft", "ttft_ms"), ("ttst", "ttst_ms"), ("itl", "itl_ms"),
+                           ("latency_s", "latency_s"), ("tps_per_user", "tok/s/user")):
+            v = [r[key] for r in steady]
+            print(f"  {label:<16} {min(v):>10.2f} {st.median(v):>10.2f}"
+                  f" {pct(v, 90):>10.2f} {max(v):>10.2f}")
+        ideal = st.median([r["latency_s"] for r in steady]) * len(recs) / 10.0
+        print(f"\n  A run of {len(recs)} requests at concurrency 10 that never stalled would")
+        print(f"  take about {ideal:.0f}s at this steady-state latency; this one took"
+              f" {span_s:.0f}s ({100 * (span_s - ideal) / span_s:.0f}% lost).")
+        print("  Adjust the divisor if you did not run --concurrency 10.")
+
+
+if __name__ == "__main__":
+    main()

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/test/aiperf-clean-tail.sh
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/test/aiperf-clean-tail.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Split an aiperf profile_export.jsonl into its stalled tail and its steady state.
+# See the header of aiperf-clean-tail.py for why a disagg run needs this before its
+# TTFT mean and upper percentiles are reported.
+#
+# Usage: ./aiperf-clean-tail.sh <path-to-profile_export.jsonl> [ttft_cutoff_ms]
+# The export is written to ${ARTIFACT_DIR} by test-aiperf.sh, which lives on the
+# shared model volume; copy it out of any pod that mounts that volume, or run this
+# from a machine that has it mounted.
+
+source .env
+
+export CMD="python3 ./aiperf-clean-tail.py ${1:-./profile_export.jsonl} ${2:-5000}"
+
+if [ ! "$VERBOSE" == "false" ]; then echo -e "\n${CMD}\n"; fi
+
+eval "${CMD}"

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/test/test-aiperf.sh
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/test/test-aiperf.sh
@@ -37,7 +37,12 @@ kubectl wait --for=condition=Ready pod/do-aiperf --timeout=120s
 # already validated on NVFP4 and one constant is easier to reason about than two.
 # Cost is wall-clock only: 30 excluded requests at --concurrency 10 add ~3 waves, ~180s
 # on that ~650s run. What it does NOT fix is a hold that RECURS mid-run: the NVFP4
-# lws-ep run of 2026-08-16 had 8 slow requests at t=224-261s, well past any warmup.
+# lws-ep run of 2026-08-16 had 8 slow requests (TTFT > 2s) at t=224-261s, well past any
+# warmup, and its worker logs carry no Triton JIT warning anywhere in that window - those
+# requests were held on the prefill side. Always state the cutoff a slow-request count was
+# taken at; the count is a function of the cut. Read that class with ./aiperf-clean-tail.sh
+# over the export before quoting a TTFT mean or an upper percentile - its header carries
+# the evidence and the prefill-side localisation.
 # AIPERF_WARMUP_REQUESTS=0 disables, any integer overrides. Same idiom as WARMUP_ENABLED
 # in the manifests -- note that one is still precision-gated, and gates the in-pod warmer,
 # not the report.


### PR DESCRIPTION
A 100-request disagg report on this stack is two populations, not one. Both runs on
2026-08-16 (p6-b200, Nemotron-3-Ultra-550B-A55B-NVFP4, --concurrency 10, ISL 1024 /
OSL 512, 0 errors) released a batch of requests at a single instant:

  disagg/lws-pp2  20 of 100, first tokens at t=229.2s and t=461.9s
  disagg/lws-ep   16 of 100, first tokens at t=93.0s  and t=311.2s

Within each instant the first-token timestamps agree to under a millisecond. A queue
staggers, so this is one release. The prefill worker log for the lws-ep run shows the
held requests sitting in the running set with "Avg prompt throughput: 0.0 tokens/s,
Waiting: 0 reqs, GPU KV cache usage: 0.2%" for about 70s, then bursting at 311-415
tokens/s and handing the whole group to decode at once; the decode leader logs
"request received" for those six ids at 06:54:37.949Z, the same millisecond prefill
logs them completed. So the wait is upstream of decode, it is not a queue, and it is
not memory pressure.

The report cannot be read without splitting them. lws-ep's aiperf summary is TTFT
avg 12,295ms / p90 54,193ms / p99 92,963ms against a p50 of 1,145ms; over the 84
requests that did not stall it is min 958 / p50 1,137 / p90 1,338 / max 4,065ms. The
mean and the upper percentiles describe the stall, and two runs that stalled a
different number of times are not comparable through them. The stall also costs wall
clock unevenly - 47% of the lws-pp2 phase against 9% of the lws-ep phase - so it
distorts aggregate throughput between topologies too.

aiperf-clean-tail.sh reports the two populations separately, groups the stalled
requests by the instant they were released, and states what the stall cost. It reads
the profile_export.jsonl that test-aiperf.sh already writes, so it needs no rerun.

Also corrects the warmup comment in test-aiperf.sh. Keeping the warmup phase is still
right - the Mamba decode Triton JIT at pod start is real and the worker logs it - but
the comment implied the warmup keeps this tail out of the sample, and it does not.
Both runs had already logged "concurrent batch buckets warm" and had the aiperf warmup
phase active, and the lws-ep worker logs carry no Triton JIT warning anywhere in the
profiling window: the last one is 06:37:34Z, more than 15 minutes before profiling
started at 06:53:05Z.

Signed-off-by: Anton Alexander <dmvevents@gmail.com>