### PR TITLE
nemotron/ultra: migrate both DGDs to nvidia.com/v1beta1

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/dgd.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/dgd.yaml-template
@@ -15,15 +15,27 @@
 # equivalent of ../agg/deployment.yaml-template — same serving shape, but managed
 # by the operator as one CRD.
 #
-# API version: nvidia.com/v1alpha1 — on the 1.3.0 operator this is the storage
-# version and admits cleanly (with a deprecation warning). v1beta1 is a DIFFERENT
-# schema (spec.components array), not a rename of this one.
+# API version: nvidia.com/v1beta1. v1alpha1 still works but the API server now
+# answers it with "nvidia.com/v1alpha1 DynamoGraphDeployment is deprecated; use
+# nvidia.com/v1beta1 DynamoGraphDeployment". Both versions are served on the 1.3.0
+# operator this deployment targets (v1alpha1 is still the storage version,
+# conversion strategy Webhook), so this file needs no operator upgrade — the DGD
+# CRD is byte-identical in 1.3.0 and 1.3.1.
+#
+# v1beta1 is a DIFFERENT schema, not a rename: spec.envs → spec.env; spec.pvcs is
+# gone (claims are referenced natively in podTemplate.spec.volumes); spec.services
+# (a map) → spec.components (a list keyed on name); componentType +
+# subComponentType → type; resources / volumeMounts / extraPodSpec and the other
+# pod-config fields collapse into ONE podTemplate (a real PodTemplateSpec) whose
+# container "main" the operator fills in and merges by name; resources.requests.gpu
+# → nvidia.com/gpu with .custom.* promoted to siblings. See ../disagg/dgd.yaml-template
+# for the same mapping written out line by line.
 #
 # Uses the golden image via ../.env (covers agg/EP16/PP>1 + the NVFP4 cubin fix);
 # MODEL_VARIANT=NVFP4 switches the checkpoint. Worker stays non-root (dynamo).
 # =============================================================================
 ---
-apiVersion: nvidia.com/v1alpha1
+apiVersion: nvidia.com/v1beta1
 kind: DynamoGraphDeployment
 metadata:
   name: ${DEPLOYMENT_NAME}
@@ -32,10 +44,7 @@ metadata:
     app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}
 spec:
   backendFramework: vllm
-  pvcs:
-    - name: fsx-pvc
-      create: false
-  envs:
+  env:
     - { name: DYNAMO_BACKEND, value: vllm }
     - { name: ETCD_ENDPOINTS, value: "${ETCD_URL}" }
     - { name: NATS_SERVER,    value: "${NATS_URL}" }
@@ -43,190 +52,213 @@ spec:
     # dies registering the model ("Failed to create cache directory /shared/hf_cache/hub:
     # Permission denied") and /v1/models stays empty -> every request 404s.
     - { name: HF_HOME,        value: /tmp/hf_cache }
-  services:
+  components:
     # ---- Frontend (router, CPU-only) --------------------------------------
-    Frontend:
-      componentType: frontend
+    - name: Frontend
+      type: frontend
       replicas: 1
