### PR TITLE
nemotron/ultra/disagg: raise the NIXL KV lease so decode cannot read blocks prefill freed

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/README.md
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/README.md
@@ -115,6 +115,7 @@ Then run any or all of the following tests:
 ./test-chat-completions.sh
 ./test-aiperf.sh
 ./aiperf-sweep-run.sh
+./kv-lease-check.sh
 ```
 
 * `./models-list.sh` - shows the names of the hosted models
@@ -123,6 +124,7 @@ Then run any or all of the following tests:
 * `./test-chat-completions.sh` - tests a single request to the /v1/chat/completions API
 * `./test-aiperf.sh` - runs aiperf against the model endpoint, reports benchmark results
 * `./aiperf-sweep-run.sh` - runs a sweep of aiperf tests with concurrency 1,4,8,16,32,64 to explore scalability
+* `./kv-lease-check.sh` - checks a disagg run for requests served on KV blocks the prefill side had already freed
 
 `test-aiperf.sh` writes its artifacts to
 `${MODEL_PATH}/aiperf/${DEPLOYMENT_TYPE}/${MANIFEST_TYPE}/${AIPERF_RUN_ID}` and prints the path
@@ -130,3 +132,10 @@ before it starts. `AIPERF_RUN_ID` defaults to a UTC timestamp, so comparing topo
 one of them keeps every report -- set `MANIFEST_TYPE` in `test/.env` to match the deployed topology
 so the folder is labelled correctly, and set `AIPERF_RUN_ID` to name a run (`AIPERF_RUN_ID=cold`).
 
+Run `./kv-lease-check.sh` after any disagg benchmark. In vLLM's NixlConnector the prefill side holds
+each request's KV blocks under a lease and frees them when it elapses; a later read by the decode
+worker is then only logged, never failed, so the request still returns 200 on blocks that are gone.
+A live 3-Pod `disagg/dgd` run on 2026-08-16 did exactly that on 8 of 42 completed requests, 21-32s
+after the stock 30s lease expired with zero reads. `KV_LEASE_DURATION` in `disagg/.env` raises the
+lease (default 300s here) and the script exits non-zero when a lease expires unread, so it can gate
+a benchmark.

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/.env
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/.env
@@ -112,6 +112,40 @@ export WARMUP_ENABLED=${WARMUP_ENABLED:-auto}
 # is that kernel and not selective_state_update on this device/dtype.
 export WARMUP_CONCURRENCY=${WARMUP_CONCURRENCY:-10}
 
+# ---- KV lease duration (seconds the PREFILL side holds KV blocks for DECODE to pull) ----
+# Feeds "kv_lease_duration" inside --kv-transfer-config's kv_connector_extra_config in every
+# template in this folder. vLLM's NixlConnector default is 30 s
+# (nixl/worker.py: get_from_extra_config("kv_lease_duration", 30)); when it elapses the producer
+# frees the blocks, and a LATER pull by the decode worker is only LOGGED, never failed - the
+# request completes and the client is told nothing.
+#
+# 30 s is too short for this model. MEASURED 2026-08-16 on a live 3-pod disagg/dgd run
+# (Nemotron-3-Ultra-550B NVFP4, p6-b200, prefill and decode on different nodes), from the
+# prefill worker's own log, the two-step sequence on 8 of 42 completed requests:
+#   1. WARNING "Releasing expired KV blocks for request <id> which were retrieved by
+#      0 remote worker(s) before lease expired."      <- 30 s elapsed with ZERO reads
+#   2. ~20 s later, ERROR "Potentially invalid KV blocks for unrecognized request <id>
+#      were retrieved by a decode worker. They may have expired."
+# Both lines appeared once per prefill TP rank (8/8), 64 lines each, and every one of those
+# 8 requests still returned 200 to the client. The lease starts when prefill hands the request
+# to decode (each release landed 29-30 s after the decode worker logged "request received"),
+# and the read landed 51-62 s after that handoff - always past the 30 s default.
+#
+# This value is read by BOTH roles and two other timings derive from it: the producer extends
+# a lease by 2/3 of it per heartbeat (worker.py: _lease_extension), and the decode side sends
+# those heartbeats every 1/6 of it (scheduler.py: _heartbeat_interval). Every template here
+# passes it to prefill AND decode for that reason - setting it on one role only desynchronises
+# the two. The heartbeat path is the intended defense against exactly this failure; the
+# releases above prove it did not renew those leases, but not why (the "Heartbeat extended
+# lease" line is logger.debug, so its absence at INFO is not evidence either way).
+#
+# 300 s covers the observed 51-62 s hold with margin. The cost of a larger lease is blocks
+# staying pinned on the prefill side that long if the decode never pulls; on this shape KV
+# cache usage measured 0.0-0.3%, so there is no pressure to trade against. This is a
+# containment for the symptom - the ~60 s hold before the pull is a separate open issue.
+# Verify a run with ../test/kv-lease-check.sh.
+export KV_LEASE_DURATION=${KV_LEASE_DURATION:-300}
+
 export ETCD_URL=http://dynamo-platform-etcd.dynamo-system.svc.cluster.local:2379
 export NATS_URL=nats://dynamo-platform-nats.dynamo-system.svc.cluster.local:4222
 

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/deployment.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/deployment.yaml-template
@@ -72,7 +72,7 @@ spec:
                 --trust-remote-code ${MAMBA_FLAGS} \
                 --load-format runai_streamer \
                 --disaggregation-mode prefill \
-                --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}'
+                --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"],"kv_lease_duration":${KV_LEASE_DURATION}}}'
           env:
             - { name: DYNAMO_BACKEND, value: vllm }
             - { name: DYN_NAMESPACE, value: dynamo-disagg }
@@ -225,7 +225,7 @@ spec:
                 --trust-remote-code ${MAMBA_FLAGS} \
                 --load-format runai_streamer \
                 --disaggregation-mode decode \
-                --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}'
+                --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"],"kv_lease_duration":${KV_LEASE_DURATION}}}'
           env:
             - { name: DYNAMO_BACKEND, value: vllm }
             - { name: DYN_NAMESPACE, value: dynamo-disagg }

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd.yaml-template
@@ -140,7 +140,7 @@ spec:
                 --trust-remote-code ${MAMBA_FLAGS} \
                 --load-format runai_streamer \
                 --disaggregation-mode prefill \
-                --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}'
+                --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"],"kv_lease_duration":${KV_LEASE_DURATION}}}'
           env:
             # Read only by the duplicate-address preflight in args above.
             - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
@@ -301,7 +301,7 @@ spec:
                 --trust-remote-code ${MAMBA_FLAGS} \
                 --load-format runai_streamer \
                 --disaggregation-mode decode \
-                --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}'
+                --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"],"kv_lease_duration":${KV_LEASE_DURATION}}}'
           env:
             # Read only by the duplicate-address preflight in args above.
             - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-2pp.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-2pp.yaml-template
@@ -175,7 +175,7 @@ spec:
                   ${MAMBA_FLAGS} \
                   --load-format runai_streamer \
                   --disaggregation-mode prefill \
-                  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}'
+                  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"],"kv_lease_duration":${KV_LEASE_DURATION}}}'
             env:
               - { name: MY_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
               # NODE_IP is read only by the node-fault preflight in args above (podIP == hostIP).
@@ -557,7 +557,7 @@ spec:
                   ${MAMBA_FLAGS} \
                   --load-format runai_streamer \
                   --disaggregation-mode decode \
-                  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}'
+                  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"],"kv_lease_duration":${KV_LEASE_DURATION}}}'
             env:
               - { name: MY_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
               # NODE_IP is read only by the node-fault preflight in args above (podIP == hostIP).

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-ep.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-ep.yaml-template
@@ -191,7 +191,7 @@ spec:
                   ${MAMBA_FLAGS} \
                   --load-format runai_streamer \
                   --disaggregation-mode prefill \
-                  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}'
+                  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"],"kv_lease_duration":${KV_LEASE_DURATION}}}'
             env:
               - { name: MY_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
               # NODE_IP is read only by the node-fault preflight in args above (podIP == hostIP).
@@ -349,7 +349,7 @@ spec:
                   ${MAMBA_FLAGS} \
                   --load-format runai_streamer \
                   --disaggregation-mode prefill \
-                  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}'
+                  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"],"kv_lease_duration":${KV_LEASE_DURATION}}}'
             env:
               - { name: MY_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
               # NODE_IP is read only by the node-fault preflight in args above (podIP == hostIP).
@@ -577,7 +577,7 @@ spec:
                   ${MAMBA_FLAGS} \
                   --load-format runai_streamer \
                   --disaggregation-mode decode \
-                  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}'
+                  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"],"kv_lease_duration":${KV_LEASE_DURATION}}}'
             env:
               - { name: MY_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
               # NODE_IP is read only by the node-fault preflight in args above (podIP == hostIP).
@@ -727,7 +727,7 @@ spec:
                   ${MAMBA_FLAGS} \
                   --load-format runai_streamer \
                   --disaggregation-mode decode \
-                  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}'
+                  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"],"kv_lease_duration":${KV_LEASE_DURATION}}}'
             env:
               - { name: MY_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
               # NODE_IP is read only by the node-fault preflight in args above (podIP == hostIP).

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-pp2.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-pp2.yaml-template
@@ -9,7 +9,9 @@
 #
 #   - kv_role: kv_both             (BOTH sides; producer/consumer split broken in 1.1.0)
 #   - kv_connector_extra_config:
-#       backends: ["LIBFABRIC"]    (NIXL on EFA, NOT UCX)
+#       backends: ["LIBFABRIC"]         (NIXL on EFA, NOT UCX)
+#       kv_lease_duration: ${KV_LEASE_DURATION}  (seconds P holds KV for D to pull; vLLM default 30
+#                                       is too short for this model - see .env)
 #   - ${MAMBA_FLAGS} (hybrid-Mamba only; derived from MODEL_NAME in .env - empty on pure transformers)
 #
 # -----------------------------------------------------------------------------
@@ -242,7 +244,7 @@ spec:
                   ${MAMBA_FLAGS} \
                   --load-format runai_streamer \
                   --disaggregation-mode prefill \
-                  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}'
+                  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"],"kv_lease_duration":${KV_LEASE_DURATION}}}'
             env:
               - { name: MY_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
               - { name: DYNAMO_BACKEND, value: vllm }
@@ -626,7 +628,7 @@ spec:
                   ${MAMBA_FLAGS} \
                   --load-format runai_streamer \
                   --disaggregation-mode decode \
-                  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}'
+                  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"],"kv_lease_duration":${KV_LEASE_DURATION}}}'
             env:
               - { name: MY_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
               - { name: DYNAMO_BACKEND, value: vllm }

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/run.sh
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/run.sh
@@ -6,6 +6,12 @@ if [ "${MANIFEST_TYPE}" == "" ]; then
 	export MANIFEST_TYPE=deployment
 fi
 
+# KV_LEASE_DURATION lands inside the JSON of --kv-transfer-config, so an .env that predates
+# it renders "kv_lease_duration":} and vLLM dies on the argument. Default it here too.
+if [ "${KV_LEASE_DURATION}" == "" ]; then
+	export KV_LEASE_DURATION=300
+fi
+
 cat ${MANIFEST_TYPE}.yaml-template | envsubst > ${MANIFEST_TYPE}.yaml
 export CMD="kubectl apply -f ./${MANIFEST_TYPE}.yaml"
 

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/test/kv-lease-check.py
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/test/kv-lease-check.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Report whether a disagg run served requests on KV blocks the producer had freed.
+
+WHY THIS EXISTS
+In vLLM's NixlConnector the PREFILL side holds a request's KV blocks under a lease and
+frees them when it elapses (nixl/worker.py: get_from_extra_config("kv_lease_duration",
+30) - the default is 30 seconds). Two things then happen in the prefill worker's log:
+
+  WARNING "Releasing expired KV blocks for request <id> which were retrieved by
+           0 remote worker(s) before lease expired."
+  ERROR   "Potentially invalid KV blocks for unrecognized request <id> were retrieved
+           by a decode worker. They may have expired."
+
+The second one is only logged. The code path is `logger.error(...); continue` - the
+request is not failed, the decode worker keeps whatever it read, and the client still
+gets HTTP 200. So a run can be silently wrong while every metric says it passed, which
+is why this needs a checker rather than an eyeball.
+
+MEASURED 2026-08-16, live 3-Pod disagg/dgd run (Nemotron-3-Ultra-550B-A55B-NVFP4,
+p6-b200, prefill and decode on different nodes, 42 completed requests): 8 of those 42
+produced BOTH lines, each once per prefill TP rank (8/8, so 64 log lines per message),
+and all 8 returned 200. The lease was the stock 30s; the gap between decode receiving
+the request and the KV being pulled measured 50-62s, always past it.
+
+USAGE
+  ./kv-lease-check.sh                      # every prefill Pod of $DEPLOYMENT_NAME
+  ./kv-lease-check.sh <prefill-worker.log> # a log you already saved
+
+Exit status is 0 when no request lost its lease and 1 when one did, so it can gate a
+benchmark. A clean log from a run that served nothing proves nothing: the report prints
+the peak prompt throughput it saw so an idle window cannot read as a pass.
+"""
+import re
+import statistics as st
+import sys
+from datetime import datetime
+
+ANSI = re.compile(r"\x1b\[[0-9;]*m")
+# vLLM worker lines carry their own MM-DD HH:MM:SS stamp and a (Worker_TPn pid=...) prefix.
+RELEASED = re.compile(
+    r"(?:\(Worker_TP(?P<rank>\d+)[^)]*\)\s*)?WARNING (?P<ts>\d\d-\d\d \d\d:\d\d:\d\d)"
+    r".*Releasing expired KV blocks for request (?P<req>\S+) which were retrieved by "
+    r"(?P<reads>\d+) remote worker"
+)
+LATE_READ = re.compile(
+    r"(?:\(Worker_TP(?P<rank>\d+)[^)]*\)\s*)?ERROR (?P<ts>\d\d-\d\d \d\d:\d\d:\d\d)"
+    r".*unrecognized request (?P<req>\S+) were retrieved by a decode worker"
+)
+# The engine's own stats line, from Dynamo's logger, ISO stamp and no TP prefix.
+THROUGHPUT = re.compile(r"Avg prompt throughput: (?P<tps>[\d.]+) tokens/s")
+
+
+def stamp(text):
+    # No year in a vLLM worker stamp; a fixed one is fine, only deltas are used.
+    return datetime.strptime("2000-" + text, "%Y-%m-%d %H:%M:%S")
+
+
+def main():
+    paths = sys.argv[1:]
+    if not paths:
+        sys.exit(__doc__)
+
+    released = {}   # req -> {"ts": first stamp, "reads": max count, "ranks": set}
+    late_read = {}  # req -> {"ts": first stamp, "ranks": set}
+    peak_tps = 0.0
+    lines = 0
+
+    for path in paths:
+        try:
+            handle = sys.stdin if path == "-" else open(path, errors="replace")
+        except OSError as err:
+            sys.exit(f"{path}: {err}")
+        for raw in handle:
+            lines += 1
+            line = ANSI.sub("", raw)
+            if m := THROUGHPUT.search(line):
+                peak_tps = max(peak_tps, float(m.group("tps")))
+                continue
+            for pattern, table in ((RELEASED, released), (LATE_READ, late_read)):
+                if not (m := pattern.search(line)):
+                    continue
+                req = m.group("req")
+                entry = table.setdefault(req, {"ts": stamp(m.group("ts")), "ranks": set()})
+                entry["ts"] = min(entry["ts"], stamp(m.group("ts")))
+                if m.group("rank") is not None:
+                    entry["ranks"].add(int(m.group("rank")))
+                if pattern is RELEASED:
+                    entry["reads"] = max(entry.get("reads", 0), int(m.group("reads")))
+                break
+
+    if not lines:
+        sys.exit("no log content on stdin or in the given files")
+
+    unread = {r: e for r, e in released.items() if e["reads"] == 0}
+    served_on_freed = sorted(set(released) & set(late_read),
+                             key=lambda r: released[r]["ts"])
+    orphan_reads = sorted(set(late_read) - set(released))
+    ranks = sorted({rank for e in list(released.values()) + list(late_read.values())
+                    for rank in e["ranks"]})
+
+    print(" ".join(paths))
+    print(f"  lines read {lines}   peak prompt throughput {peak_tps:.1f} tok/s"
+          f"   prefill TP ranks reporting {len(ranks)}"
+          + (f" (TP{ranks[0]}..TP{ranks[-1]})" if ranks else ""))
+    print(f"  leases expired {len(released)}   of those with 0 reads {len(unread)}"
+          f"   later read anyway {len(served_on_freed)}")
+
+    if served_on_freed:
+        gaps = []
+        print(f"\n  SERVED ON FREED KV - the producer released these, then a decode"
+              f" worker read them")
+        print(f"  {'request':<46} {'expired':>9} {'reads':>6} {'late_read':>10} {'gap_s':>7}")
+        for req in served_on_freed:
+            gap = (late_read[req]["ts"] - released[req]["ts"]).total_seconds()
+            gaps.append(gap)
+            expired_at = released[req]["ts"].strftime("%H:%M:%S")
+            read_at = late_read[req]["ts"].strftime("%H:%M:%S")
+            print(f"  {req[:46]:<46} {expired_at:>9} {released[req]['reads']:>6}"
+                  f" {read_at:>10} {gap:>7.0f}")
+        clean = [g for g in gaps if g >= 0]
+        if clean:
+            print(f"  expired -> late read (s): min {min(clean):.0f}"
+                  f"  median {st.median(clean):.0f}  max {max(clean):.0f}")
+            print(f"  Every one of these requests still returned 200 to its client.")
+
+    if orphan_reads:
+        print(f"\n  {len(orphan_reads)} late read(s) with no matching release in these"
+              f" logs - a producer\n  restart or a rotated log, not necessarily a"
+              f" different fault:")
+        for req in orphan_reads[:10]:
+            print(f"    {req}")
+
+    if unread:
+        print(f"\nFAIL: {len(unread)} request(s) had their KV lease expire with 0 reads.")
+        print("  Raise the lease past the longest hold this shape produces:")
+        print("    ../disagg/.env -> KV_LEASE_DURATION (default 300, vLLM's own is 30)")
+        print("  Set it once: every template in ../disagg passes it to BOTH roles, and")
+        print("  two other timings derive from it - the producer's extension per")
+        print("  heartbeat (2/3 of it) and the decode side's heartbeat interval (1/6 of")
+        print("  it) - so a value on only one role desynchronises them.")
+        print("  Containment, not a cure: the reason decode took that long to pull is a")
+        print("  separate question, and the lease only stops it corrupting the answer.")
+        sys.exit(1)
+
+    if released:
+        print(f"\nPASS with a caveat: {len(released)} lease(s) expired, but each had"
+              f" already been read.")
+        print("  Blocks were freed on schedule after their consumer was done.")
+        sys.exit(0)
+
+    print("\nPASS: no KV lease expired in these logs.")
+    if peak_tps == 0.0:
+        print("  Peak prompt throughput was 0 tok/s though - this log may not cover a")
+        print("  window where anything was actually served. Re-check after a benchmark.")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/test/kv-lease-check.sh
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/test/kv-lease-check.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Report whether a disagg run served requests on KV blocks the prefill side had freed.
+# See the header of kv-lease-check.py for the two log lines this looks for and why the
+# second one does not fail the request.
+#
+# Usage: ./kv-lease-check.sh                        # live: every prefill Pod of the deployment
+#        ./kv-lease-check.sh <prefill-worker.log>   # a log you already saved
+#
+# Live mode is read-only - it runs `kubectl logs` and nothing else - and writes each
+# Pod's log under ./kv-lease-check-logs/ so a finding stays reproducible after teardown.
+# Exits 1 when a lease expired unread, so it can gate a benchmark.
+
+source .env
+
+if [ "$1" == "" ]; then
+
+  export PREFILL_PODS=$(kubectl -n ${NAMESPACE} get pods -o name | grep "${DEPLOYMENT_NAME}" | grep -i prefill | sed 's|^pod/||')
+
+  if [ "${PREFILL_PODS}" == "" ]; then
+    echo "No prefill Pod matching '${DEPLOYMENT_NAME}' and 'prefill' in namespace ${NAMESPACE}."
+    echo "Check NAMESPACE and DEPLOYMENT_NAME in .env, or pass a saved log:"
+    echo "  ./kv-lease-check.sh <prefill-worker.log>"
+    exit 1
+  fi
+
+  export LOG_DIR=./kv-lease-check-logs
+  mkdir -p ${LOG_DIR}
+  export LOGS=""
+
+  for POD in ${PREFILL_PODS}; do
+    export CMD="kubectl -n ${NAMESPACE} logs ${POD} > ${LOG_DIR}/${POD}.log"
+    if [ ! "$VERBOSE" == "false" ]; then echo -e "\n${CMD}\n"; fi
+    eval "${CMD}"
+    export LOGS="${LOGS} ${LOG_DIR}/${POD}.log"
+  done
+
+else
+  export LOGS="$@"
+fi
+
+export CMD="python3 ./kv-lease-check.py ${LOGS}"
+
+if [ ! "$VERBOSE" == "false" ]; then echo -e "\n${CMD}\n"; fi
+
+eval "${CMD}"


### PR DESCRIPTION
## What

`nemotron/ultra/disagg` exposes vLLM's NixlConnector KV lease as `KV_LEASE_DURATION` and defaults it to 300s, because the stock 30s is shorter than the hold this model produces and the failure it causes is silent.

## Why

A live 3-Pod `disagg/dgd` run on 2026-08-16 (Nemotron-3-Ultra-550B-A55B-NVFP4, p6-b200, prefill and decode on different nodes) served **8 of 42 completed requests on KV blocks the prefill side had already released**. Both halves are in the prefill worker's log, each once per prefill TP rank (8/8, so 64 lines per message):

```
WARNING 08-16 08:09:07 [worker.py:2967] Releasing expired KV blocks for request
        8f07dfc0-...-a2f0e657 which were retrieved by 0 remote worker(s) before lease expired.
