### PR TITLE
nemotron/ultra: add v1beta1 DynamoGraphDeployment templates (agg + disagg)

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/README.md
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/README.md
@@ -63,6 +63,7 @@ The folder decides whether prefill and decode are split; `MANIFEST_TYPE` decides
 | `agg/` | `lws` | one worker, TP8/PP2 across 2 nodes | 2 | no |
 | `agg/` | `lws-ep` | wide expert parallelism, DP`EP_DP_SIZE` x TP8 (EP16 by default) | 2 | no |
 | `agg/` | `dgd` | `DynamoGraphDeployment`, one worker (needs the Dynamo operator) | 1 | no |
+| `agg/` | `dgd-v1beta1` | the same deployment on the `nvidia.com/v1beta1` API instead of the deprecated `v1alpha1` | 1 | no |
 | `disagg/` | `deployment` | 1 prefill + 1 decode, TP8/PP1 each | 2 | yes |
 | `disagg/` | `lws-2pp` | prefill TP8/PP2 + 2x decode TP8/PP1 | 4 | yes |
 | `disagg/` | `lws-pp2` | symmetrical PP2: prefill AND decode each TP8/PP2 | 4 | yes |
@@ -87,7 +88,16 @@ kubectl get crd dynamographdeployments.nvidia.com \
   -o jsonpath='{range .spec.versions[*]}{.name}{" served="}{.served}{" storage="}{.storage}{"\n"}{end}'
 ```
 
-`disagg/dgd-v1beta1` is the same deployment expressed on the new API, for when you want the warning gone or want to be ready for the release that flips the storage version. It is a pure API port -- image, flags, env, resources, probes, node placement and `--kv-transfer-config` are byte-identical to `disagg/dgd`. What the new schema changes: `spec.services{}` becomes `spec.components[]`, `spec.envs` becomes `spec.env`, `componentType: worker` + `subComponentType: prefill|decode` becomes `type: prefill|decode`, `extraPodSpec.mainContainer` becomes a normal pod template whose container is named `main`, and `spec.pvcs` is gone in favour of an ordinary `persistentVolumeClaim` volume.
+`agg/dgd-v1beta1` and `disagg/dgd-v1beta1` are the same two deployments expressed on the new API, for when you want the warning gone or want to be ready for the release that flips the storage version. Each is a pure API port -- image, flags, env, resources, probes, node placement and (for disagg) `--kv-transfer-config` are byte-identical to its `dgd` sibling. What the new schema changes: `spec.services{}` becomes `spec.components[]`, `spec.envs` becomes `spec.env`, `componentType: worker` + `subComponentType: prefill|decode` becomes `type: prefill|decode`, `extraPodSpec.mainContainer` becomes a normal pod template whose container is named `main`, and `spec.pvcs` is gone in favour of an ordinary `persistentVolumeClaim` volume.
+
+The `dgd` templates are the default and stay on `v1alpha1` deliberately: nothing about the warning requires action, and switching API version mid-results-table would put a second variable into the comparison. Deploy `dgd-v1beta1` once, confirm the pods come up, and flip your default after that.
+
+One real difference the port exposes: **the `64Gi` `dshm` emptyDir in the `dgd` templates has never taken effect**, so the `dgd-v1beta1` files omit it and leave `sharedMemorySize` unset. The operator owns `/dev/shm` -- `GenerateBasePodSpec` calls `ApplySharedMemoryVolumeAndMount` unconditionally, a nil `sharedMemorySize` means its own **8Gi** default rather than "no volume", and a mount the pod template already declares is kept only when both its name *and* its `mountPath` differ from the operator's, so a `dshm` mount at `/dev/shm` is silently dropped (the volume survives, mounted nowhere). Every `dgd` run under `test/results/` therefore had 8Gi of shared memory, which is also why writing `64Gi` into the new files would be a change rather than a port. This is admission-invisible -- the injection happens at reconcile -- so check a running pod, not a dry run:
+
+```bash
+kubectl get pod <worker> -o jsonpath='{.spec.containers[?(@.name=="main")].volumeMounts}'
+kubectl get pod <worker> -o jsonpath='{.spec.volumes}'
+```
 
 Both API versions depend on the operator pod being healthy, so check it before blaming a manifest. The `DynamoGraphDeployment` admission webhooks are registered with `failurePolicy: Fail` and the CRD's conversion strategy is `Webhook`: with the controller-manager not Ready, a `v1alpha1` apply is rejected by admission, and a `v1beta1` apply or even `kubectl get dgd` additionally fails conversion with `conversion webhook ... no endpoints available`.
 

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/README.md
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/README.md
@@ -68,8 +68,33 @@ The folder decides whether prefill and decode are split; `MANIFEST_TYPE` decides
 | `disagg/` | `lws-pp2` | symmetrical PP2: prefill AND decode each TP8/PP2 | 4 | yes |
 | `disagg/` | `lws-ep` | wide expert parallelism **per role**: prefill DP`EP_DP_SIZE` x TP8 + decode DP`EP_DP_SIZE` x TP8 (EP16 each by default) | 2 x `EP_DP_SIZE` (4) | yes |
 | `disagg/` | `dgd` | `DynamoGraphDeployment` prefill + decode (needs the Dynamo operator) | 2 | yes |
+| `disagg/` | `dgd-v1beta1` | the same deployment on the `nvidia.com/v1beta1` API instead of the deprecated `v1alpha1` | 2 | yes |
 
 `MANIFEST_TYPE` names the template file directly -- `run.sh` and `stop.sh` render `$MANIFEST_TYPE.yaml-template`, so a value that is not in this table does not render and nothing is applied. A stale value in `stop.sh` still tears down: step 2 there sweeps every resource labelled `app.kubernetes.io/part-of=${DEPLOYMENT_NAME}` regardless of manifest type.
+
+#### The `DynamoGraphDeployment` deprecation warning
+
+Applying either `dgd` template on a Dynamo platform 1.3.x operator prints:
+
+```
+Warning: nvidia.com/v1alpha1 DynamoGraphDeployment is deprecated; use nvidia.com/v1beta1 DynamoGraphDeployment
+```
+
+Nothing is wrong and nothing is lost. `v1alpha1` is still the CRD's **storage** version on 1.3.x, so the object is stored exactly as written; the warning is the API server reading the CRD's `deprecationWarning` field. Confirm on your own cluster with:
+
+```bash
+kubectl get crd dynamographdeployments.nvidia.com \
+  -o jsonpath='{range .spec.versions[*]}{.name}{" served="}{.served}{" storage="}{.storage}{"\n"}{end}'
+```
+
+`disagg/dgd-v1beta1` is the same deployment expressed on the new API, for when you want the warning gone or want to be ready for the release that flips the storage version. It is a pure API port -- image, flags, env, resources, probes, node placement and `--kv-transfer-config` are byte-identical to `disagg/dgd`. What the new schema changes: `spec.services{}` becomes `spec.components[]`, `spec.envs` becomes `spec.env`, `componentType: worker` + `subComponentType: prefill|decode` becomes `type: prefill|decode`, `extraPodSpec.mainContainer` becomes a normal pod template whose container is named `main`, and `spec.pvcs` is gone in favour of an ordinary `persistentVolumeClaim` volume.
+
+Both API versions depend on the operator pod being healthy, so check it before blaming a manifest. The `DynamoGraphDeployment` admission webhooks are registered with `failurePolicy: Fail` and the CRD's conversion strategy is `Webhook`: with the controller-manager not Ready, a `v1alpha1` apply is rejected by admission, and a `v1beta1` apply or even `kubectl get dgd` additionally fails conversion with `conversion webhook ... no endpoints available`.
+
+```bash
+kubectl -n dynamo-system get pods
+kubectl -n dynamo-system get endpoints dynamo-platform-dynamo-operator-webhook-service
+```
 
 Every `disagg/` template carries `--kv-transfer-config` with `NixlConnector` and moves the KV cache over EFA; no `agg/` template does. **`lws-ep` exists in both folders under the same name, and they are different topologies** -- the folder is the discriminator, so read it as "wide expert parallelism, in this folder's mode". `agg/lws-ep` is **aggregated** wide-EP: it exercises EFA heavily (the MoE all-to-all is NCCL across nodes on every token) but it does not disaggregate, so label its benchmark numbers aggregated and compare them against a P/D run only at equal GPU count. `disagg/lws-ep` is the disaggregated one, at twice the node count.
 

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/.env
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/.env
@@ -11,11 +11,18 @@ export DOLLAR='$'
 export NAMESPACE=${NAMESPACE:-default}
 export DEPLOYMENT_NAME=${DEPLOYMENT_NAME:-nemotron3-ultra-550b-agg}
 
-# MANIFEST_TYPE=deployment|lws|lws-ep|dgd
+# MANIFEST_TYPE=deployment|lws|lws-ep|dgd|dgd-v1beta1
 #   deployment : plain Deployment, 1 worker node, TP8/PP1 (simplest)
 #   lws        : LeaderWorkerSet, one engine TP8/PP2 across 2 nodes
 #   lws-ep     : EP16 aggregated - LWS DP2 x TP8 with --enable-expert-parallel (EP degree 16)
 #   dgd        : DynamoGraphDeployment via the Dynamo operator (needs ../../../nvidia-dynamo)
+#   dgd-v1beta1: the SAME deployment on the nvidia.com/v1beta1 API instead of the deprecated
+#                v1alpha1. Every value is byte-identical to dgd (gated: the two render to the
+#                same shell bodies, env, resources, probes and node placement), so the only
+#                variable between the two is the API version. Use it to silence the
+#                "nvidia.com/v1alpha1 DynamoGraphDeployment is deprecated" warning, and to be
+#                ready for the operator release that flips the CRD's storage version. Keep
+#                benchmarking on ONE of the two within a single results table.
 # NONE of these disaggregate prefill from decode - that is ../disagg (every template there
 # carries --kv-transfer-config). lws-ep in particular is AGGREGATED wide-EP, so report its
 # numbers as AGGREGATED. ../disagg/.env offers the SAME NAME `lws-ep` for the DISAGGREGATED

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/dgd-v1beta1.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/dgd-v1beta1.yaml-template
@@ -1,0 +1,272 @@
+# =============================================================================
+# Nemotron-3 Ultra 550B AGGREGATED — DynamoGraphDeployment, nvidia.com/v1beta1
+# =============================================================================
+#
+# Author: Anton Alexander
+#
+# This is dgd.yaml-template ported to the v1beta1 API, nothing else — the agg
+# counterpart of ../disagg/dgd-v1beta1.yaml-template, which carries the full
+# v1alpha1 -> v1beta1 mapping table and the operator-health checks. Every value
+# (image, flags, env, resources, probes, node placement) is byte-identical to the
+# v1alpha1 file; the only differences are the ones the new schema forces, plus the
+# one documented /dev/shm correction below.
+#
+#   MANIFEST_TYPE=dgd-v1beta1 ./run.sh
+#
+# WHY: on the 1.3.x operator every v1alpha1 apply prints
+#   Warning: nvidia.com/v1alpha1 DynamoGraphDeployment is deprecated;
+#            use nvidia.com/v1beta1 DynamoGraphDeployment
+# The warning is only a warning today — v1alpha1 is still the CRD's STORAGE
+# version, so nothing is dropped, and both versions are served (the DGD CRD is
+# byte-identical in platform 1.3.0 and 1.3.1, so no operator upgrade is needed).
+# It stops being cosmetic when a release flips storage to v1beta1.
+#
+# Requires the Dynamo platform (operator + etcd + NATS) from
+# eks/deployment/nvidia-dynamo. The operator turns this single resource into the
+# frontend + worker deployments and owns their lifecycle, so ./stop.sh removes
+# everything it created.
+#
+# Aggregated (prefill+decode co-located) single-node worker: TP=${GPU_PER_WORKER}/PP=1,
+# intra-node NVLink. NO P/D disaggregation, so NO NIXL / KV-transfer / EFA needed
+# for the model itself (contrast ../disagg/dgd-v1beta1.yaml-template). This is the
+# DGD equivalent of ./deployment.yaml-template — same serving shape, managed by the
+# operator as one CRD.
+#
+# /dev/shm — the operator owns this mount, so the `dshm` emptyDir that
+# dgd.yaml-template declares is NOT carried over, and sharedMemorySize is left
+# unset. Mechanism, read from the 1.3.1 operator source: GenerateBasePodSpec calls
+# ApplySharedMemoryVolumeAndMount unconditionally (internal/dynamo/graph.go:1578);
+# a nil sharedMemorySize injects an 8Gi emptyDir named `shared-memory` at /dev/shm
+# rather than nothing (shared_memory.go:28-48, only "0" suppresses it); and a mount
+# the pod template already had is kept ONLY if its name AND its mountPath both
+# differ from the operator's, so a `dshm` mount at /dev/shm is silently dropped,
+# not rejected (shared_memory.go:69). The 64Gi in dgd.yaml-template has therefore
+# never been in effect. Full write-up in ../disagg/dgd-v1beta1.yaml-template.
+#
+# Uses the golden image via ../.env (covers agg/EP16/PP>1 + the NVFP4 cubin fix);
+# MODEL_VARIANT=NVFP4 switches the checkpoint. Worker stays non-root (dynamo).
+# =============================================================================
+---
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: ${DEPLOYMENT_NAME}
+  namespace: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}
+spec:
+  backendFramework: vllm
+  env:
+    - { name: DYNAMO_BACKEND, value: vllm }
+    - { name: ETCD_ENDPOINTS, value: "${ETCD_URL}" }
+    - { name: NATS_SERVER,    value: "${NATS_URL}" }
+    # /tmp, NOT /shared: pods run uid 1000 and /shared is root-owned — the frontend
+    # dies registering the model ("Failed to create cache directory /shared/hf_cache/hub:
+    # Permission denied") and /v1/models stays empty -> every request 404s.
+    - { name: HF_HOME,        value: /tmp/hf_cache }
+  components:
+    # ---- Frontend (router, CPU-only) --------------------------------------
+    - name: Frontend
+      type: frontend
+      replicas: 1
+      podTemplate:
+        spec:
+          nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_FRONTEND} }
+          volumes:
+            # v1beta1 has no top-level spec.pvcs; reference the pre-existing claim natively.
+            - { name: fsx-pvc, persistentVolumeClaim: { claimName: fsx-pvc } }
+          containers:
+            # The operator injects its defaults (image, command, env, ports, probes,
+            # resources, volume mounts) into the container named "main" and merges these
+            # overrides by name. Any other container here is a user-managed sidecar.
+            - name: main
+              resources:
+                requests:
+                  cpu: "2"
+                  memory: "4Gi"
+                limits:
+                  cpu: "4"
+                  memory: "8Gi"
+              image: ${REGISTRY}${IMAGE}${TAG}
+              imagePullPolicy: Always
+              command: ["/bin/bash", "-c"]
+              # 1.3.x images have no /opt/dynamo/venv — activate only when present.
+              args:
+                - |-
+                  # ---- Node-fault preflight: duplicate pod address (podIP == hostIP) ----
+                  # The CNI can hand this sandbox the node's own kubelet InternalIP; cluster DNS then
+                  # never answers for the pod, so NATS/etcd are unreachable. A container RESTART CANNOT
+                  # CLEAR IT (restarts reuse the sandbox, CNI ADD is not re-invoked) - the pod object has
+                  # to be deleted. Measured 2026-08-15 on a 4-node ml.p6-b200.48xlarge cluster: all four
+                  # nodes carry their own InternalIP inside their ipamd assignable pool, so ANY
+                  # hostNetwork:false pod here can draw it. Mechanism + incident: disagg/lws-2pp.yaml-template.
+                  if [ -n "${DOLLAR}{POD_IP:-}" ] && [ "${DOLLAR}{POD_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
+                    echo "[frontend] FATAL: pod IP ${DOLLAR}POD_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                    echo "[frontend]        Cluster DNS cannot answer for this pod, so NATS/etcd are unreachable."
+                    echo "[frontend]        RESTARTING WILL NOT HELP - the sandbox keeps the address. Remedy:"
+                    echo "[frontend]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                    exit 1
+                  fi
+                  if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+                  exec python3 -m dynamo.frontend --http-port 8000 --http-host 0.0.0.0
+              env:
+                # Read only by the duplicate-address preflight in args above.
+                - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+                - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
+              ports: [{ containerPort: 8000, name: http }]
+              # NOTE: no readinessProbe here — the operator injects its own frontend probe;
+              # adding ours makes the API server reject the generated pod
+              # ("may not specify more than 1 handler type").
+              volumeMounts:
+                - { name: fsx-pvc, mountPath: /shared }
+    # ---- Aggregated worker (prefill+decode, TP${GPU_PER_WORKER}/PP1, 1 node) ----
+    - name: VllmWorker
+      type: worker
+      replicas: 1
+      podTemplate:
+        spec:
+          nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_WORKER} }
+          tolerations:
+            - { key: nvidia.com/gpu, operator: Exists, effect: NoSchedule }
+          volumes:
+            # v1beta1 has no top-level spec.pvcs; reference the pre-existing claim natively.
+            - { name: fsx-pvc, persistentVolumeClaim: { claimName: fsx-pvc } }
+          containers:
+            # The operator injects its defaults (image, command, env, ports, probes,
+            # resources, volume mounts) into the container named "main" and merges these
+            # overrides by name. Any other container here is a user-managed sidecar.
+            - name: main
+              resources:
+                requests:
+                  cpu: "48"
+                  memory: "800Gi"
+                  nvidia.com/gpu: "${GPU_PER_WORKER}"
+                limits:
+                  cpu: "48"
+                  memory: "800Gi"
+                  nvidia.com/gpu: "${GPU_PER_WORKER}"
+              image: ${REGISTRY}${IMAGE}${TAG}
+              imagePullPolicy: Always
+              securityContext: { capabilities: { add: ["IPC_LOCK"] } }
+              command: ["/bin/bash", "-c"]
+              args:
+                - |-
+                  set -u
+                  unset HPCX_DIR HPCX_MPI_DIR HPCX_HOME HPCX_UCX_DIR HPCX_SHARP_DIR \
+                        HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
+                  if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+                  # ---- Node-fault preflight: duplicate pod address (podIP == hostIP) ----
+                  # The CNI can hand this sandbox the node's own kubelet InternalIP; cluster DNS then
+                  # never answers for the pod, so NATS/etcd are unreachable. A container RESTART CANNOT
+                  # CLEAR IT (restarts reuse the sandbox, CNI ADD is not re-invoked) - the pod object has
+                  # to be deleted. Measured 2026-08-15 on a 4-node ml.p6-b200.48xlarge cluster: all four
+                  # nodes carry their own InternalIP inside their ipamd assignable pool, so ANY
+                  # hostNetwork:false pod here can draw it. Mechanism + incident: disagg/lws-2pp.yaml-template.
+                  if [ -n "${DOLLAR}{POD_IP:-}" ] && [ "${DOLLAR}{POD_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
+                    echo "[worker] FATAL: pod IP ${DOLLAR}POD_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                    echo "[worker]        Cluster DNS cannot answer for this pod, so NATS/etcd are unreachable."
+                    echo "[worker]        RESTARTING WILL NOT HELP - the sandbox keeps the address. Remedy:"
+                    echo "[worker]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                    exit 1
+                  fi
+                  # Cold-start warmup (detached), same block and same knobs as the disagg templates -
+                  # aggregated pays the identical tax because it runs the same decode kernels. A fresh
+                  # pod's FIRST request spends a one-time ~4min Triton JIT on the Mamba DECODE kernels
+                  # (_selective_scan_update, _causal_conv1d_update): startup only warms the PREFILL SSD
+                  # path and --enforce-eager skips cudagraph capture, not JIT. Measured on a 2-node
+                  # disagg pair with this block as the only variable: first request 7,782ms -> 1,172ms
+                  # (6.6x), total benchmark wall -24.7%, steady state within 2%. Concurrency is a
+                  # Triton compile key on the decode path (_causal_conv1d_update: seqlen / state_len /
+                  # NP2_STATELEN / strides are tl.constexpr; see ../disagg/lws-pp2.yaml-template),
+                  # hence bs=1 first then a concurrent burst of WARMUP_CONCURRENCY. NVFP4-only by default
+                  # (WARMUP_ENABLED=auto keys off the served model's precision suffix); see .env for
+                  # the knobs. Shares the pod, never blocks the engine launch, swallows every error so
+                  # it cannot crash the pod. FE is the operator-generated frontend Service, the same
+                  # name ../test/.env resolves for this manifest type.
+                  # ALSO measured UNWARMED on a live NVFP4 p6-b200 run (2026-08-15): first request 119.5s,
+                  # an 18-minute JIT window, and an AIPerf report with TTFT max 340,349ms / p90 128,579ms
+                  # against a p50 of 759ms - the aggregate columns are unusable while steady state is fine
+                  # (0.148 req/s), and ITL p50 reads 146.77ms vs ~124-129ms warm. So "ignore the TTFT
+                  # column" is not a workaround; the run has to START warm.
+                  (
+                    FE="http://${DEPLOYMENT_NAME}-frontend.${NAMESPACE}.svc.cluster.local:8000"
+                    LH="http://localhost:${DOLLAR}{DYN_SYSTEM_PORT:-9090}/health"
+                    WARMUP_CONCURRENCY=${DOLLAR}{WARMUP_CONCURRENCY:-10}
+                    WARMUP_ENABLED=${DOLLAR}{WARMUP_ENABLED:-auto}
+                    case "${DOLLAR}WARMUP_ENABLED" in
+                      auto) case "${MODEL_NAME}" in
+                              *NVFP4*|*nvfp4*) : ;;
+                              *) echo "[warmup] ${MODEL_NAME} is not NVFP4; warmup not needed, skipping (non-fatal)"; exit 0 ;;
+                            esac ;;
+                      0|false|no) echo "[warmup] WARMUP_ENABLED=${DOLLAR}WARMUP_ENABLED; skipping (non-fatal)"; exit 0 ;;
+                    esac
+                    if ! command -v curl >/dev/null 2>&1; then
+                      echo "[warmup] curl not present; skipping cold-start warmup (non-fatal)"
+                    else
+                      warmed=0
+                      for i in ${DOLLAR}(seq 1 360); do
+                        if curl -sf -o /dev/null --max-time 5 "${DOLLAR}LH" 2>/dev/null \
+                           && curl -sf --max-time 5 "${DOLLAR}FE/v1/models" 2>/dev/null | grep -q "${MODEL_NAME}"; then
+                          echo "[warmup] engine ready (own /health 200 + model registered); priming batch=1 Mamba decode kernel (one-time JIT, ~4min)"
+                          curl -s -o /dev/null --max-time 900 "${DOLLAR}FE/v1/completions" \
+                            -H 'Content-Type: application/json' \
+                            -d "{\"model\":\"${MODEL_NAME}\",\"prompt\":\"warmup\",\"max_tokens\":4,\"temperature\":0}" \
+                            && echo "[warmup] batch=1 warm; priming concurrent batch buckets 1..${DOLLAR}WARMUP_CONCURRENCY" \
+                            || echo "[warmup] batch=1 warmup returned non-zero (non-fatal)"
+                          for j in ${DOLLAR}(seq 1 "${DOLLAR}WARMUP_CONCURRENCY"); do
+                            curl -s -o /dev/null --max-time 900 "${DOLLAR}FE/v1/completions" \
+                              -H 'Content-Type: application/json' \
+                              -d "{\"model\":\"${MODEL_NAME}\",\"prompt\":\"warmup\",\"max_tokens\":4,\"temperature\":0}" &
+                          done
+                          wait
+                          echo "[warmup] concurrent batch buckets warm; benchmark opening will be fast"
+                          warmed=1
+                          break
+                        fi
+                        sleep 5
+                      done
+                      # Fail LOUD if the gate never opened (still non-fatal to the pod): falling out of
+                      # this loop silently is indistinguishable from "warmed up fine", and the next
+                      # benchmark would quietly pay the JIT tax again.
+                      [ "${DOLLAR}warmed" = 1 ] || echo "[warmup] gave up after 30min waiting for ${DOLLAR}LH 200 + ${MODEL_NAME} in ${DOLLAR}FE/v1/models; the FIRST benchmark requests will pay the Mamba JIT (non-fatal)"
+                    fi
+                  ) &
+                  exec python3 -m dynamo.vllm \
+                    --model ${MODEL_PATH} \
+                    --served-model-name ${MODEL_NAME} \
+                    --load-format ${LOAD_FORMAT} \
+                    --tensor-parallel-size ${GPU_PER_WORKER} --pipeline-parallel-size 1 \
+                    --max-model-len 4096 --gpu-memory-utilization 0.97 --enforce-eager \
+                    --trust-remote-code \
+                    --mamba-cache-mode align
+              env:
+                # Read only by the duplicate-address preflight in args above.
+                - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+                - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
+                - { name: DYN_SYSTEM_ENABLED, value: "true" }
+                - { name: DYN_SYSTEM_PORT, value: "9090" }
+                # The warmer above reads these INSIDE the container, so they have to be passed
+                # through here - without these two lines the knobs in .env are inert and the ladder
+                # is always 1..10 no matter what you set in your shell.
+                - { name: WARMUP_ENABLED, value: "${WARMUP_ENABLED}" }
+                - { name: WARMUP_CONCURRENCY, value: "${WARMUP_CONCURRENCY}" }
+                # Raise the execute_model RPC deadline (default 300s) so a JIT-heavy first concurrent
+                # decode step cannot trip it and kill EngineCore ("RPC call to execute_model timed
+                # out" -> EngineDeadError).
+                - { name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS, value: "1800" }
+                - { name: HF_MODULES_CACHE, value: /tmp/hf_cache/modules }
+                - { name: VLLM_LOGGING_LEVEL, value: INFO }
+                # NVFP4 cubin dir is handled in the golden image (build-time chmod); no env needed.
+              # Port MUST be named "system": the operator injects readiness/liveness probes
+              # that target the named port; any other name fails with
+              # 'strconv.Atoi: parsing "system"' and the worker never goes Ready.
+              ports: [{ containerPort: 9090, name: system }]
+              startupProbe:
+                httpGet: { path: /health, port: 9090 }
+                periodSeconds: 30
+                timeoutSeconds: 10
+                # 550B BF16 is a ~1 TB checkpoint; a cold Lustre load can exceed an hour.
+                # 240 x 30s = 120 min. NVFP4 loads far faster; the ceiling is harmless once ready.
+                failureThreshold: 240
+              volumeMounts:
+                - { name: fsx-pvc, mountPath: /shared }

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/.env
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/.env
@@ -11,7 +11,7 @@ export DOLLAR='$'
 export NAMESPACE=${NAMESPACE:-default}
 export DEPLOYMENT_NAME=${DEPLOYMENT_NAME:-nemotron3-ultra-550b-disagg}
 
-# MANIFEST_TYPE=deployment|lws-2pp|lws-pp2|lws-ep|dgd
+# MANIFEST_TYPE=deployment|lws-2pp|lws-pp2|lws-ep|dgd|dgd-v1beta1
 #   deployment : plain Deployments, 1 prefill + 1 decode node, TP8/PP1 each (simplest)
 #   lws-2pp    : LeaderWorkerSet, prefill TP8/PP2 (2 nodes) + decode 2x TP8/PP1 (2x PP1 decode pods)
 #   lws-pp2    : LeaderWorkerSet, symmetrical PP2 - prefill AND decode each TP8/PP2 across 2 nodes
@@ -19,6 +19,13 @@ export DEPLOYMENT_NAME=${DEPLOYMENT_NAME:-nemotron3-ultra-550b-disagg}
 #                DP2 x TP8 (EP16) across 4 nodes, --enable-expert-parallel on BOTH roles AND a
 #                prefill/decode split
 #   dgd        : DynamoGraphDeployment via the Dynamo operator (requires the platform from ../../../nvidia-dynamo)
+#   dgd-v1beta1: the SAME deployment on the nvidia.com/v1beta1 API instead of the deprecated
+#                v1alpha1. Every value is byte-identical to dgd (gated: the two render to the
+#                same shell bodies, env, resources, probes and node placement), so the only
+#                variable between the two is the API version. Use it to silence the
+#                "nvidia.com/v1alpha1 DynamoGraphDeployment is deprecated" warning, and to be
+#                ready for the operator release that flips the CRD's storage version. Keep
+#                benchmarking on ONE of the two within a single results table.
 #
 # EVERY template in this folder splits prefill from decode (all carry --kv-transfer-config with
 # NixlConnector) - including lws-ep. ../agg/.env offers the SAME NAME `lws-ep` for the

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd-v1beta1.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd-v1beta1.yaml-template
@@ -7,8 +7,9 @@
 # This is dgd.yaml-template ported to the v1beta1 API, nothing else. Every value
 # (image, flags, env, resources, probes, node placement, KV transfer config) is
 # byte-identical to the v1alpha1 file; the only differences are the ones the new
-# schema forces. That is deliberate: it makes a single A/B run against
-# MANIFEST_TYPE=dgd a clean test of the API port, with no second variable.
+# schema forces, plus the one documented /dev/shm correction below. That is
+# deliberate: it makes a single A/B run against MANIFEST_TYPE=dgd a clean test of
+# the API port, with no second variable.
 #
 #   MANIFEST_TYPE=dgd-v1beta1 ./run.sh
 #
@@ -50,9 +51,29 @@
 #   kubectl -n dynamo-system get pods
 #   kubectl -n dynamo-system get endpoints dynamo-platform-dynamo-operator-webhook-service
 #
+# /dev/shm — the operator owns this mount, so the `dshm` emptyDir that
+# dgd.yaml-template declares is NOT carried over, and sharedMemorySize is left
+# unset. Read from the 1.3.1 operator source, which is the version this cluster's
+# CRD reports in nvidia.com/dynamo-operator-origin-version:
+#   - GenerateBasePodSpec calls ApplySharedMemoryVolumeAndMount UNCONDITIONALLY
+#     (internal/dynamo/graph.go:1578) — there is no "user opted out" path.
+#   - A nil sharedMemorySize means the operator's own default, not "no volume":
+#     it injects an 8Gi emptyDir named `shared-memory` mounted at /dev/shm
+#     (internal/dynamo/shared_memory.go:28-48). Only the literal "0" suppresses it.
+#   - It then keeps a mount the pod template already had ONLY when the name AND the
+#     mountPath both differ from its own (shared_memory.go:69). A `dshm` mount at
+#     /dev/shm collides on path, so it is silently DROPPED — not rejected. Volumes
+#     are deduplicated by name alone (:61), so the `dshm` volume itself survives,
+#     declared but mounted nowhere.
+# So the 64Gi in dgd.yaml-template has never been in effect: every dgd run in
+# ../test/results/ got 8Gi at /dev/shm. Leaving sharedMemorySize unset here keeps
+# that value; writing 64Gi would be the first time it actually applied, i.e. a real
+# change to a knob none of those runs used. Confirm on a running pod — NOT with
+# --dry-run, since the injection happens at reconcile, not at admission:
+#   kubectl get pod <worker> -o jsonpath='{.spec.containers[?(@.name=="main")].volumeMounts}'
+#   kubectl get pod <worker> -o jsonpath='{.spec.volumes}'
+#
 # NOT ported on purpose (each would add a second variable to the A/B):
-#   - sharedMemorySize: 64Gi would replace the dshm emptyDir + /dev/shm mount below
-#     (v1beta1 default is 8Gi, so it cannot simply be dropped).
 #   - compilationCache: a PVC-backed cache the operator wires up itself.
 #   - multinode: nodeCount, which is how a PP>1 role would be expressed here instead
 #     of a LeaderWorkerSet.
@@ -152,8 +173,7 @@ spec:
                   topologyKey: kubernetes.io/hostname
           volumes:
             - { name: fsx-pvc, persistentVolumeClaim: { claimName: fsx-pvc } }
-            - { name: dshm,       emptyDir: { medium: Memory, sizeLimit: 64Gi } }
-            - { name: gdrdrv,     hostPath: { path: /dev/gdrdrv, type: CharDevice } }
+            - { name: gdrdrv, hostPath: { path: /dev/gdrdrv, type: CharDevice } }
           containers:
             - name: main
               image: ${REGISTRY}${IMAGE}${TAG}
@@ -223,8 +243,7 @@ spec:
                 failureThreshold: 240
               volumeMounts:
                 - { name: fsx-pvc, mountPath: /shared }
-                - { name: dshm,       mountPath: /dev/shm }
-                - { name: gdrdrv,     mountPath: /dev/gdrdrv }
+                - { name: gdrdrv, mountPath: /dev/gdrdrv }
               resources:
                 requests: { cpu: "${CPU_PER_WORKER}", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
                 limits:   { cpu: "${CPU_PER_WORKER}", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
@@ -247,8 +266,7 @@ spec:
                   topologyKey: kubernetes.io/hostname
           volumes:
             - { name: fsx-pvc, persistentVolumeClaim: { claimName: fsx-pvc } }
-            - { name: dshm,       emptyDir: { medium: Memory, sizeLimit: 64Gi } }
-            - { name: gdrdrv,     hostPath: { path: /dev/gdrdrv, type: CharDevice } }
+            - { name: gdrdrv, hostPath: { path: /dev/gdrdrv, type: CharDevice } }
           containers:
             - name: main
               image: ${REGISTRY}${IMAGE}${TAG}
@@ -393,8 +411,7 @@ spec:
                 failureThreshold: 240
               volumeMounts:
                 - { name: fsx-pvc, mountPath: /shared }
-                - { name: dshm,       mountPath: /dev/shm }
-                - { name: gdrdrv,     mountPath: /dev/gdrdrv }
+                - { name: gdrdrv, mountPath: /dev/gdrdrv }
               resources:
                 requests: { cpu: "${CPU_PER_WORKER}", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
                 limits:   { cpu: "${CPU_PER_WORKER}", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd-v1beta1.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd-v1beta1.yaml-template
@@ -1,0 +1,400 @@
+# =============================================================================
+# Nemotron-3 Ultra disaggregated P/D — DynamoGraphDeployment, nvidia.com/v1beta1
+# =============================================================================
+#
+# Author: Anton Alexander
+#
+# This is dgd.yaml-template ported to the v1beta1 API, nothing else. Every value
+# (image, flags, env, resources, probes, node placement, KV transfer config) is
+# byte-identical to the v1alpha1 file; the only differences are the ones the new
+# schema forces. That is deliberate: it makes a single A/B run against
+# MANIFEST_TYPE=dgd a clean test of the API port, with no second variable.
+#
+#   MANIFEST_TYPE=dgd-v1beta1 ./run.sh
+#
+# WHY: on the 1.3.1 operator every v1alpha1 apply prints
+#   Warning: nvidia.com/v1alpha1 DynamoGraphDeployment is deprecated;
+#            use nvidia.com/v1beta1 DynamoGraphDeployment
+# The warning is only a warning today — v1alpha1 is still the CRD's STORAGE
+# version (`kubectl get crd dynamographdeployments.nvidia.com -o
+# jsonpath='{.spec.versions[*].storage}'`), so nothing is being dropped. It stops
+# being cosmetic when the operator flips storage to v1beta1 and, eventually, stops
+# serving v1alpha1: at that point this file is the one that still applies.
+#
+# v1alpha1 -> v1beta1, the whole delta (verified against the live CRD schema and
+# by `kubectl apply --dry-run=server` on a 1.3.1 operator):
+#   spec.services{}            -> spec.components[]   (map -> list, `name` per item)
+#   spec.envs                  -> spec.env
+#   componentType: worker
+#     + subComponentType: X    -> type: X             (prefill/decode are first-class
+#                                                      values in the `type` enum)
+#   componentType: frontend    -> type: frontend
+#   extraPodSpec.mainContainer -> podTemplate.spec.containers[] entry named "main"
+#                                 (the operator merges its defaults into the container
+#                                 called exactly "main"; any other container is treated
+#                                 as a user-managed sidecar and gets no defaults)
+#   extraPodSpec.<pod fields>  -> podTemplate.spec.<pod fields>
+#   spec.pvcs + volumeMounts[].mountPoint
+#                              -> a normal pod volume with persistentVolumeClaim +
+#                                 container volumeMounts[].mountPath
+#   resources.requests.gpu     -> resources.requests["nvidia.com/gpu"]
+#   resources.requests.custom  -> resources.requests["vpc.amazonaws.com/efa"]
+#                                 (v1beta1 takes a plain core/v1 ResourceRequirements)
+#
+# Both API versions go through the SAME operator webhooks, so both depend on the
+# operator pod being healthy: the DGD mutating+validating webhooks are registered
+# for v1alpha1 with failurePolicy: Fail and matchPolicy: Equivalent, and the CRD's
+# conversion strategy is Webhook. If the controller-manager pod is not Ready, a
+# v1alpha1 apply is rejected by admission AND a v1beta1 apply additionally fails
+# conversion ("conversion webhook ... no endpoints available"). Check first:
+#   kubectl -n dynamo-system get pods
+#   kubectl -n dynamo-system get endpoints dynamo-platform-dynamo-operator-webhook-service
+#
+# NOT ported on purpose (each would add a second variable to the A/B):
+#   - sharedMemorySize: 64Gi would replace the dshm emptyDir + /dev/shm mount below
+#     (v1beta1 default is 8Gi, so it cannot simply be dropped).
+#   - compilationCache: a PVC-backed cache the operator wires up itself.
+#   - multinode: nodeCount, which is how a PP>1 role would be expressed here instead
+#     of a LeaderWorkerSet.
+#
+# Topology, unchanged from dgd.yaml-template: 1 prefill node + 1 decode node,
+# TP=${GPU_PER_WORKER}/PP=1 each. KV moves prefill->decode over EFA RDMA via NIXL
+# LIBFABRIC.
+# =============================================================================
+---
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: ${DEPLOYMENT_NAME}
+  namespace: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}
+spec:
+  backendFramework: vllm
+  env:
+    - { name: DYNAMO_BACKEND, value: vllm }
+    - { name: ETCD_ENDPOINTS, value: "${ETCD_URL}" }
+    - { name: NATS_SERVER,    value: "${NATS_URL}" }
+    # /tmp, NOT /shared: pods run uid 1000 and /shared is root-owned - the frontend
+    # dies registering the model ("Failed to create cache directory /shared/hf_cache/hub:
+    # Permission denied") and /v1/models stays empty -> every request 404s.
+    - { name: HF_HOME,        value: /tmp/hf_cache }
+  components:
+    # ---- Frontend (router, CPU-only) --------------------------------------
+    - name: Frontend
+      type: frontend
+      replicas: 1
+      podTemplate:
+        spec:
+          nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_FRONTEND} }
+          volumes:
+            # v1beta1 has no spec.pvcs: the claim is mounted as an ordinary pod volume.
+            - { name: fsx-pvc, persistentVolumeClaim: { claimName: fsx-pvc } }
+          containers:
+            # The name MUST be "main" - that is the container the operator merges its
+            # image/command/env/ports/probe defaults into. Any other name is treated as a
+            # user-managed sidecar and gets nothing injected.
+            - name: main
+              image: ${REGISTRY}${IMAGE}${TAG}
+              imagePullPolicy: Always
+              command: ["/bin/bash", "-c"]
+              # 1.3.0-era images have no /opt/dynamo/venv - activate only when present.
+              args:
+                - |-
+                  # ---- Node-fault preflight: duplicate pod address (podIP == hostIP) ----
+                  # The CNI can hand this sandbox the node's own kubelet InternalIP; cluster DNS then
+                  # never answers for the pod, so NATS/etcd are unreachable. A container RESTART CANNOT
+                  # CLEAR IT (restarts reuse the sandbox, CNI ADD is not re-invoked) - the pod object has
+                  # to be deleted. Measured 2026-08-15 on a 4-node ml.p6-b200.48xlarge cluster: all four
+                  # nodes carry their own InternalIP inside their ipamd assignable pool, so ANY
+                  # hostNetwork:false pod here can draw it. Mechanism + incident: disagg/lws-2pp.yaml-template.
+                  if [ -n "${DOLLAR}{POD_IP:-}" ] && [ "${DOLLAR}{POD_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
+                    echo "[frontend] FATAL: pod IP ${DOLLAR}POD_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                    echo "[frontend]        Cluster DNS cannot answer for this pod, so NATS/etcd are unreachable."
+                    echo "[frontend]        RESTARTING WILL NOT HELP - the sandbox keeps the address. Remedy:"
+                    echo "[frontend]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                    exit 1
+                  fi
+                  if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+                  exec python3 -m dynamo.frontend --http-port 8000 --http-host 0.0.0.0
+              env:
+                # Read only by the duplicate-address preflight in args above.
+                - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+                - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
+              ports: [{ containerPort: 8000, name: http }]
+              # The frontend reads the model dir (config/tokenizer, not weights) to build the
+              # preprocessor when workers register a local path - without this mount the model
+              # never appears in /v1/models.
+              volumeMounts:
+                - { name: fsx-pvc, mountPath: /shared }
+              resources:
+                requests: { cpu: "2", memory: 4Gi }
+                limits:   { cpu: "4", memory: 8Gi }
+              # NOTE: no readinessProbe here - the operator injects its own frontend
+              # probe; adding ours makes the API server reject the generated pod
+              # ("may not specify more than 1 handler type").
+    # ---- Prefill worker (TP${GPU_PER_WORKER}/PP1, 1 node) ---------
+    - name: VllmPrefillWorker
+      # v1alpha1 said componentType: worker + subComponentType: prefill; in v1beta1
+      # prefill is a first-class value of `type`.
+      type: prefill
+      replicas: 1
+      podTemplate:
+        spec:
+          nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_WORKER} }
+          tolerations:
+            - { key: nvidia.com/gpu, operator: Exists, effect: NoSchedule }
+            - { key: vpc.amazonaws.com/efa, operator: Exists, effect: NoSchedule }
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector: { matchLabels: { app.kubernetes.io/part-of: ${DEPLOYMENT_NAME} } }
+                  topologyKey: kubernetes.io/hostname
+          volumes:
+            - { name: fsx-pvc, persistentVolumeClaim: { claimName: fsx-pvc } }
+            - { name: dshm,       emptyDir: { medium: Memory, sizeLimit: 64Gi } }
+            - { name: gdrdrv,     hostPath: { path: /dev/gdrdrv, type: CharDevice } }
+          containers:
+            - name: main
+              image: ${REGISTRY}${IMAGE}${TAG}
+              imagePullPolicy: Always
+              securityContext: { capabilities: { add: ["IPC_LOCK"] } }
+              command: ["/bin/bash", "-c"]
+              args:
+                - |-
+                  set -u
+                  unset HPCX_DIR HPCX_MPI_DIR HPCX_HOME HPCX_UCX_DIR HPCX_SHARP_DIR \
+                        HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
+                  if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+                  # ---- Node-fault preflight: duplicate pod address (podIP == hostIP) ----
+                  # The CNI can hand this sandbox the node's own kubelet InternalIP; cluster DNS then
+                  # never answers for the pod, so NATS/etcd are unreachable. A container RESTART CANNOT
+                  # CLEAR IT (restarts reuse the sandbox, CNI ADD is not re-invoked) - the pod object has
+                  # to be deleted. Measured 2026-08-15 on a 4-node ml.p6-b200.48xlarge cluster: all four
+                  # nodes carry their own InternalIP inside their ipamd assignable pool, so ANY
+                  # hostNetwork:false pod here can draw it. Mechanism + incident: disagg/lws-2pp.yaml-template.
+                  if [ -n "${DOLLAR}{POD_IP:-}" ] && [ "${DOLLAR}{POD_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
+                    echo "[prefill] FATAL: pod IP ${DOLLAR}POD_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                    echo "[prefill]        Cluster DNS cannot answer for this pod, so NATS/etcd are unreachable."
+                    echo "[prefill]        RESTARTING WILL NOT HELP - the sandbox keeps the address. Remedy:"
+                    echo "[prefill]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                    exit 1
+                  fi
+                  exec python3 -m dynamo.vllm \
+                    --model ${MODEL_PATH} \
+                    --served-model-name ${MODEL_NAME} \
+                    --tensor-parallel-size ${GPU_PER_WORKER} --pipeline-parallel-size 1 \
+                    --max-model-len 4096 --gpu-memory-utilization 0.97 --enforce-eager \
+                    --trust-remote-code ${MAMBA_FLAGS} \
+                    --load-format runai_streamer \
+                    --disaggregation-mode prefill \
+                    --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"],"kv_lease_duration":${KV_LEASE_DURATION}}}'
+              env:
+                # Read only by the duplicate-address preflight in args above.
+                - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+                - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
+                - { name: DYN_SYSTEM_ENABLED, value: "true" }
+                - { name: DYN_SYSTEM_PORT, value: "9091" }
+                # Same value as decode: a prefill-side compile under a concurrent opening must not
+                # trip the 300s execute_model default either.
+                - { name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS, value: "1800" }
+                - { name: VLLM_LOGGING_LEVEL, value: INFO }
+                - { name: VLLM_SSM_CONV_STATE_LAYOUT, value: DS }
+                - { name: FLASHINFER_DISABLE_VERSION_CHECK, value: "1" }
+                - { name: FI_PROVIDER, value: efa }
+                - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
+                - { name: FI_EFA_FORK_SAFE, value: "1" }
+                - { name: FI_HMEM_CUDA_USE_DMABUF, value: "1" }
+                - { name: FI_EFA_ENABLE_SHM, value: "0" }
+                - { name: FI_EFA_ENABLE_SHM_TRANSFER, value: "0" }
+                - { name: NIXL_LIBFABRIC_MAX_RAILS, value: "1" }
+                - { name: NIXL_SKIP_TOPOLOGY_CHECK, value: "1" }
+                - { name: NCCL_NET_PLUGIN, value: ofi }
+                - { name: NCCL_TUNER_PLUGIN, value: ofi }
+                - { name: OFI_NCCL_FORCE_NUM_RAILS, value: "4" }
+              # Port MUST be named "system": the operator injects readiness/liveness probes
+              # that target the named port; any other name fails with
+              # 'strconv.Atoi: parsing "system"' and the worker never goes Ready.
+              ports: [{ containerPort: 9091, name: system }]
+              startupProbe:
+                httpGet: { path: /health, port: 9091 }
+                periodSeconds: 30
+                timeoutSeconds: 10
+                failureThreshold: 240
+              volumeMounts:
+                - { name: fsx-pvc, mountPath: /shared }
+                - { name: dshm,       mountPath: /dev/shm }
+                - { name: gdrdrv,     mountPath: /dev/gdrdrv }
+              resources:
+                requests: { cpu: "${CPU_PER_WORKER}", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+                limits:   { cpu: "${CPU_PER_WORKER}", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+    # ---- Decode worker (TP${GPU_PER_WORKER}/PP1, 1 node) ----------
+    - name: VllmDecodeWorker
+      # v1alpha1 said componentType: worker + subComponentType: decode; in v1beta1
+      # decode is a first-class value of `type`.
+      type: decode
+      replicas: 1
+      podTemplate:
+        spec:
+          nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_WORKER} }
+          tolerations:
+            - { key: nvidia.com/gpu, operator: Exists, effect: NoSchedule }
+            - { key: vpc.amazonaws.com/efa, operator: Exists, effect: NoSchedule }
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector: { matchLabels: { app.kubernetes.io/part-of: ${DEPLOYMENT_NAME} } }
+                  topologyKey: kubernetes.io/hostname
+          volumes:
+            - { name: fsx-pvc, persistentVolumeClaim: { claimName: fsx-pvc } }
+            - { name: dshm,       emptyDir: { medium: Memory, sizeLimit: 64Gi } }
+            - { name: gdrdrv,     hostPath: { path: /dev/gdrdrv, type: CharDevice } }
+          containers:
+            - name: main
+              image: ${REGISTRY}${IMAGE}${TAG}
+              imagePullPolicy: Always
+              securityContext: { capabilities: { add: ["IPC_LOCK"] } }
+              command: ["/bin/bash", "-c"]
+              args:
+                - |-
+                  set -u
+                  unset HPCX_DIR HPCX_MPI_DIR HPCX_HOME HPCX_UCX_DIR HPCX_SHARP_DIR \
+                        HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
+                  if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+                  # ---- Node-fault preflight: duplicate pod address (podIP == hostIP) ----
+                  # The CNI can hand this sandbox the node's own kubelet InternalIP; cluster DNS then
+                  # never answers for the pod, so NATS/etcd are unreachable. A container RESTART CANNOT
+                  # CLEAR IT (restarts reuse the sandbox, CNI ADD is not re-invoked) - the pod object has
+                  # to be deleted. Measured 2026-08-15 on a 4-node ml.p6-b200.48xlarge cluster: all four
+                  # nodes carry their own InternalIP inside their ipamd assignable pool, so ANY
+                  # hostNetwork:false pod here can draw it. Mechanism + incident: disagg/lws-2pp.yaml-template.
+                  if [ -n "${DOLLAR}{POD_IP:-}" ] && [ "${DOLLAR}{POD_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
+                    echo "[decode] FATAL: pod IP ${DOLLAR}POD_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                    echo "[decode]        Cluster DNS cannot answer for this pod, so NATS/etcd are unreachable."
+                    echo "[decode]        RESTARTING WILL NOT HELP - the sandbox keeps the address. Remedy:"
+                    echo "[decode]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                    exit 1
+                  fi
+                  # Cold-start warmup (detached). A fresh pod's FIRST request pays a one-time ~4min
+                  # Triton JIT compiling the Mamba DECODE kernels (_selective_scan_update,
+                  # _causal_conv1d_update): startup only warms the PREFILL SSD path, and
+                  # --enforce-eager skips cudagraph capture, not JIT. Measured on a 2-node disagg pair
+                  # with this block as the only variable: first request 7,782ms -> 1,172ms (6.6x),
+                  # total benchmark wall -24.7%, steady state within 2%. Concurrency is a Triton
+                  # compile key on the decode path (_causal_conv1d_update: seqlen / state_len /
+                  # NP2_STATELEN / strides are tl.constexpr), hence bs=1 first
+                  # then a concurrent burst of WARMUP_CONCURRENCY. NVFP4-only by default
+                  # (WARMUP_ENABLED=auto keys off the served model's precision suffix); see .env for
+                  # the knobs and lws-pp2.yaml-template for the long-form rationale. Shares the pod, never
+                  # blocks the engine launch, swallows every error so it cannot crash the pod.
+                  # The frontend Service name is the operator-generated ${DEPLOYMENT_NAME}-frontend,
+                  # the same name ../test/.env resolves for this manifest type.
+                  # ALSO measured UNWARMED on a live NVFP4 p6-b200 run (2026-08-15): first request 119.5s,
+                  # an 18-minute JIT window, and an AIPerf report with TTFT max 340,349ms / p90 128,579ms
+                  # against a p50 of 759ms - the aggregate columns are unusable while steady state is fine
+                  # (0.148 req/s), and ITL p50 reads 146.77ms vs ~124-129ms warm. So "ignore the TTFT
+                  # column" is not a workaround; the run has to START warm.
+                  # DISAGG-SPECIFIC, from that same run: while one engine compiles the other blocks, and it
+                  # lands on the KV handoff - 15x "No available shared memory broadcast block found in 60
+                  # seconds" plus KV-transfer P90 spikes of 62-63s that stopped 9s after the last compile,
+                  # then held 125-133ms (Avg post time never moved, 3.05-3.56ms: the fabric was healthy).
+                  (
+                    FE="http://${DEPLOYMENT_NAME}-frontend.${NAMESPACE}.svc.cluster.local:8000"
+                    # Gate on THIS pod's dyn-system /health: the frontend answers /v1/models 200 long
+                    # before the engine has loaded, so gating on the frontend alone fires the warmup at
+                    # a dead engine and compiles nothing.
+                    LH="http://localhost:${DOLLAR}{DYN_SYSTEM_PORT:-9092}/health"
+                    WARMUP_CONCURRENCY=${DOLLAR}{WARMUP_CONCURRENCY:-10}
+                    WARMUP_ENABLED=${DOLLAR}{WARMUP_ENABLED:-auto}
+                    case "${DOLLAR}WARMUP_ENABLED" in
+                      auto) case "${MODEL_NAME}" in
+                              *NVFP4*|*nvfp4*) : ;;
+                              *) echo "[warmup] ${MODEL_NAME} is not NVFP4; warmup not needed, skipping (non-fatal)"; exit 0 ;;
+                            esac ;;
+                      0|false|no) echo "[warmup] WARMUP_ENABLED=${DOLLAR}WARMUP_ENABLED; skipping (non-fatal)"; exit 0 ;;
+                    esac
+                    if ! command -v curl >/dev/null 2>&1; then
+                      echo "[warmup] curl not present; skipping cold-start warmup (non-fatal)"
+                    else
+                      warmed=0
+                      for i in ${DOLLAR}(seq 1 360); do
+                        if curl -sf -o /dev/null --max-time 5 "${DOLLAR}LH" 2>/dev/null \
+                           && curl -sf --max-time 5 "${DOLLAR}FE/v1/models" 2>/dev/null | grep -q "${MODEL_NAME}"; then
+                          echo "[warmup] engine ready (own /health 200 + model registered); priming batch=1 Mamba decode kernel (one-time JIT, ~4min)"
+                          curl -s -o /dev/null --max-time 900 "${DOLLAR}FE/v1/completions" \
+                            -H 'Content-Type: application/json' \
+                            -d "{\"model\":\"${MODEL_NAME}\",\"prompt\":\"warmup\",\"max_tokens\":4,\"temperature\":0}" \
+                            && echo "[warmup] batch=1 warm; priming concurrent batch buckets 1..${DOLLAR}WARMUP_CONCURRENCY" \
+                            || echo "[warmup] batch=1 warmup returned non-zero (non-fatal)"
+                          for j in ${DOLLAR}(seq 1 "${DOLLAR}WARMUP_CONCURRENCY"); do
+                            curl -s -o /dev/null --max-time 900 "${DOLLAR}FE/v1/completions" \
+                              -H 'Content-Type: application/json' \
+                              -d "{\"model\":\"${MODEL_NAME}\",\"prompt\":\"warmup\",\"max_tokens\":4,\"temperature\":0}" &
+                          done
+                          wait
+                          echo "[warmup] concurrent batch buckets warm; benchmark opening will be fast"
+                          warmed=1
+                          break
+                        fi
+                        sleep 5
+                      done
+                      # Fail LOUD if the gate never opened (still non-fatal to the pod): falling out of
+                      # this loop silently is indistinguishable from "warmed up fine", and the next
+                      # benchmark would quietly pay the JIT tax again.
+                      [ "${DOLLAR}warmed" = 1 ] || echo "[warmup] gave up after 30min waiting for ${DOLLAR}LH 200 + ${MODEL_NAME} in ${DOLLAR}FE/v1/models; the FIRST benchmark requests will pay the Mamba JIT (non-fatal)"
+                    fi
+                  ) &
+                  exec python3 -m dynamo.vllm \
+                    --model ${MODEL_PATH} \
+                    --served-model-name ${MODEL_NAME} \
+                    --tensor-parallel-size ${GPU_PER_WORKER} --pipeline-parallel-size 1 \
+                    --max-model-len 4096 --gpu-memory-utilization 0.97 --enforce-eager \
+                    --trust-remote-code ${MAMBA_FLAGS} \
+                    --load-format runai_streamer \
+                    --disaggregation-mode decode \
+                    --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"],"kv_lease_duration":${KV_LEASE_DURATION}}}'
+              env:
+                # Read only by the duplicate-address preflight in args above.
+                - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+                - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
+                - { name: DYN_SYSTEM_ENABLED, value: "true" }
+                - { name: DYN_SYSTEM_PORT, value: "9092" }
+                # The warmer above reads these INSIDE the container, so they have to be passed
+                # through here - without these two lines the knobs in .env are inert and the ladder
+                # is always 1..10 no matter what you set in your shell.
+                - { name: WARMUP_ENABLED, value: "${WARMUP_ENABLED}" }
+                - { name: WARMUP_CONCURRENCY, value: "${WARMUP_CONCURRENCY}" }
+                # Raise the execute_model RPC deadline (default 300s) so a JIT-heavy first concurrent
+                # decode step cannot trip it and kill EngineCore ("RPC call to execute_model timed
+                # out" -> EngineDeadError).
+                - { name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS, value: "1800" }
+                - { name: VLLM_LOGGING_LEVEL, value: INFO }
+                - { name: VLLM_SSM_CONV_STATE_LAYOUT, value: DS }
+                - { name: FLASHINFER_DISABLE_VERSION_CHECK, value: "1" }
+                - { name: FI_PROVIDER, value: efa }
+                - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
+                - { name: FI_EFA_FORK_SAFE, value: "1" }
+                - { name: FI_HMEM_CUDA_USE_DMABUF, value: "1" }
+                - { name: FI_EFA_ENABLE_SHM, value: "0" }
+                - { name: FI_EFA_ENABLE_SHM_TRANSFER, value: "0" }
+                - { name: NIXL_LIBFABRIC_MAX_RAILS, value: "1" }
+                - { name: NIXL_SKIP_TOPOLOGY_CHECK, value: "1" }
+                - { name: NCCL_NET_PLUGIN, value: ofi }
+                - { name: NCCL_TUNER_PLUGIN, value: ofi }
+                - { name: OFI_NCCL_FORCE_NUM_RAILS, value: "4" }
+              # Port MUST be named "system": the operator injects readiness/liveness probes
+              # that target the named port; any other name fails with
+              # 'strconv.Atoi: parsing "system"' and the worker never goes Ready.
+              ports: [{ containerPort: 9092, name: system }]
+              startupProbe:
+                httpGet: { path: /health, port: 9092 }
+                periodSeconds: 30
+                timeoutSeconds: 10
+                failureThreshold: 240
+              volumeMounts:
+                - { name: fsx-pvc, mountPath: /shared }
+                - { name: dshm,       mountPath: /dev/shm }
+                - { name: gdrdrv,     mountPath: /dev/gdrdrv }
+              resources:
+                requests: { cpu: "${CPU_PER_WORKER}", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+                limits:   { cpu: "${CPU_PER_WORKER}", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/test/.env
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/test/.env
@@ -8,7 +8,7 @@ export DEPLOYMENT_NAME=nemotron3-ultra-550b-${DEPLOYMENT_TYPE}
 # MANIFEST_TYPE mirrors ../${DEPLOYMENT_TYPE}/.env and is used here for one purpose only:
 # scoping the aiperf artifact directory. Nothing in test/ renders a manifest, so a value that
 # does not match the deployed topology only mislabels the results folder.
-# agg: deployment|lws|lws-ep|dgd   disagg: deployment|lws-2pp|lws-pp2|lws-ep|dgd
+# agg: deployment|lws|lws-ep|dgd   disagg: deployment|lws-2pp|lws-pp2|lws-ep|dgd|dgd-v1beta1
 export MANIFEST_TYPE="${MANIFEST_TYPE:-deployment}"
 export SERVICE_NAME=${DEPLOYMENT_NAME}-frontend
 export NAMESPACE=default

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/test/.env
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/test/.env
@@ -8,7 +8,8 @@ export DEPLOYMENT_NAME=nemotron3-ultra-550b-${DEPLOYMENT_TYPE}
 # MANIFEST_TYPE mirrors ../${DEPLOYMENT_TYPE}/.env and is used here for one purpose only:
 # scoping the aiperf artifact directory. Nothing in test/ renders a manifest, so a value that
 # does not match the deployed topology only mislabels the results folder.
-# agg: deployment|lws|lws-ep|dgd   disagg: deployment|lws-2pp|lws-pp2|lws-ep|dgd|dgd-v1beta1
+# agg: deployment|lws|lws-ep|dgd|dgd-v1beta1
+# disagg: deployment|lws-2pp|lws-pp2|lws-ep|dgd|dgd-v1beta1
 export MANIFEST_TYPE="${MANIFEST_TYPE:-deployment}"
 export SERVICE_NAME=${DEPLOYMENT_NAME}-frontend
 export NAMESPACE=default


### PR DESCRIPTION
## What

`MANIFEST_TYPE=dgd-v1beta1` in both `agg/` and `disagg/`: the two existing `dgd`
deployments expressed on `nvidia.com/v1beta1` instead of the deprecated
`nvidia.com/v1alpha1`. Additive — the `dgd` templates are untouched and remain the
default.

## Why

Applying either `dgd` template on a Dynamo platform 1.3.x operator prints:

```
Warning: nvidia.com/v1alpha1 DynamoGraphDeployment is deprecated; use nvidia.com/v1beta1 DynamoGraphDeployment
```

Nothing is wrong and nothing is dropped: `v1alpha1` is still the CRD's **storage**
version on 1.3.x. So this is not urgent, and it needs no operator upgrade — the DGD
CRD is byte-identical in platform 1.3.0 and 1.3.1 (md5 `66bacf6f…`, both serve
`v1beta1`). It stops being cosmetic when a release flips the storage version.

Deliberately additive rather than in-place: switching API version underneath an
in-progress results table would add a second variable to every comparison. Deploy
`dgd-v1beta1` once, confirm the pods come up, then flip the default.

## v1beta1 is a different schema, not a rename

| v1alpha1 | v1beta1 |
|---|---|
| `spec.services{}` (map) | `spec.components[]` (list keyed on `name`) |
| `spec.envs` | `spec.env` |
| `componentType: worker` + `subComponentType: prefill\|decode` | `type: prefill\|decode` (first-class enum values) |
| `extraPodSpec.mainContainer` | `podTemplate.spec.containers[]` entry named exactly `main` |
| `extraPodSpec.<pod fields>` | `podTemplate.spec.<pod fields>` |
| `spec.pvcs` + `volumeMounts[].mountPoint` | ordinary `persistentVolumeClaim` volume + `volumeMounts[].mountPath` |
| `resources.requests.gpu` / `.custom.*` | `nvidia.com/gpu` / `vpc.amazonaws.com/efa` as plain `ResourceRequirements` keys |

## One real difference the port exposes: the 64Gi `/dev/shm` never applied

Both `dgd` templates declare a `dshm` emptyDir sized **64Gi** and mount it at
`/dev/shm`. That has never taken effect, so these files omit it and leave
`sharedMemorySize` unset. From the 1.3.1 operator source — the version this
cluster's CRD reports in `nvidia.com/dynamo-operator-origin-version`:

- `GenerateBasePodSpec` calls `ApplySharedMemoryVolumeAndMount` **unconditionally**
  (`internal/dynamo/graph.go:1578`). There is no opt-out path.
- A nil `sharedMemorySize` means the operator's own default, not "no volume": it
  injects an **8Gi** emptyDir named `shared-memory` mounted at `/dev/shm`
  (`internal/dynamo/shared_memory.go:28-48`). Only the literal `"0"` suppresses it.
- It keeps a mount the pod template already had **only when the name AND the
  mountPath both differ** from its own (`shared_memory.go:69`). A `dshm` mount at
  `/dev/shm` collides on path, so it is **dropped silently, not rejected** — which
  is why the `v1alpha1` templates have always applied cleanly. Volumes are
  deduplicated by name alone (`:61`), so the `dshm` volume survives, declared but
  mounted nowhere.
- The `v1alpha1` templates set no `sharedMemory` key, and `ToBetaSharedMemorySize`
  maps that nil straight through (`internal/dynamo/v1beta1_helpers.go:209`), so the
  `v1alpha1` path lands on the same 8Gi default.

Every `dgd` run under `test/results/` therefore had 8Gi at `/dev/shm`. Leaving
`sharedMemorySize` unset preserves that; writing `64Gi` would be the first time
that size ever applied — a change, not a port, and not one to make underneath a
results table. It is also admission-invisible (injection happens at reconcile), so
it can only be confirmed on a running pod:

```bash
kubectl get pod <worker> -o jsonpath='{.spec.containers[?(@.name=="main")].volumeMounts}'
kubectl get pod <worker> -o jsonpath='{.spec.volumes}'
```

## Verification

- **Both files render and YAML round-trip**, and all five container bash bodies are
  **byte-identical** to their `v1alpha1` siblings — Frontend 1169 chars/16 lines,
  agg `VllmWorker` 5641/88, disagg `VllmDecodeWorker` 6373/96, disagg
  `VllmPrefillWorker` 1856/27. `env` lists, resources, ports, probes,
  `securityContext`, `nodeSelector`, `tolerations` and volume mounts all carry over
  with only the documented translations applied.
- **Engine argv unchanged**: agg `tp=8 pp=1 util=0.97 kv=NO flags=10`; disagg
  prefill/decode `tp=8 pp=1 util=0.97 kv=yes flags=13`. `v1alpha1` == `v1beta1`.
- **All four manifests pass `kubectl apply --dry-run=server`** against a live 1.3.1
  operator (schema validation + conversion webhook + admission webhooks). The
  deprecation warning appears on both `v1alpha1` applies and on **neither**
  `v1beta1` apply.
- **Conversion is lossless.** `v1alpha1` is still the storage version, so a
  `v1beta1` apply is converted down to alpha and back through the conversion
  webhook. Diffing the returned object against the input: **0 dropped, 0 changed**
  for both files (the only additions are API-server defaulting — `protocol: TCP`,
  `uid`, `generation`, `creationTimestamp`).

**NOT verified: reconciliation.** Dry-run exercises schema validation, conversion
and admission, but the operator injects image/command/env/probes/shared-memory in
its *controller*, so a clean dry-run means "the API server accepts this", not "the
pods come up". That is exactly why this is additive and `dgd` stays the default.

Supersedes #86, which did the same port in place and asserted the operator would
*reject* a duplicate `/dev/shm` mountPath; it drops it instead. Closed in favour of
this one.

## Operator health applies to both API versions

The DGD admission webhooks are registered with `failurePolicy: Fail` and the CRD's
conversion strategy is `Webhook`. With the controller-manager not Ready, a
`v1alpha1` apply is rejected by admission and a `v1beta1` apply — or even
`kubectl get dgd` — additionally fails conversion with
`conversion webhook ... no endpoints available`. Check before blaming a manifest:

```bash
kubectl -n dynamo-system get pods
kubectl -n dynamo-system get endpoints dynamo-platform-dynamo-operator-webhook-service
```