-      resources:
-        requests: { cpu: "2", memory: 4Gi }
-        limits:   { cpu: "4", memory: 8Gi }
-      # The frontend reads the model dir (config/tokenizer, not weights) to build the
-      # preprocessor when the worker registers a local path — without this mount the
-      # model never appears in /v1/models.
-      volumeMounts:
-        - { name: fsx-pvc, mountPoint: /shared }
-      extraPodSpec:
-        nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_FRONTEND} }
-        mainContainer:
-          image: ${REGISTRY}${IMAGE}${TAG}
-          imagePullPolicy: Always
-          command: ["/bin/bash", "-c"]
-          # 1.3.x images have no /opt/dynamo/venv — activate only when present.
-          args:
-            - |-
-              # ---- Node-fault preflight: duplicate pod address (podIP == hostIP) ----
-              # The CNI can hand this sandbox the node's own kubelet InternalIP; cluster DNS then
-              # never answers for the pod, so NATS/etcd are unreachable. A container RESTART CANNOT
-              # CLEAR IT (restarts reuse the sandbox, CNI ADD is not re-invoked) - the pod object has
-              # to be deleted. Measured 2026-08-15 on a 4-node ml.p6-b200.48xlarge cluster: all four
-              # nodes carry their own InternalIP inside their ipamd assignable pool, so ANY
-              # hostNetwork:false pod here can draw it. Mechanism + incident: disagg/lws-2pp.yaml-template.
-              if [ -n "${DOLLAR}{POD_IP:-}" ] && [ "${DOLLAR}{POD_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
-                echo "[frontend] FATAL: pod IP ${DOLLAR}POD_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
-                echo "[frontend]        Cluster DNS cannot answer for this pod, so NATS/etcd are unreachable."
-                echo "[frontend]        RESTARTING WILL NOT HELP - the sandbox keeps the address. Remedy:"
-                echo "[frontend]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
-                exit 1
-              fi
-              if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
-              exec python3 -m dynamo.frontend --http-port 8000 --http-host 0.0.0.0
-          env:
-            # Read only by the duplicate-address preflight in args above.
-            - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
-            - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
-          ports: [{ containerPort: 8000, name: http }]
-          # NOTE: no readinessProbe here — the operator injects its own frontend probe;
-          # adding ours makes the API server reject the generated pod
-          # ("may not specify more than 1 handler type").
+      podTemplate:
+        spec:
+          nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_FRONTEND} }
+          volumes:
+            # v1beta1 has no top-level spec.pvcs; reference the pre-existing claim natively.
+            - { name: fsx-pvc, persistentVolumeClaim: { claimName: fsx-pvc } }
+          containers:
+            # The operator injects its defaults (image, command, env, ports, probes,
+            # resources, volume mounts) into the container named "main" and merges these
+            # overrides by name. Any other container here is a user-managed sidecar.
+            - name: main
+              resources:
+                requests:
+                  cpu: "2"
+                  memory: "4Gi"
+                limits:
+                  cpu: "4"
+                  memory: "8Gi"
+              image: ${REGISTRY}${IMAGE}${TAG}
+              imagePullPolicy: Always
+              command: ["/bin/bash", "-c"]
+              # 1.3.x images have no /opt/dynamo/venv — activate only when present.
+              args:
+                - |-
+                  # ---- Node-fault preflight: duplicate pod address (podIP == hostIP) ----
+                  # The CNI can hand this sandbox the node's own kubelet InternalIP; cluster DNS then
+                  # never answers for the pod, so NATS/etcd are unreachable. A container RESTART CANNOT
+                  # CLEAR IT (restarts reuse the sandbox, CNI ADD is not re-invoked) - the pod object has
+                  # to be deleted. Measured 2026-08-15 on a 4-node ml.p6-b200.48xlarge cluster: all four
+                  # nodes carry their own InternalIP inside their ipamd assignable pool, so ANY
+                  # hostNetwork:false pod here can draw it. Mechanism + incident: disagg/lws-2pp.yaml-template.
+                  if [ -n "${DOLLAR}{POD_IP:-}" ] && [ "${DOLLAR}{POD_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
+                    echo "[frontend] FATAL: pod IP ${DOLLAR}POD_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                    echo "[frontend]        Cluster DNS cannot answer for this pod, so NATS/etcd are unreachable."
+                    echo "[frontend]        RESTARTING WILL NOT HELP - the sandbox keeps the address. Remedy:"
+                    echo "[frontend]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                    exit 1
+                  fi
+                  if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+                  exec python3 -m dynamo.frontend --http-port 8000 --http-host 0.0.0.0
+              env:
+                # Read only by the duplicate-address preflight in args above.
+                - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+                - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
+              ports: [{ containerPort: 8000, name: http }]
+              # NOTE: no readinessProbe here — the operator injects its own frontend probe;
+              # adding ours makes the API server reject the generated pod
+              # ("may not specify more than 1 handler type").
+              volumeMounts:
+                - { name: fsx-pvc, mountPath: /shared }
     # ---- Aggregated worker (prefill+decode, TP${GPU_PER_WORKER}/PP1, 1 node) ----
-    VllmWorker:
-      componentType: worker
+    - name: VllmWorker
+      type: worker
       replicas: 1
-      resources:
-        requests: { cpu: "48", memory: 800Gi, gpu: "${GPU_PER_WORKER}" }
-        limits:   { cpu: "48", memory: 800Gi, gpu: "${GPU_PER_WORKER}" }
-      volumeMounts:
-        - { name: fsx-pvc, mountPoint: /shared }
-      extraPodSpec:
-        nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_WORKER} }
-        tolerations:
-          - { key: nvidia.com/gpu, operator: Exists, effect: NoSchedule }
-        volumes:
-          - { name: dshm, emptyDir: { medium: Memory, sizeLimit: 64Gi } }
-        mainContainer:
-          image: ${REGISTRY}${IMAGE}${TAG}
-          imagePullPolicy: Always
-          securityContext: { capabilities: { add: ["IPC_LOCK"] } }
-          command: ["/bin/bash", "-c"]
-          args:
-            - |-
-              set -u
-              unset HPCX_DIR HPCX_MPI_DIR HPCX_HOME HPCX_UCX_DIR HPCX_SHARP_DIR \
-                    HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
-              if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
-              # ---- Node-fault preflight: duplicate pod address (podIP == hostIP) ----
-              # The CNI can hand this sandbox the node's own kubelet InternalIP; cluster DNS then
-              # never answers for the pod, so NATS/etcd are unreachable. A container RESTART CANNOT
-              # CLEAR IT (restarts reuse the sandbox, CNI ADD is not re-invoked) - the pod object has
-              # to be deleted. Measured 2026-08-15 on a 4-node ml.p6-b200.48xlarge cluster: all four
-              # nodes carry their own InternalIP inside their ipamd assignable pool, so ANY
-              # hostNetwork:false pod here can draw it. Mechanism + incident: disagg/lws-2pp.yaml-template.
-              if [ -n "${DOLLAR}{POD_IP:-}" ] && [ "${DOLLAR}{POD_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
-                echo "[worker] FATAL: pod IP ${DOLLAR}POD_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
-                echo "[worker]        Cluster DNS cannot answer for this pod, so NATS/etcd are unreachable."
-                echo "[worker]        RESTARTING WILL NOT HELP - the sandbox keeps the address. Remedy:"
-                echo "[worker]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
-                exit 1
-              fi
-              # Cold-start warmup (detached), same block and same knobs as the disagg templates -
-              # aggregated pays the identical tax because it runs the same decode kernels. A fresh
-              # pod's FIRST request spends a one-time ~4min Triton JIT on the Mamba DECODE kernels
-              # (_selective_scan_update, _causal_conv1d_update): startup only warms the PREFILL SSD
-              # path and --enforce-eager skips cudagraph capture, not JIT. Measured on a 2-node
-              # disagg pair with this block as the only variable: first request 7,782ms -> 1,172ms
-              # (6.6x), total benchmark wall -24.7%, steady state within 2%. Concurrency is a
-              # Triton compile key on the decode path (_causal_conv1d_update: seqlen / state_len /
-              # NP2_STATELEN / strides are tl.constexpr; see ../disagg/lws-pp2.yaml-template),
-              # hence bs=1 first then a concurrent burst of WARMUP_CONCURRENCY. NVFP4-only by default
-              # (WARMUP_ENABLED=auto keys off the served model's precision suffix); see .env for
-              # the knobs. Shares the pod, never blocks the engine launch, swallows every error so
-              # it cannot crash the pod. FE is the operator-generated frontend Service, the same
-              # name ../test/.env resolves for this manifest type.
-              # ALSO measured UNWARMED on a live NVFP4 p6-b200 run (2026-08-15): first request 119.5s,
-              # an 18-minute JIT window, and an AIPerf report with TTFT max 340,349ms / p90 128,579ms
-              # against a p50 of 759ms - the aggregate columns are unusable while steady state is fine
-              # (0.148 req/s), and ITL p50 reads 146.77ms vs ~124-129ms warm. So "ignore the TTFT
-              # column" is not a workaround; the run has to START warm.
-              (
-                FE="http://${DEPLOYMENT_NAME}-frontend.${NAMESPACE}.svc.cluster.local:8000"
-                LH="http://localhost:${DOLLAR}{DYN_SYSTEM_PORT:-9090}/health"
-                WARMUP_CONCURRENCY=${DOLLAR}{WARMUP_CONCURRENCY:-10}
-                WARMUP_ENABLED=${DOLLAR}{WARMUP_ENABLED:-auto}
-                case "${DOLLAR}WARMUP_ENABLED" in
-                  auto) case "${MODEL_NAME}" in
-                          *NVFP4*|*nvfp4*) : ;;
-                          *) echo "[warmup] ${MODEL_NAME} is not NVFP4; warmup not needed, skipping (non-fatal)"; exit 0 ;;
-                        esac ;;
-                  0|false|no) echo "[warmup] WARMUP_ENABLED=${DOLLAR}WARMUP_ENABLED; skipping (non-fatal)"; exit 0 ;;
-                esac
-                if ! command -v curl >/dev/null 2>&1; then
-                  echo "[warmup] curl not present; skipping cold-start warmup (non-fatal)"
-                else
-                  warmed=0
-                  for i in ${DOLLAR}(seq 1 360); do
-                    if curl -sf -o /dev/null --max-time 5 "${DOLLAR}LH" 2>/dev/null \
-                       && curl -sf --max-time 5 "${DOLLAR}FE/v1/models" 2>/dev/null | grep -q "${MODEL_NAME}"; then
-                      echo "[warmup] engine ready (own /health 200 + model registered); priming batch=1 Mamba decode kernel (one-time JIT, ~4min)"
-                      curl -s -o /dev/null --max-time 900 "${DOLLAR}FE/v1/completions" \
-                        -H 'Content-Type: application/json' \
-                        -d "{\"model\":\"${MODEL_NAME}\",\"prompt\":\"warmup\",\"max_tokens\":4,\"temperature\":0}" \
-                        && echo "[warmup] batch=1 warm; priming concurrent batch buckets 1..${DOLLAR}WARMUP_CONCURRENCY" \
-                        || echo "[warmup] batch=1 warmup returned non-zero (non-fatal)"
-                      for j in ${DOLLAR}(seq 1 "${DOLLAR}WARMUP_CONCURRENCY"); do
-                        curl -s -o /dev/null --max-time 900 "${DOLLAR}FE/v1/completions" \
-                          -H 'Content-Type: application/json' \
-                          -d "{\"model\":\"${MODEL_NAME}\",\"prompt\":\"warmup\",\"max_tokens\":4,\"temperature\":0}" &
+      # v1beta1 replaces the manual dshm emptyDir with this: the operator mounts the
+      # tmpfs at /dev/shm itself (default 8Gi), so also declaring our own volume at
+      # that path would give the pod a duplicate mountPath and the webhook rejects it.
+      sharedMemorySize: 64Gi
+      podTemplate:
+        spec:
+          nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_WORKER} }
+          tolerations:
+            - { key: nvidia.com/gpu, operator: Exists, effect: NoSchedule }
+          volumes:
+            # v1beta1 has no top-level spec.pvcs; reference the pre-existing claim natively.
+            - { name: fsx-pvc, persistentVolumeClaim: { claimName: fsx-pvc } }
+          containers:
+            # The operator injects its defaults (image, command, env, ports, probes,
+            # resources, volume mounts) into the container named "main" and merges these
+            # overrides by name. Any other container here is a user-managed sidecar.
+            - name: main
+              resources:
+                requests:
+                  cpu: "48"
+                  memory: "800Gi"
+                  nvidia.com/gpu: "${GPU_PER_WORKER}"
+                limits:
+                  cpu: "48"
+                  memory: "800Gi"
+                  nvidia.com/gpu: "${GPU_PER_WORKER}"
+              image: ${REGISTRY}${IMAGE}${TAG}
+              imagePullPolicy: Always
+              securityContext: { capabilities: { add: ["IPC_LOCK"] } }
+              command: ["/bin/bash", "-c"]
+              args:
+                - |-
+                  set -u
+                  unset HPCX_DIR HPCX_MPI_DIR HPCX_HOME HPCX_UCX_DIR HPCX_SHARP_DIR \
+                        HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
+                  if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+                  # ---- Node-fault preflight: duplicate pod address (podIP == hostIP) ----
+                  # The CNI can hand this sandbox the node's own kubelet InternalIP; cluster DNS then
+                  # never answers for the pod, so NATS/etcd are unreachable. A container RESTART CANNOT
+                  # CLEAR IT (restarts reuse the sandbox, CNI ADD is not re-invoked) - the pod object has
+                  # to be deleted. Measured 2026-08-15 on a 4-node ml.p6-b200.48xlarge cluster: all four
+                  # nodes carry their own InternalIP inside their ipamd assignable pool, so ANY
+                  # hostNetwork:false pod here can draw it. Mechanism + incident: disagg/lws-2pp.yaml-template.
+                  if [ -n "${DOLLAR}{POD_IP:-}" ] && [ "${DOLLAR}{POD_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
+                    echo "[worker] FATAL: pod IP ${DOLLAR}POD_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                    echo "[worker]        Cluster DNS cannot answer for this pod, so NATS/etcd are unreachable."
+                    echo "[worker]        RESTARTING WILL NOT HELP - the sandbox keeps the address. Remedy:"
+                    echo "[worker]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                    exit 1
+                  fi
+                  # Cold-start warmup (detached), same block and same knobs as the disagg templates -
+                  # aggregated pays the identical tax because it runs the same decode kernels. A fresh
+                  # pod's FIRST request spends a one-time ~4min Triton JIT on the Mamba DECODE kernels
+                  # (_selective_scan_update, _causal_conv1d_update): startup only warms the PREFILL SSD
+                  # path and --enforce-eager skips cudagraph capture, not JIT. Measured on a 2-node
+                  # disagg pair with this block as the only variable: first request 7,782ms -> 1,172ms
+                  # (6.6x), total benchmark wall -24.7%, steady state within 2%. Concurrency is a
+                  # Triton compile key on the decode path (_causal_conv1d_update: seqlen / state_len /
+                  # NP2_STATELEN / strides are tl.constexpr; see ../disagg/lws-pp2.yaml-template),
+                  # hence bs=1 first then a concurrent burst of WARMUP_CONCURRENCY. NVFP4-only by default
+                  # (WARMUP_ENABLED=auto keys off the served model's precision suffix); see .env for
+                  # the knobs. Shares the pod, never blocks the engine launch, swallows every error so
+                  # it cannot crash the pod. FE is the operator-generated frontend Service, the same
+                  # name ../test/.env resolves for this manifest type.
+                  # ALSO measured UNWARMED on a live NVFP4 p6-b200 run (2026-08-15): first request 119.5s,
+                  # an 18-minute JIT window, and an AIPerf report with TTFT max 340,349ms / p90 128,579ms
+                  # against a p50 of 759ms - the aggregate columns are unusable while steady state is fine
+                  # (0.148 req/s), and ITL p50 reads 146.77ms vs ~124-129ms warm. So "ignore the TTFT
+                  # column" is not a workaround; the run has to START warm.
+                  (
+                    FE="http://${DEPLOYMENT_NAME}-frontend.${NAMESPACE}.svc.cluster.local:8000"
+                    LH="http://localhost:${DOLLAR}{DYN_SYSTEM_PORT:-9090}/health"
+                    WARMUP_CONCURRENCY=${DOLLAR}{WARMUP_CONCURRENCY:-10}
+                    WARMUP_ENABLED=${DOLLAR}{WARMUP_ENABLED:-auto}
+                    case "${DOLLAR}WARMUP_ENABLED" in
+                      auto) case "${MODEL_NAME}" in
+                              *NVFP4*|*nvfp4*) : ;;
+                              *) echo "[warmup] ${MODEL_NAME} is not NVFP4; warmup not needed, skipping (non-fatal)"; exit 0 ;;
+                            esac ;;
+                      0|false|no) echo "[warmup] WARMUP_ENABLED=${DOLLAR}WARMUP_ENABLED; skipping (non-fatal)"; exit 0 ;;
+                    esac
+                    if ! command -v curl >/dev/null 2>&1; then
+                      echo "[warmup] curl not present; skipping cold-start warmup (non-fatal)"
+                    else
+                      warmed=0
+                      for i in ${DOLLAR}(seq 1 360); do
+                        if curl -sf -o /dev/null --max-time 5 "${DOLLAR}LH" 2>/dev/null \
+                           && curl -sf --max-time 5 "${DOLLAR}FE/v1/models" 2>/dev/null | grep -q "${MODEL_NAME}"; then
+                          echo "[warmup] engine ready (own /health 200 + model registered); priming batch=1 Mamba decode kernel (one-time JIT, ~4min)"
+                          curl -s -o /dev/null --max-time 900 "${DOLLAR}FE/v1/completions" \
+                            -H 'Content-Type: application/json' \
+                            -d "{\"model\":\"${MODEL_NAME}\",\"prompt\":\"warmup\",\"max_tokens\":4,\"temperature\":0}" \
+                            && echo "[warmup] batch=1 warm; priming concurrent batch buckets 1..${DOLLAR}WARMUP_CONCURRENCY" \
+                            || echo "[warmup] batch=1 warmup returned non-zero (non-fatal)"
+                          for j in ${DOLLAR}(seq 1 "${DOLLAR}WARMUP_CONCURRENCY"); do
+                            curl -s -o /dev/null --max-time 900 "${DOLLAR}FE/v1/completions" \
+                              -H 'Content-Type: application/json' \
+                              -d "{\"model\":\"${MODEL_NAME}\",\"prompt\":\"warmup\",\"max_tokens\":4,\"temperature\":0}" &
+                          done
+                          wait
+                          echo "[warmup] concurrent batch buckets warm; benchmark opening will be fast"
+                          warmed=1
+                          break
+                        fi
+                        sleep 5
                       done
