### PR TITLE
nemotron/ultra/test: warm up before every aiperf run, not only NVFP4 ones

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/test/test-aiperf.sh
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/test/test-aiperf.sh
@@ -21,17 +21,35 @@ kubectl wait --for=condition=Ready pod/do-aiperf --timeout=120s
 # window on that run admitted ~31 requests = 3 full waves at --concurrency 10.
 # The manifest-side warmer already primes the engine at pod start, so this is normally a
 # no-op; it is what makes the benchmark reproducible when the pods ARE cold.
-# auto (default) follows the model's precision suffix. AIPERF_WARMUP_REQUESTS=0 disables,
-# any integer overrides. Same idiom as WARMUP_ENABLED in the manifests.
+#
+# This used to be precision-gated -- auto meant 30 for NVFP4 and 0 for everything else,
+# on the reasoning that only the NVFP4 checkpoint pulls in the extra JIT. A BF16 run
+# refutes that gate: BF16 disagg/lws-ep on p6-b200 (2026-08-17T06:01:40Z, 100 requests,
+# ISL 1024 / OSL 512, --concurrency 10) reported TTFT p95 57,264ms / p99 57,401ms /
+# max 57,627ms against a p50 of 704ms. Per-request records place the whole penalty in the
+# opening concurrency wave -- the 10 requests issued at t=0 took 40.1-57.6s to first token
+# and the remaining 90 took 0.60-1.38s -- so it is a cold-engine cost, and an EXCLUDED
+# warmup phase is exactly what keeps it out of the report. It is also TTFT-only: those 10
+# requests' ITL p50 was 114.89ms against 114.58ms for the other 90, which is why the
+# warmup changes what the tail columns mean without moving the p50s (measured: TTFT p50
+# 704.28 -> 703.28, ITL p50 114.58 -> 114.58, i.e. under 0.2%).
+# 30 is kept rather than 10 (one wave was enough on that run) because 30 is the count
+# already validated on NVFP4 and one constant is easier to reason about than two.
+# Cost is wall-clock only: 30 excluded requests at --concurrency 10 add ~3 waves, ~180s
+# on that ~650s run. What it does NOT fix is a hold that RECURS mid-run: the NVFP4
+# lws-ep run of 2026-08-16 had 8 slow requests at t=224-261s, well past any warmup.
+# AIPERF_WARMUP_REQUESTS=0 disables, any integer overrides. Same idiom as WARMUP_ENABLED
+# in the manifests -- note that one is still precision-gated, and gates the in-pod warmer,
+# not the report.
 export AIPERF_WARMUP_REQUESTS="${AIPERF_WARMUP_REQUESTS:-auto}"
 case "${AIPERF_WARMUP_REQUESTS}" in
-  auto) case "${MODEL_NAME}" in *NVFP4*|*nvfp4*) _WARMUP_COUNT=30 ;; *) _WARMUP_COUNT=0 ;; esac ;;
+  auto) _WARMUP_COUNT=30 ;;
   *)    _WARMUP_COUNT="${AIPERF_WARMUP_REQUESTS}" ;;
 esac
 _WARMUP_ARG=""
 if [ "${_WARMUP_COUNT}" -gt 0 ] 2>/dev/null; then
   _WARMUP_ARG="--warmup-request-count ${_WARMUP_COUNT}"
-  echo "NVFP4 model detected: adding ${_WARMUP_ARG} (excluded from the report)"
+  echo "Adding ${_WARMUP_ARG} (a separate phase, excluded from the report)"
 fi
 
 # Artifact directory. ${MODEL_PATH}/aiperf/${DEPLOYMENT_TYPE} alone is not unique per run:


### PR DESCRIPTION
`AIPERF_WARMUP_REQUESTS=auto` resolved to **30 for an NVFP4 model and 0 for everything else**. I added that gate on the reasoning that the cold-engine tax is an NVFP4 property (the NVFP4 checkpoint pulls in more Mamba JIT). A BF16 run on p6-b200 refutes it, so this drops the precision branch: `auto` is now 30 for every model.

## The measurement that refutes the gate

BF16 `disagg/lws-ep`, `2026-08-17T06:01:40Z`, 100 requests, ISL 1024 / OSL 512, `--concurrency 10`, aiperf 0.9.0, `benchmark_id 56f13fa763da`:

| TTFT | ms |
|---|---|
| p50 | 704.28 |
| p90 | 5247.12 |
| p95 | 57264.31 |
| p99 | 57400.63 |
| max | 57626.52 |

The per-request records (`profile_export.jsonl`) place the entire penalty in the **opening concurrency wave**:

- the 10 requests issued at `t=0` took **40.1-57.6 s** to first token;
- the remaining 90 took **0.60-1.38 s**, and none after `t=1 s` exceeded 1.38 s.

That is a cold engine inside the measured sample — exactly what a separate, **excluded** warmup phase exists to remove.

## Why it changes the tail without moving the headline

The cost is TTFT-only. The opening wave's ITL p50 is **114.89 ms** against **114.58 ms** for the other 90 requests, so dropping the wave moves:

- TTFT p50 `704.28 -> 703.28 ms`
- ITL p50 `114.58 -> 114.58 ms`

Under 0.2% on both. What changes is that `p95/p99/max` stop describing 10 cold requests and start describing the deployment.

## Why 30 and not 10

One wave would have been enough on this run. 30 is kept because it is the count already validated against the NVFP4 JIT window, and one constant is easier to reason about than two. The cost is wall-clock only — 30 excluded requests at `--concurrency 10` is ~3 waves, **~180 s on that ~650 s run**.

## Scope, so it is not oversold

This removes a cold **opening** wave. It does not fix a hold that **recurs mid-run**: the NVFP4 `lws-ep` run of 2026-08-16 had 8 slow requests at `t=224-261 s`, long past any warmup phase. That one is still unexplained and is not what this PR claims to address.

`WARMUP_ENABLED` in the manifests is deliberately left precision-gated — it gates the in-pod warmer, not what lands in the report, and its skip is non-fatal.

## Verification

- `bash -n test-aiperf.sh`
- the `case` block exercised for `AIPERF_WARMUP_REQUESTS=auto / 0 / 12 / bogus / unset` -> `30 / 0 / 12 / 0 / 30`, with `run-meta.json`'s `warmup_requests` staying valid JSON in every case (`30`, `0`, `12`, `"bogus"`, `30`).
- No change to any other flag in the `aiperf profile` command line.