ERROR   08-16 08:09:28 [worker.py:3004] Potentially invalid KV blocks for unrecognized request
        8f07dfc0-...-a2f0e657 were retrieved by a decode worker. They may have expired.
```

The producer leases a request's blocks and frees them when the lease elapses (`nixl/worker.py`: `get_from_extra_config("kv_lease_duration", 30)`). The later read is then only logged — the code path is `logger.error(...); continue` — so the request is not failed, decode keeps whatever it read, and the client still gets HTTP 200. All 8 of these returned 200.

Timing, from the prefill and decode logs together — each release landed 29-30s after decode logged `request received`, and the read landed 51-62s after that handoff:

| request | received | released | read | handoff→read |
|---|---|---|---|---|
| `8f07dfc0-…-a2f0e657` | 08:08:37 | 08:09:07 | 08:09:28 | 51s |
| `6b550912-…-9df8eddc` | 08:29:08 | 08:29:38 | 08:30:10 | 61s |
| `bf7f0d7d-…-afda8201` | 08:30:57 | 08:31:27 | 08:31:59 | 62s |

## Changes

- `disagg/.env` — new `KV_LEASE_DURATION` (default 300) with the measurement above recorded next to it.
- all five `disagg/*.yaml-template` — the value goes into `kv_connector_extra_config` for **both** roles (12 sites). Two other timings derive from it: the producer extends a lease by 2/3 of it per heartbeat, the decode side sends those heartbeats every 1/6 of it, so a value on one role only desynchronises them.
- `disagg/run.sh` — defaults the variable too. It lands inside the JSON of `--kv-transfer-config`, so an `.env` predating it would render `"kv_lease_duration":}` and vLLM would die on the argument.
- `test/kv-lease-check.{py,sh}` — finds this in any run.

```
cd test && ./kv-lease-check.sh          # live: every prefill Pod of $DEPLOYMENT_NAME
cd test && ./kv-lease-check.sh <log>    # a log you already saved
```

Live mode is read-only (`kubectl logs` only) and saves each Pod's log so a finding survives teardown. It exits non-zero when a lease expired unread so it can gate a benchmark, and reports the peak prompt throughput it saw so an idle window cannot read as a pass. On the run above:

```
leases expired 8   of those with 0 reads 8   later read anyway 8
expired -> late read (s): min 21  median 32  max 32
FAIL: 8 request(s) had their KV lease expire with 0 reads.
```

## Scope

This is containment, not a cure. The reason decode takes ~60s to pull is the same prefill hold that produces the TTFT tail on this model, and that is still open. What it closes is the failure being silent — 8 wrong answers that every metric reported as successful. The cost of a longer lease is blocks staying pinned on the producer when the consumer never pulls; GPU KV cache usage measured 0.0-0.3% on this shape, so there is nothing to trade against.

## Verification

- rendered all five templates through `envsubst` and parsed each `--kv-transfer-config` back as JSON: **12 of 12 valid** with `kv_lease_duration=300` (int).
- rendered `dgd` with the variable unset to confirm `run.sh`'s guard produces 300 rather than a syntax error.
- `bash -n` on `run.sh` and `kv-lease-check.sh`; checker exercised against a real prefill log (FAIL, exit 1), a decode log (PASS, exit 0) and an empty file.
- YAML parse of all five renders: 4/1/4/4/4 documents, kinds unchanged.

Touches only `nemotron/ultra`. No image change.