-                      wait
-                      echo "[warmup] concurrent batch buckets warm; benchmark opening will be fast"
-                      warmed=1
-                      break
+                      # Fail LOUD if the gate never opened (still non-fatal to the pod): falling out of
+                      # this loop silently is indistinguishable from "warmed up fine", and the next
+                      # benchmark would quietly pay the JIT tax again.
+                      [ "${DOLLAR}warmed" = 1 ] || echo "[warmup] gave up after 30min waiting for ${DOLLAR}LH 200 + ${MODEL_NAME} in ${DOLLAR}FE/v1/models; the FIRST benchmark requests will pay the Mamba JIT (non-fatal)"
                     fi
-                    sleep 5
-                  done
-                  # Fail LOUD if the gate never opened (still non-fatal to the pod): falling out of
-                  # this loop silently is indistinguishable from "warmed up fine", and the next
-                  # benchmark would quietly pay the JIT tax again.
-                  [ "${DOLLAR}warmed" = 1 ] || echo "[warmup] gave up after 30min waiting for ${DOLLAR}LH 200 + ${MODEL_NAME} in ${DOLLAR}FE/v1/models; the FIRST benchmark requests will pay the Mamba JIT (non-fatal)"
-                fi
-              ) &
-              exec python3 -m dynamo.vllm \
-                --model ${MODEL_PATH} \
-                --served-model-name ${MODEL_NAME} \
-                --load-format ${LOAD_FORMAT} \
-                --tensor-parallel-size ${GPU_PER_WORKER} --pipeline-parallel-size 1 \
-                --max-model-len 4096 --gpu-memory-utilization 0.97 --enforce-eager \
-                --trust-remote-code \
-                --mamba-cache-mode align
-          env:
-            # Read only by the duplicate-address preflight in args above.
-            - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
-            - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
-            - { name: DYN_SYSTEM_ENABLED, value: "true" }
-            - { name: DYN_SYSTEM_PORT, value: "9090" }
-            # The warmer above reads these INSIDE the container, so they have to be passed
-            # through here - without these two lines the knobs in .env are inert and the ladder
-            # is always 1..10 no matter what you set in your shell.
-            - { name: WARMUP_ENABLED, value: "${WARMUP_ENABLED}" }
-            - { name: WARMUP_CONCURRENCY, value: "${WARMUP_CONCURRENCY}" }
-            # Raise the execute_model RPC deadline (default 300s) so a JIT-heavy first concurrent
-            # decode step cannot trip it and kill EngineCore ("RPC call to execute_model timed
-            # out" -> EngineDeadError).
-            - { name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS, value: "1800" }
-            - { name: HF_MODULES_CACHE, value: /tmp/hf_cache/modules }
-            - { name: VLLM_LOGGING_LEVEL, value: INFO }
-            # NVFP4 cubin dir is handled in the golden image (build-time chmod); no env needed.
-          # Port MUST be named "system": the operator injects readiness/liveness probes
-          # that target the named port; any other name fails with
-          # 'strconv.Atoi: parsing "system"' and the worker never goes Ready.
-          ports: [{ containerPort: 9090, name: system }]
-          startupProbe:
-            httpGet: { path: /health, port: 9090 }
-            periodSeconds: 30
-            timeoutSeconds: 10
-            # 550B BF16 is a ~1 TB checkpoint; a cold Lustre load can exceed an hour.
-            # 240 x 30s = 120 min. NVFP4 loads far faster; the ceiling is harmless once ready.
-            failureThreshold: 240
-          volumeMounts:
-            - { name: dshm, mountPath: /dev/shm }
+                  ) &
+                  exec python3 -m dynamo.vllm \
+                    --model ${MODEL_PATH} \
+                    --served-model-name ${MODEL_NAME} \
+                    --load-format ${LOAD_FORMAT} \
+                    --tensor-parallel-size ${GPU_PER_WORKER} --pipeline-parallel-size 1 \
+                    --max-model-len 4096 --gpu-memory-utilization 0.97 --enforce-eager \
+                    --trust-remote-code \
+                    --mamba-cache-mode align
+              env:
+                # Read only by the duplicate-address preflight in args above.
+                - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+                - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
+                - { name: DYN_SYSTEM_ENABLED, value: "true" }
+                - { name: DYN_SYSTEM_PORT, value: "9090" }
+                # The warmer above reads these INSIDE the container, so they have to be passed
+                # through here - without these two lines the knobs in .env are inert and the ladder
+                # is always 1..10 no matter what you set in your shell.
+                - { name: WARMUP_ENABLED, value: "${WARMUP_ENABLED}" }
+                - { name: WARMUP_CONCURRENCY, value: "${WARMUP_CONCURRENCY}" }
+                # Raise the execute_model RPC deadline (default 300s) so a JIT-heavy first concurrent
+                # decode step cannot trip it and kill EngineCore ("RPC call to execute_model timed
+                # out" -> EngineDeadError).
+                - { name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS, value: "1800" }
+                - { name: HF_MODULES_CACHE, value: /tmp/hf_cache/modules }
+                - { name: VLLM_LOGGING_LEVEL, value: INFO }
+                # NVFP4 cubin dir is handled in the golden image (build-time chmod); no env needed.
+              # Port MUST be named "system": the operator injects readiness/liveness probes
+              # that target the named port; any other name fails with
+              # 'strconv.Atoi: parsing "system"' and the worker never goes Ready.
+              ports: [{ containerPort: 9090, name: system }]
+              startupProbe:
+                httpGet: { path: /health, port: 9090 }
+                periodSeconds: 30
+                timeoutSeconds: 10
+                # 550B BF16 is a ~1 TB checkpoint; a cold Lustre load can exceed an hour.
+                # 240 x 30s = 120 min. NVFP4 loads far faster; the ceiling is harmless once ready.
+                failureThreshold: 240
+              volumeMounts:
+                - { name: fsx-pvc, mountPath: /shared }

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd.yaml-template
@@ -13,12 +13,31 @@
 # the validated single-node-per-role serving shape. KV moves prefill->decode
 # over EFA RDMA via NIXL LIBFABRIC.
 #
-# API version: nvidia.com/v1alpha1 - on the 1.3.0 operator this is the storage
-# version and admits cleanly (with a deprecation warning). v1beta1 is a
-# DIFFERENT schema (spec.components array), not a rename of this one.
+# API version: nvidia.com/v1beta1. v1alpha1 still works but the API server now
+# answers it with "nvidia.com/v1alpha1 DynamoGraphDeployment is deprecated; use
+# nvidia.com/v1beta1 DynamoGraphDeployment". Both versions are served on the
+# 1.3.0 operator this deployment targets (v1alpha1 is still the storage version,
+# conversion strategy Webhook), so this file needs no operator upgrade - the DGD
+# CRD is byte-identical in 1.3.0 and 1.3.1.
+#
+# v1beta1 is a DIFFERENT schema, not a rename. What moved, and why each line
+# below looks the way it does:
+#   spec.envs                        -> spec.env
+#   spec.pvcs                        -> gone; claims are referenced natively in
+#                                       podTemplate.spec.volumes
+#   spec.services (map name -> spec) -> spec.components (list keyed on name)
+#   componentType + subComponentType -> type (prefill/decode are first-class)
+#   resources / volumeMounts / extraPodSpec + the other pod-config fields
+#                                    -> ONE podTemplate (a real PodTemplateSpec);
+#                                       the operator injects its defaults into
+#                                       the container named "main" and merges
+#                                       these overrides by name
+#   resources.requests.gpu           -> nvidia.com/gpu, and .custom.* promoted to
+#                                       sibling keys (native ResourceRequirements)
+#   the manual dshm emptyDir         -> sharedMemorySize (see the note on it)
 # =============================================================================
 ---
-apiVersion: nvidia.com/v1alpha1
+apiVersion: nvidia.com/v1beta1
 kind: DynamoGraphDeployment
 metadata:
   name: ${DEPLOYMENT_NAME}
@@ -27,10 +46,7 @@ metadata:
     app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}
 spec:
   backendFramework: vllm
-  pvcs:
-    - name: fsx-pvc
-      create: false
-  envs:
+  env:
     - { name: DYNAMO_BACKEND, value: vllm }
     - { name: ETCD_ENDPOINTS, value: "${ETCD_URL}" }
     - { name: NATS_SERVER,    value: "${NATS_URL}" }
@@ -38,305 +54,344 @@ spec:
     # dies registering the model ("Failed to create cache directory /shared/hf_cache/hub:
     # Permission denied") and /v1/models stays empty -> every request 404s.
     - { name: HF_HOME,        value: /tmp/hf_cache }
-  services:
+  components:
     # ---- Frontend (router, CPU-only) --------------------------------------
-    Frontend:
-      componentType: frontend
+    - name: Frontend
+      type: frontend
       replicas: 1
-      resources:
-        requests: { cpu: "2", memory: 4Gi }
-        limits:   { cpu: "4", memory: 8Gi }
-      # The frontend reads the model dir (config/tokenizer, not weights) to build the
-      # preprocessor when workers register a local path - without this mount the model
-      # never appears in /v1/models.
-      volumeMounts:
-        - { name: fsx-pvc, mountPoint: /shared }
-      extraPodSpec:
-        nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_FRONTEND} }
-        mainContainer:
-          image: ${REGISTRY}${IMAGE}${TAG}
-          imagePullPolicy: Always
-          command: ["/bin/bash", "-c"]
-          # 1.3.0-era images have no /opt/dynamo/venv - activate only when present.
-          args:
-            - |-
-              # ---- Node-fault preflight: duplicate pod address (podIP == hostIP) ----
-              # The CNI can hand this sandbox the node's own kubelet InternalIP; cluster DNS then
-              # never answers for the pod, so NATS/etcd are unreachable. A container RESTART CANNOT
-              # CLEAR IT (restarts reuse the sandbox, CNI ADD is not re-invoked) - the pod object has
-              # to be deleted. Measured 2026-08-15 on a 4-node ml.p6-b200.48xlarge cluster: all four
-              # nodes carry their own InternalIP inside their ipamd assignable pool, so ANY
-              # hostNetwork:false pod here can draw it. Mechanism + incident: disagg/lws-2pp.yaml-template.
-              if [ -n "${DOLLAR}{POD_IP:-}" ] && [ "${DOLLAR}{POD_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
-                echo "[frontend] FATAL: pod IP ${DOLLAR}POD_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
-                echo "[frontend]        Cluster DNS cannot answer for this pod, so NATS/etcd are unreachable."
-                echo "[frontend]        RESTARTING WILL NOT HELP - the sandbox keeps the address. Remedy:"
-                echo "[frontend]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
-                exit 1
-              fi
-              if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
-              exec python3 -m dynamo.frontend --http-port 8000 --http-host 0.0.0.0
-          env:
-            # Read only by the duplicate-address preflight in args above.
-            - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
-            - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
-          ports: [{ containerPort: 8000, name: http }]
-          # NOTE: no readinessProbe here - the operator injects its own frontend
-          # probe; adding ours makes the API server reject the generated pod
-          # ("may not specify more than 1 handler type").
+      podTemplate:
+        spec:
+          nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_FRONTEND} }
+          volumes:
+            # v1beta1 has no top-level spec.pvcs; reference the pre-existing claim natively.
+            - { name: fsx-pvc, persistentVolumeClaim: { claimName: fsx-pvc } }
+          containers:
+            # The operator injects its defaults (image, command, env, ports, probes,
+            # resources, volume mounts) into the container named "main" and merges these
+            # overrides by name. Any other container here is a user-managed sidecar.
+            - name: main
+              resources:
+                requests:
+                  cpu: "2"
+                  memory: "4Gi"
+                limits:
+                  cpu: "4"
+                  memory: "8Gi"
+              image: ${REGISTRY}${IMAGE}${TAG}
+              imagePullPolicy: Always
+              command: ["/bin/bash", "-c"]
+              # 1.3.0-era images have no /opt/dynamo/venv - activate only when present.
+              args:
+                - |-
+                  # ---- Node-fault preflight: duplicate pod address (podIP == hostIP) ----
+                  # The CNI can hand this sandbox the node's own kubelet InternalIP; cluster DNS then
+                  # never answers for the pod, so NATS/etcd are unreachable. A container RESTART CANNOT
+                  # CLEAR IT (restarts reuse the sandbox, CNI ADD is not re-invoked) - the pod object has
+                  # to be deleted. Measured 2026-08-15 on a 4-node ml.p6-b200.48xlarge cluster: all four
+                  # nodes carry their own InternalIP inside their ipamd assignable pool, so ANY
+                  # hostNetwork:false pod here can draw it. Mechanism + incident: disagg/lws-2pp.yaml-template.
+                  if [ -n "${DOLLAR}{POD_IP:-}" ] && [ "${DOLLAR}{POD_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
+                    echo "[frontend] FATAL: pod IP ${DOLLAR}POD_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                    echo "[frontend]        Cluster DNS cannot answer for this pod, so NATS/etcd are unreachable."
+                    echo "[frontend]        RESTARTING WILL NOT HELP - the sandbox keeps the address. Remedy:"
+                    echo "[frontend]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                    exit 1
+                  fi
+                  if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+                  exec python3 -m dynamo.frontend --http-port 8000 --http-host 0.0.0.0
+              env:
+                # Read only by the duplicate-address preflight in args above.
+                - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+                - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
+              ports: [{ containerPort: 8000, name: http }]
+              # NOTE: no readinessProbe here - the operator injects its own frontend
+              # probe; adding ours makes the API server reject the generated pod
+              # ("may not specify more than 1 handler type").
+              volumeMounts:
+                - { name: fsx-pvc, mountPath: /shared }
     # ---- Prefill worker (TP${GPU_PER_WORKER}/PP1, 1 node) -----------------
-    VllmPrefillWorker:
-      componentType: worker
-      subComponentType: prefill
+    - name: VllmPrefillWorker
+      type: prefill
       replicas: 1
-      resources:
-        requests: { cpu: "${CPU_PER_WORKER}", memory: 1000Gi, gpu: "${GPU_PER_WORKER}", custom: { vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" } }
-        limits:   { cpu: "${CPU_PER_WORKER}", memory: 1000Gi, gpu: "${GPU_PER_WORKER}", custom: { vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" } }
-      volumeMounts:
-        - { name: fsx-pvc, mountPoint: /shared }
-      extraPodSpec:
-        nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_WORKER} }
-        tolerations:
-          - { key: nvidia.com/gpu, operator: Exists, effect: NoSchedule }
-          - { key: vpc.amazonaws.com/efa, operator: Exists, effect: NoSchedule }
-        affinity:
-          podAntiAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              - labelSelector: { matchLabels: { app.kubernetes.io/part-of: ${DEPLOYMENT_NAME} } }
-                topologyKey: kubernetes.io/hostname
-        volumes:
-          - { name: dshm,       emptyDir: { medium: Memory, sizeLimit: 64Gi } }
-          - { name: gdrdrv,     hostPath: { path: /dev/gdrdrv, type: CharDevice } }
-        mainContainer:
-          image: ${REGISTRY}${IMAGE}${TAG}
-          imagePullPolicy: Always
-          securityContext: { capabilities: { add: ["IPC_LOCK"] } }
-          command: ["/bin/bash", "-c"]
-          args:
-            - |-
-              set -u
-              unset HPCX_DIR HPCX_MPI_DIR HPCX_HOME HPCX_UCX_DIR HPCX_SHARP_DIR \
-                    HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
-              if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
-              # ---- Node-fault preflight: duplicate pod address (podIP == hostIP) ----
-              # The CNI can hand this sandbox the node's own kubelet InternalIP; cluster DNS then
-              # never answers for the pod, so NATS/etcd are unreachable. A container RESTART CANNOT
-              # CLEAR IT (restarts reuse the sandbox, CNI ADD is not re-invoked) - the pod object has
-              # to be deleted. Measured 2026-08-15 on a 4-node ml.p6-b200.48xlarge cluster: all four
-              # nodes carry their own InternalIP inside their ipamd assignable pool, so ANY
-              # hostNetwork:false pod here can draw it. Mechanism + incident: disagg/lws-2pp.yaml-template.
-              if [ -n "${DOLLAR}{POD_IP:-}" ] && [ "${DOLLAR}{POD_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
-                echo "[prefill] FATAL: pod IP ${DOLLAR}POD_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
-                echo "[prefill]        Cluster DNS cannot answer for this pod, so NATS/etcd are unreachable."
-                echo "[prefill]        RESTARTING WILL NOT HELP - the sandbox keeps the address. Remedy:"
-                echo "[prefill]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
-                exit 1
-              fi
-              exec python3 -m dynamo.vllm \
-                --model ${MODEL_PATH} \
-                --served-model-name ${MODEL_NAME} \
-                --tensor-parallel-size ${GPU_PER_WORKER} --pipeline-parallel-size 1 \
-                --max-model-len 4096 --gpu-memory-utilization 0.97 --enforce-eager \
-                --trust-remote-code ${MAMBA_FLAGS} \
-                --load-format runai_streamer \
-                --disaggregation-mode prefill \
-                --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"],"kv_lease_duration":${KV_LEASE_DURATION}}}'
-          env:
-            # Read only by the duplicate-address preflight in args above.
-            - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
-            - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
-            - { name: DYN_SYSTEM_ENABLED, value: "true" }
-            - { name: DYN_SYSTEM_PORT, value: "9091" }
-            # Same value as decode: a prefill-side compile under a concurrent opening must not
-            # trip the 300s execute_model default either.
-            - { name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS, value: "1800" }
-            - { name: VLLM_LOGGING_LEVEL, value: INFO }
-            - { name: VLLM_SSM_CONV_STATE_LAYOUT, value: DS }
-            - { name: FLASHINFER_DISABLE_VERSION_CHECK, value: "1" }
-            - { name: FI_PROVIDER, value: efa }
-            - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
-            - { name: FI_EFA_FORK_SAFE, value: "1" }
-            - { name: FI_HMEM_CUDA_USE_DMABUF, value: "1" }
-            - { name: FI_EFA_ENABLE_SHM, value: "0" }
-            - { name: FI_EFA_ENABLE_SHM_TRANSFER, value: "0" }
-            - { name: NIXL_LIBFABRIC_MAX_RAILS, value: "1" }
-            - { name: NIXL_SKIP_TOPOLOGY_CHECK, value: "1" }
-            - { name: NCCL_NET_PLUGIN, value: ofi }
-            - { name: NCCL_TUNER_PLUGIN, value: ofi }
-            - { name: OFI_NCCL_FORCE_NUM_RAILS, value: "4" }
-          # Port MUST be named "system": the operator injects readiness/liveness probes
-          # that target the named port; any other name fails with
-          # 'strconv.Atoi: parsing "system"' and the worker never goes Ready.
-          ports: [{ containerPort: 9091, name: system }]
-          startupProbe:
-            httpGet: { path: /health, port: 9091 }
-            periodSeconds: 30
-            timeoutSeconds: 10
-            failureThreshold: 240
-          volumeMounts:
-            - { name: dshm,       mountPath: /dev/shm }
-            - { name: gdrdrv,     mountPath: /dev/gdrdrv }
+      # v1beta1 replaces the manual dshm emptyDir with this: the operator mounts the
+      # tmpfs at /dev/shm itself (default 8Gi), so also declaring our own volume at
+      # that path would give the pod a duplicate mountPath and the webhook rejects it.
+      sharedMemorySize: 64Gi
+      podTemplate:
+        spec:
+          nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_WORKER} }
+          tolerations:
+            - { key: nvidia.com/gpu, operator: Exists, effect: NoSchedule }
+            - { key: vpc.amazonaws.com/efa, operator: Exists, effect: NoSchedule }
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector: { matchLabels: { app.kubernetes.io/part-of: ${DEPLOYMENT_NAME} } }
+                  topologyKey: kubernetes.io/hostname
+          volumes:
+            # v1beta1 has no top-level spec.pvcs; reference the pre-existing claim natively.
+            - { name: fsx-pvc, persistentVolumeClaim: { claimName: fsx-pvc } }
+            - { name: gdrdrv,  hostPath: { path: /dev/gdrdrv, type: CharDevice } }
+          containers:
+            # The operator injects its defaults (image, command, env, ports, probes,
+            # resources, volume mounts) into the container named "main" and merges these
+            # overrides by name. Any other container here is a user-managed sidecar.
+            - name: main
+              resources:
+                requests:
+                  cpu: "${CPU_PER_WORKER}"
+                  memory: "1000Gi"
+                  nvidia.com/gpu: "${GPU_PER_WORKER}"
+                  vpc.amazonaws.com/efa: "${EFA_PER_WORKER}"
+                limits:
+                  cpu: "${CPU_PER_WORKER}"
+                  memory: "1000Gi"
+                  nvidia.com/gpu: "${GPU_PER_WORKER}"
+                  vpc.amazonaws.com/efa: "${EFA_PER_WORKER}"
+              image: ${REGISTRY}${IMAGE}${TAG}
+              imagePullPolicy: Always
+              securityContext: { capabilities: { add: ["IPC_LOCK"] } }
+              command: ["/bin/bash", "-c"]
+              args:
+                - |-
+                  set -u
+                  unset HPCX_DIR HPCX_MPI_DIR HPCX_HOME HPCX_UCX_DIR HPCX_SHARP_DIR \
+                        HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
+                  if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+                  # ---- Node-fault preflight: duplicate pod address (podIP == hostIP) ----
+                  # The CNI can hand this sandbox the node's own kubelet InternalIP; cluster DNS then
+                  # never answers for the pod, so NATS/etcd are unreachable. A container RESTART CANNOT
+                  # CLEAR IT (restarts reuse the sandbox, CNI ADD is not re-invoked) - the pod object has
+                  # to be deleted. Measured 2026-08-15 on a 4-node ml.p6-b200.48xlarge cluster: all four
+                  # nodes carry their own InternalIP inside their ipamd assignable pool, so ANY
+                  # hostNetwork:false pod here can draw it. Mechanism + incident: disagg/lws-2pp.yaml-template.
+                  if [ -n "${DOLLAR}{POD_IP:-}" ] && [ "${DOLLAR}{POD_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
+                    echo "[prefill] FATAL: pod IP ${DOLLAR}POD_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                    echo "[prefill]        Cluster DNS cannot answer for this pod, so NATS/etcd are unreachable."
+                    echo "[prefill]        RESTARTING WILL NOT HELP - the sandbox keeps the address. Remedy:"
+                    echo "[prefill]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                    exit 1
+                  fi
+                  exec python3 -m dynamo.vllm \
+                    --model ${MODEL_PATH} \
+                    --served-model-name ${MODEL_NAME} \
+                    --tensor-parallel-size ${GPU_PER_WORKER} --pipeline-parallel-size 1 \
+                    --max-model-len 4096 --gpu-memory-utilization 0.97 --enforce-eager \
+                    --trust-remote-code ${MAMBA_FLAGS} \
+                    --load-format runai_streamer \
+                    --disaggregation-mode prefill \
+                    --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"],"kv_lease_duration":${KV_LEASE_DURATION}}}'
+              env:
+                # Read only by the duplicate-address preflight in args above.
+                - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+                - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
+                - { name: DYN_SYSTEM_ENABLED, value: "true" }
+                - { name: DYN_SYSTEM_PORT, value: "9091" }
+                # Same value as decode: a prefill-side compile under a concurrent opening must not
+                # trip the 300s execute_model default either.
+                - { name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS, value: "1800" }
+                - { name: VLLM_LOGGING_LEVEL, value: INFO }
+                - { name: VLLM_SSM_CONV_STATE_LAYOUT, value: DS }
+                - { name: FLASHINFER_DISABLE_VERSION_CHECK, value: "1" }
+                - { name: FI_PROVIDER, value: efa }
+                - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
+                - { name: FI_EFA_FORK_SAFE, value: "1" }
+                - { name: FI_HMEM_CUDA_USE_DMABUF, value: "1" }
+                - { name: FI_EFA_ENABLE_SHM, value: "0" }
+                - { name: FI_EFA_ENABLE_SHM_TRANSFER, value: "0" }
+                - { name: NIXL_LIBFABRIC_MAX_RAILS, value: "1" }
+                - { name: NIXL_SKIP_TOPOLOGY_CHECK, value: "1" }
+                - { name: NCCL_NET_PLUGIN, value: ofi }
+                - { name: NCCL_TUNER_PLUGIN, value: ofi }
+                - { name: OFI_NCCL_FORCE_NUM_RAILS, value: "4" }
+              # Port MUST be named "system": the operator injects readiness/liveness probes
+              # that target the named port; any other name fails with
+              # 'strconv.Atoi: parsing "system"' and the worker never goes Ready.
+              ports: [{ containerPort: 9091, name: system }]
+              startupProbe:
+                httpGet: { path: /health, port: 9091 }
+                periodSeconds: 30
+                timeoutSeconds: 10
+                failureThreshold: 240
+              volumeMounts:
+                - { name: fsx-pvc, mountPath: /shared }
+                - { name: gdrdrv,  mountPath: /dev/gdrdrv }
     # ---- Decode worker (TP${GPU_PER_WORKER}/PP1, 1 node) ------------------
-    VllmDecodeWorker:
-      componentType: worker
-      subComponentType: decode
+    - name: VllmDecodeWorker
+      type: decode
       replicas: 1
-      resources:
-        requests: { cpu: "${CPU_PER_WORKER}", memory: 1000Gi, gpu: "${GPU_PER_WORKER}", custom: { vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" } }
-        limits:   { cpu: "${CPU_PER_WORKER}", memory: 1000Gi, gpu: "${GPU_PER_WORKER}", custom: { vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" } }
-      volumeMounts:
-        - { name: fsx-pvc, mountPoint: /shared }
-      extraPodSpec:
-        nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_WORKER} }
-        tolerations:
-          - { key: nvidia.com/gpu, operator: Exists, effect: NoSchedule }
-          - { key: vpc.amazonaws.com/efa, operator: Exists, effect: NoSchedule }
-        affinity:
-          podAntiAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              - labelSelector: { matchLabels: { app.kubernetes.io/part-of: ${DEPLOYMENT_NAME} } }
-                topologyKey: kubernetes.io/hostname
-        volumes:
-          - { name: dshm,       emptyDir: { medium: Memory, sizeLimit: 64Gi } }
-          - { name: gdrdrv,     hostPath: { path: /dev/gdrdrv, type: CharDevice } }
-        mainContainer:
-          image: ${REGISTRY}${IMAGE}${TAG}
-          imagePullPolicy: Always
-          securityContext: { capabilities: { add: ["IPC_LOCK"] } }
-          command: ["/bin/bash", "-c"]
-          args:
-            - |-
-              set -u
-              unset HPCX_DIR HPCX_MPI_DIR HPCX_HOME HPCX_UCX_DIR HPCX_SHARP_DIR \
-                    HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
-              if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
-              # ---- Node-fault preflight: duplicate pod address (podIP == hostIP) ----
-              # The CNI can hand this sandbox the node's own kubelet InternalIP; cluster DNS then
-              # never answers for the pod, so NATS/etcd are unreachable. A container RESTART CANNOT
-              # CLEAR IT (restarts reuse the sandbox, CNI ADD is not re-invoked) - the pod object has
-              # to be deleted. Measured 2026-08-15 on a 4-node ml.p6-b200.48xlarge cluster: all four
-              # nodes carry their own InternalIP inside their ipamd assignable pool, so ANY
-              # hostNetwork:false pod here can draw it. Mechanism + incident: disagg/lws-2pp.yaml-template.
-              if [ -n "${DOLLAR}{POD_IP:-}" ] && [ "${DOLLAR}{POD_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
-                echo "[decode] FATAL: pod IP ${DOLLAR}POD_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
-                echo "[decode]        Cluster DNS cannot answer for this pod, so NATS/etcd are unreachable."
-                echo "[decode]        RESTARTING WILL NOT HELP - the sandbox keeps the address. Remedy:"
-                echo "[decode]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
-                exit 1
-              fi
-              # Cold-start warmup (detached). A fresh pod's FIRST request pays a one-time ~4min
-              # Triton JIT compiling the Mamba DECODE kernels (_selective_scan_update,
-              # _causal_conv1d_update): startup only warms the PREFILL SSD path, and
-              # --enforce-eager skips cudagraph capture, not JIT. Measured on a 2-node disagg pair
-              # with this block as the only variable: first request 7,782ms -> 1,172ms (6.6x),
-              # total benchmark wall -24.7%, steady state within 2%. Concurrency is a Triton
-              # compile key on the decode path (_causal_conv1d_update: seqlen / state_len /
-              # NP2_STATELEN / strides are tl.constexpr), hence bs=1 first
-              # then a concurrent burst of WARMUP_CONCURRENCY. NVFP4-only by default
-              # (WARMUP_ENABLED=auto keys off the served model's precision suffix); see .env for
-              # the knobs and lws-pp2.yaml-template for the long-form rationale. Shares the pod, never
-              # blocks the engine launch, swallows every error so it cannot crash the pod.
-              # The frontend Service name is the operator-generated ${DEPLOYMENT_NAME}-frontend,
-              # the same name ../test/.env resolves for this manifest type.
-              # ALSO measured UNWARMED on a live NVFP4 p6-b200 run (2026-08-15): first request 119.5s,
-              # an 18-minute JIT window, and an AIPerf report with TTFT max 340,349ms / p90 128,579ms
-              # against a p50 of 759ms - the aggregate columns are unusable while steady state is fine
-              # (0.148 req/s), and ITL p50 reads 146.77ms vs ~124-129ms warm. So "ignore the TTFT
-              # column" is not a workaround; the run has to START warm.
-              # DISAGG-SPECIFIC, from that same run: while one engine compiles the other blocks, and it
-              # lands on the KV handoff - 15x "No available shared memory broadcast block found in 60
-              # seconds" plus KV-transfer P90 spikes of 62-63s that stopped 9s after the last compile,
-              # then held 125-133ms (Avg post time never moved, 3.05-3.56ms: the fabric was healthy).
-              (
-                FE="http://${DEPLOYMENT_NAME}-frontend.${NAMESPACE}.svc.cluster.local:8000"
-                # Gate on THIS pod's dyn-system /health: the frontend answers /v1/models 200 long
-                # before the engine has loaded, so gating on the frontend alone fires the warmup at
-                # a dead engine and compiles nothing.
-                LH="http://localhost:${DOLLAR}{DYN_SYSTEM_PORT:-9092}/health"
-                WARMUP_CONCURRENCY=${DOLLAR}{WARMUP_CONCURRENCY:-10}
-                WARMUP_ENABLED=${DOLLAR}{WARMUP_ENABLED:-auto}
-                case "${DOLLAR}WARMUP_ENABLED" in
-                  auto) case "${MODEL_NAME}" in
-                          *NVFP4*|*nvfp4*) : ;;
-                          *) echo "[warmup] ${MODEL_NAME} is not NVFP4; warmup not needed, skipping (non-fatal)"; exit 0 ;;
-                        esac ;;
-                  0|false|no) echo "[warmup] WARMUP_ENABLED=${DOLLAR}WARMUP_ENABLED; skipping (non-fatal)"; exit 0 ;;
-                esac
-                if ! command -v curl >/dev/null 2>&1; then
-                  echo "[warmup] curl not present; skipping cold-start warmup (non-fatal)"
-                else
-                  warmed=0
-                  for i in ${DOLLAR}(seq 1 360); do
-                    if curl -sf -o /dev/null --max-time 5 "${DOLLAR}LH" 2>/dev/null \
-                       && curl -sf --max-time 5 "${DOLLAR}FE/v1/models" 2>/dev/null | grep -q "${MODEL_NAME}"; then
-                      echo "[warmup] engine ready (own /health 200 + model registered); priming batch=1 Mamba decode kernel (one-time JIT, ~4min)"
-                      curl -s -o /dev/null --max-time 900 "${DOLLAR}FE/v1/completions" \
-                        -H 'Content-Type: application/json' \
-                        -d "{\"model\":\"${MODEL_NAME}\",\"prompt\":\"warmup\",\"max_tokens\":4,\"temperature\":0}" \
-                        && echo "[warmup] batch=1 warm; priming concurrent batch buckets 1..${DOLLAR}WARMUP_CONCURRENCY" \
-                        || echo "[warmup] batch=1 warmup returned non-zero (non-fatal)"
-                      for j in ${DOLLAR}(seq 1 "${DOLLAR}WARMUP_CONCURRENCY"); do
-                        curl -s -o /dev/null --max-time 900 "${DOLLAR}FE/v1/completions" \
-                          -H 'Content-Type: application/json' \
-                          -d "{\"model\":\"${MODEL_NAME}\",\"prompt\":\"warmup\",\"max_tokens\":4,\"temperature\":0}" &
+      # v1beta1 replaces the manual dshm emptyDir with this: the operator mounts the
+      # tmpfs at /dev/shm itself (default 8Gi), so also declaring our own volume at
+      # that path would give the pod a duplicate mountPath and the webhook rejects it.
+      sharedMemorySize: 64Gi
+      podTemplate:
+        spec:
+          nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_WORKER} }
+          tolerations:
+            - { key: nvidia.com/gpu, operator: Exists, effect: NoSchedule }
+            - { key: vpc.amazonaws.com/efa, operator: Exists, effect: NoSchedule }
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector: { matchLabels: { app.kubernetes.io/part-of: ${DEPLOYMENT_NAME} } }
+                  topologyKey: kubernetes.io/hostname
+          volumes:
+            # v1beta1 has no top-level spec.pvcs; reference the pre-existing claim natively.
+            - { name: fsx-pvc, persistentVolumeClaim: { claimName: fsx-pvc } }
+            - { name: gdrdrv,  hostPath: { path: /dev/gdrdrv, type: CharDevice } }
+          containers:
+            # The operator injects its defaults (image, command, env, ports, probes,
+            # resources, volume mounts) into the container named "main" and merges these
+            # overrides by name. Any other container here is a user-managed sidecar.
+            - name: main
+              resources:
+                requests:
+                  cpu: "${CPU_PER_WORKER}"
+                  memory: "1000Gi"
+                  nvidia.com/gpu: "${GPU_PER_WORKER}"
+                  vpc.amazonaws.com/efa: "${EFA_PER_WORKER}"
+                limits:
+                  cpu: "${CPU_PER_WORKER}"
+                  memory: "1000Gi"
+                  nvidia.com/gpu: "${GPU_PER_WORKER}"
+                  vpc.amazonaws.com/efa: "${EFA_PER_WORKER}"
+              image: ${REGISTRY}${IMAGE}${TAG}
+              imagePullPolicy: Always
+              securityContext: { capabilities: { add: ["IPC_LOCK"] } }
+              command: ["/bin/bash", "-c"]
+              args:
+                - |-
+                  set -u
+                  unset HPCX_DIR HPCX_MPI_DIR HPCX_HOME HPCX_UCX_DIR HPCX_SHARP_DIR \
+                        HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
+                  if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+                  # ---- Node-fault preflight: duplicate pod address (podIP == hostIP) ----
+                  # The CNI can hand this sandbox the node's own kubelet InternalIP; cluster DNS then
+                  # never answers for the pod, so NATS/etcd are unreachable. A container RESTART CANNOT
+                  # CLEAR IT (restarts reuse the sandbox, CNI ADD is not re-invoked) - the pod object has
+                  # to be deleted. Measured 2026-08-15 on a 4-node ml.p6-b200.48xlarge cluster: all four
+                  # nodes carry their own InternalIP inside their ipamd assignable pool, so ANY
+                  # hostNetwork:false pod here can draw it. Mechanism + incident: disagg/lws-2pp.yaml-template.
+                  if [ -n "${DOLLAR}{POD_IP:-}" ] && [ "${DOLLAR}{POD_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
+                    echo "[decode] FATAL: pod IP ${DOLLAR}POD_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                    echo "[decode]        Cluster DNS cannot answer for this pod, so NATS/etcd are unreachable."
+                    echo "[decode]        RESTARTING WILL NOT HELP - the sandbox keeps the address. Remedy:"
+                    echo "[decode]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                    exit 1
+                  fi
+                  # Cold-start warmup (detached). A fresh pod's FIRST request pays a one-time ~4min
+                  # Triton JIT compiling the Mamba DECODE kernels (_selective_scan_update,
+                  # _causal_conv1d_update): startup only warms the PREFILL SSD path, and
+                  # --enforce-eager skips cudagraph capture, not JIT. Measured on a 2-node disagg pair
+                  # with this block as the only variable: first request 7,782ms -> 1,172ms (6.6x),
+                  # total benchmark wall -24.7%, steady state within 2%. Concurrency is a Triton
+                  # compile key on the decode path (_causal_conv1d_update: seqlen / state_len /
+                  # NP2_STATELEN / strides are tl.constexpr), hence bs=1 first
+                  # then a concurrent burst of WARMUP_CONCURRENCY. NVFP4-only by default
+                  # (WARMUP_ENABLED=auto keys off the served model's precision suffix); see .env for
+                  # the knobs and lws-pp2.yaml-template for the long-form rationale. Shares the pod, never
+                  # blocks the engine launch, swallows every error so it cannot crash the pod.
+                  # The frontend Service name is the operator-generated ${DEPLOYMENT_NAME}-frontend,
+                  # the same name ../test/.env resolves for this manifest type.
+                  # ALSO measured UNWARMED on a live NVFP4 p6-b200 run (2026-08-15): first request 119.5s,
+                  # an 18-minute JIT window, and an AIPerf report with TTFT max 340,349ms / p90 128,579ms
+                  # against a p50 of 759ms - the aggregate columns are unusable while steady state is fine
+                  # (0.148 req/s), and ITL p50 reads 146.77ms vs ~124-129ms warm. So "ignore the TTFT
+                  # column" is not a workaround; the run has to START warm.
+                  # DISAGG-SPECIFIC, from that same run: while one engine compiles the other blocks, and it
+                  # lands on the KV handoff - 15x "No available shared memory broadcast block found in 60
+                  # seconds" plus KV-transfer P90 spikes of 62-63s that stopped 9s after the last compile,
+                  # then held 125-133ms (Avg post time never moved, 3.05-3.56ms: the fabric was healthy).
+                  (
+                    FE="http://${DEPLOYMENT_NAME}-frontend.${NAMESPACE}.svc.cluster.local:8000"
+                    # Gate on THIS pod's dyn-system /health: the frontend answers /v1/models 200 long
+                    # before the engine has loaded, so gating on the frontend alone fires the warmup at
+                    # a dead engine and compiles nothing.
+                    LH="http://localhost:${DOLLAR}{DYN_SYSTEM_PORT:-9092}/health"
+                    WARMUP_CONCURRENCY=${DOLLAR}{WARMUP_CONCURRENCY:-10}
+                    WARMUP_ENABLED=${DOLLAR}{WARMUP_ENABLED:-auto}
+                    case "${DOLLAR}WARMUP_ENABLED" in
+                      auto) case "${MODEL_NAME}" in
+                              *NVFP4*|*nvfp4*) : ;;
+                              *) echo "[warmup] ${MODEL_NAME} is not NVFP4; warmup not needed, skipping (non-fatal)"; exit 0 ;;
+                            esac ;;
+                      0|false|no) echo "[warmup] WARMUP_ENABLED=${DOLLAR}WARMUP_ENABLED; skipping (non-fatal)"; exit 0 ;;
+                    esac
+                    if ! command -v curl >/dev/null 2>&1; then
+                      echo "[warmup] curl not present; skipping cold-start warmup (non-fatal)"
+                    else
+                      warmed=0
+                      for i in ${DOLLAR}(seq 1 360); do
+                        if curl -sf -o /dev/null --max-time 5 "${DOLLAR}LH" 2>/dev/null \
+                           && curl -sf --max-time 5 "${DOLLAR}FE/v1/models" 2>/dev/null | grep -q "${MODEL_NAME}"; then
+                          echo "[warmup] engine ready (own /health 200 + model registered); priming batch=1 Mamba decode kernel (one-time JIT, ~4min)"
+                          curl -s -o /dev/null --max-time 900 "${DOLLAR}FE/v1/completions" \
+                            -H 'Content-Type: application/json' \
+                            -d "{\"model\":\"${MODEL_NAME}\",\"prompt\":\"warmup\",\"max_tokens\":4,\"temperature\":0}" \
+                            && echo "[warmup] batch=1 warm; priming concurrent batch buckets 1..${DOLLAR}WARMUP_CONCURRENCY" \
+                            || echo "[warmup] batch=1 warmup returned non-zero (non-fatal)"
+                          for j in ${DOLLAR}(seq 1 "${DOLLAR}WARMUP_CONCURRENCY"); do
+                            curl -s -o /dev/null --max-time 900 "${DOLLAR}FE/v1/completions" \
+                              -H 'Content-Type: application/json' \
+                              -d "{\"model\":\"${MODEL_NAME}\",\"prompt\":\"warmup\",\"max_tokens\":4,\"temperature\":0}" &
+                          done
+                          wait
+                          echo "[warmup] concurrent batch buckets warm; benchmark opening will be fast"
+                          warmed=1
+                          break
+                        fi
+                        sleep 5
                       done
-                      wait
-                      echo "[warmup] concurrent batch buckets warm; benchmark opening will be fast"
-                      warmed=1
-                      break
+                      # Fail LOUD if the gate never opened (still non-fatal to the pod): falling out of
+                      # this loop silently is indistinguishable from "warmed up fine", and the next
+                      # benchmark would quietly pay the JIT tax again.
+                      [ "${DOLLAR}warmed" = 1 ] || echo "[warmup] gave up after 30min waiting for ${DOLLAR}LH 200 + ${MODEL_NAME} in ${DOLLAR}FE/v1/models; the FIRST benchmark requests will pay the Mamba JIT (non-fatal)"
                     fi
-                    sleep 5
-                  done
-                  # Fail LOUD if the gate never opened (still non-fatal to the pod): falling out of
-                  # this loop silently is indistinguishable from "warmed up fine", and the next
-                  # benchmark would quietly pay the JIT tax again.
-                  [ "${DOLLAR}warmed" = 1 ] || echo "[warmup] gave up after 30min waiting for ${DOLLAR}LH 200 + ${MODEL_NAME} in ${DOLLAR}FE/v1/models; the FIRST benchmark requests will pay the Mamba JIT (non-fatal)"
-                fi
-              ) &
-              exec python3 -m dynamo.vllm \
-                --model ${MODEL_PATH} \
-                --served-model-name ${MODEL_NAME} \
-                --tensor-parallel-size ${GPU_PER_WORKER} --pipeline-parallel-size 1 \
-                --max-model-len 4096 --gpu-memory-utilization 0.97 --enforce-eager \
-                --trust-remote-code ${MAMBA_FLAGS} \
-                --load-format runai_streamer \
-                --disaggregation-mode decode \
-                --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"],"kv_lease_duration":${KV_LEASE_DURATION}}}'
-          env:
-            # Read only by the duplicate-address preflight in args above.
-            - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
-            - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
-            - { name: DYN_SYSTEM_ENABLED, value: "true" }
-            - { name: DYN_SYSTEM_PORT, value: "9092" }
-            # The warmer above reads these INSIDE the container, so they have to be passed
-            # through here - without these two lines the knobs in .env are inert and the ladder
-            # is always 1..10 no matter what you set in your shell.
-            - { name: WARMUP_ENABLED, value: "${WARMUP_ENABLED}" }
-            - { name: WARMUP_CONCURRENCY, value: "${WARMUP_CONCURRENCY}" }
-            # Raise the execute_model RPC deadline (default 300s) so a JIT-heavy first concurrent
-            # decode step cannot trip it and kill EngineCore ("RPC call to execute_model timed
-            # out" -> EngineDeadError).
-            - { name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS, value: "1800" }
-            - { name: VLLM_LOGGING_LEVEL, value: INFO }
-            - { name: VLLM_SSM_CONV_STATE_LAYOUT, value: DS }
-            - { name: FLASHINFER_DISABLE_VERSION_CHECK, value: "1" }
-            - { name: FI_PROVIDER, value: efa }
-            - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
-            - { name: FI_EFA_FORK_SAFE, value: "1" }
-            - { name: FI_HMEM_CUDA_USE_DMABUF, value: "1" }
-            - { name: FI_EFA_ENABLE_SHM, value: "0" }
-            - { name: FI_EFA_ENABLE_SHM_TRANSFER, value: "0" }
-            - { name: NIXL_LIBFABRIC_MAX_RAILS, value: "1" }
-            - { name: NIXL_SKIP_TOPOLOGY_CHECK, value: "1" }
-            - { name: NCCL_NET_PLUGIN, value: ofi }
-            - { name: NCCL_TUNER_PLUGIN, value: ofi }
-            - { name: OFI_NCCL_FORCE_NUM_RAILS, value: "4" }
-          ports: [{ containerPort: 9092, name: system }]
-          startupProbe:
-            httpGet: { path: /health, port: 9092 }
-            periodSeconds: 30
-            timeoutSeconds: 10
-            failureThreshold: 240
-          volumeMounts:
-            - { name: dshm,       mountPath: /dev/shm }
-            - { name: gdrdrv,     mountPath: /dev/gdrdrv }
+                  ) &
+                  exec python3 -m dynamo.vllm \
+                    --model ${MODEL_PATH} \
+                    --served-model-name ${MODEL_NAME} \
+                    --tensor-parallel-size ${GPU_PER_WORKER} --pipeline-parallel-size 1 \
+                    --max-model-len 4096 --gpu-memory-utilization 0.97 --enforce-eager \
+                    --trust-remote-code ${MAMBA_FLAGS} \
+                    --load-format runai_streamer \
+                    --disaggregation-mode decode \
+                    --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"],"kv_lease_duration":${KV_LEASE_DURATION}}}'
+              env:
+                # Read only by the duplicate-address preflight in args above.
+                - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+                - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
+                - { name: DYN_SYSTEM_ENABLED, value: "true" }
+                - { name: DYN_SYSTEM_PORT, value: "9092" }
+                # The warmer above reads these INSIDE the container, so they have to be passed
+                # through here - without these two lines the knobs in .env are inert and the ladder
+                # is always 1..10 no matter what you set in your shell.
+                - { name: WARMUP_ENABLED, value: "${WARMUP_ENABLED}" }
+                - { name: WARMUP_CONCURRENCY, value: "${WARMUP_CONCURRENCY}" }
+                # Raise the execute_model RPC deadline (default 300s) so a JIT-heavy first concurrent
+                # decode step cannot trip it and kill EngineCore ("RPC call to execute_model timed
+                # out" -> EngineDeadError).
+                - { name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS, value: "1800" }
+                - { name: VLLM_LOGGING_LEVEL, value: INFO }
+                - { name: VLLM_SSM_CONV_STATE_LAYOUT, value: DS }
+                - { name: FLASHINFER_DISABLE_VERSION_CHECK, value: "1" }
+                - { name: FI_PROVIDER, value: efa }
+                - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
+                - { name: FI_EFA_FORK_SAFE, value: "1" }
+                - { name: FI_HMEM_CUDA_USE_DMABUF, value: "1" }
+                - { name: FI_EFA_ENABLE_SHM, value: "0" }
+                - { name: FI_EFA_ENABLE_SHM_TRANSFER, value: "0" }
+                - { name: NIXL_LIBFABRIC_MAX_RAILS, value: "1" }
+                - { name: NIXL_SKIP_TOPOLOGY_CHECK, value: "1" }
+                - { name: NCCL_NET_PLUGIN, value: ofi }
+                - { name: NCCL_TUNER_PLUGIN, value: ofi }
+                - { name: OFI_NCCL_FORCE_NUM_RAILS, value: "4" }
+              ports: [{ containerPort: 9092, name: system }]
+              startupProbe:
+                httpGet: { path: /health, port: 9092 }
+                periodSeconds: 30
+                timeoutSeconds: 10
+                failureThreshold: 240
+              volumeMounts:
+                - { name: fsx-pvc, mountPath: /shared }
+                - { name: gdrdrv,  mountPath: /dev/gdrdrv }


### PR DESCRIPTION
## Why

Applying either DGD now produces:

```
Warning: nvidia.com/v1alpha1 DynamoGraphDeployment is deprecated; use nvidia.com/v1beta1 DynamoGraphDeployment
```

This moves `agg/dgd.yaml-template` and `disagg/dgd.yaml-template` onto `v1beta1` so the deployment stops exercising the deprecated path.

## What changed

`v1beta1` is a **different schema, not a rename**, so this is a real translation rather than an `apiVersion` bump:

| v1alpha1 | v1beta1 |
|---|---|
| `spec.envs` | `spec.env` |
| `spec.pvcs` | removed — claims referenced natively in `podTemplate.spec.volumes` |
| `spec.services` (map name→spec) | `spec.components` (list keyed on `name`) |
| `componentType` + `subComponentType` | `type` (`prefill`/`decode` are first-class enum values) |
| `resources`, `volumeMounts`, `extraPodSpec` + the other per-component pod-config fields | ONE `podTemplate` (a real `PodTemplateSpec`) |
| `resources.requests.gpu`, `.custom.*` | `nvidia.com/gpu`, `.custom.*` promoted to sibling keys |
| `volumeMounts[].mountPoint` | `volumeMounts[].mountPath` |
| the manual `dshm` emptyDir | `sharedMemorySize: 64Gi` |

Two of those have teeth:

- **The `main` container.** The operator injects its defaults (image, command, env, ports, probes, resources, mounts) into the container *named* `main` and strategic-merges these overrides by name. Any other container in `podTemplate` is a user-managed sidecar.
- **`sharedMemorySize` forces dropping the manual `dshm` volume.** With it set the operator mounts the tmpfs at `/dev/shm` itself, so *also* declaring our own volume at that path gives the pod a duplicate `mountPath` and the webhook rejects it. The volume and its mount had to go, not just be renamed.

## No operator upgrade needed

The DGD CRD is **byte-identical** in platform `1.3.0` (what this deployment targets) and `1.3.1` — same md5. Both serve `v1alpha1` (storage, deprecated) and `v1beta1`, conversion strategy `Webhook`.

## Verification (read-only)

`kubectl apply --dry-run=server` persists nothing and runs no controller, so this stayed non-mutating against a live 1.3.1 operator:

- **All four manifests accepted.** The deprecation warning appears on `v1alpha1` and is **absent** on `v1beta1`.
- **Conversion round-trip is lossless.** Since `v1alpha1` is still the storage version, a `v1beta1` apply is converted down and back by the conversion webhook. Diffing the returned object against the input: **0 fields dropped, 0 changed.** The only additions are API-server defaulting (`ports[].protocol: TCP`, `uid`/`generation`) and the operator's own `nvidia.com/dynamo-operator-origin-version: 1.3.1` annotation.
- **The container scripts are untouched.** All five bash bodies are byte-identical to the v1alpha1 originals after reindentation (1169 / 5641 / 6373 / 1856 chars), and the rendered argv agrees flag-for-flag:

  | component | argv readback |
  |---|---|
  | agg `VllmWorker` | `tp=8 pp=1 util=0.97` kv=no, 10 flags |
  | disagg `VllmPrefillWorker` | `role=prefill tp=8 pp=1 util=0.97` kv=**yes**, 13 flags |
  | disagg `VllmDecodeWorker` | `role=decode tp=8 pp=1 util=0.97` kv=**yes**, 13 flags |

## What is NOT verified

**Reconciliation.** The operator fills in the `main` container in its controller, not at admission, so a clean server dry-run proves the API server accepts these objects — it does **not** prove the pods come up. That needs a real apply on a cluster with the model weights staged.
