### PR TITLE
eks/deployment: dynamo 1.4.0 default + standalone grove/kai deploy scripts

### DIFF
--- a/Container-Root/eks/deployment/grove/deploy.sh
+++ b/Container-Root/eks/deployment/grove/deploy.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# Deploy NVIDIA Grove (multinode orchestration via PodCliqueSets) and the KAI scheduler
+# (gang scheduling) as STANDALONE releases, then enable Grove integration on an existing
+# Dynamo platform release if one is present.
+# Refs: https://github.com/ai-dynamo/grove  https://github.com/NVIDIA/KAI-Scheduler
+#
+# Installed separately (not via the dynamo-platform bundled subcharts) per the chart's own
+# guidance: "For production environments, it is recommended to install Grove separately."
+# Versions default to the pair the dynamo-platform 1.4.0 Chart.lock ships, so the combination
+# is the one NVIDIA tests together. Override with GROVE_VERSION / KAI_VERSION.
+
+export GROVE_NAMESPACE=${GROVE_NAMESPACE:-grove-system}
+export GROVE_VERSION=${GROVE_VERSION:-"v0.1.0-alpha.12-rc1"}
+export KAI_NAMESPACE=${KAI_NAMESPACE:-kai-scheduler}
+export KAI_VERSION=${KAI_VERSION:-"v0.13.4"}
+export DYNAMO_NAMESPACE=${DYNAMO_NAMESPACE:-dynamo-system}
+
+# 1. KAI scheduler first: Grove PodGangs schedule best with gang scheduling available.
+helm upgrade --install kai-scheduler oci://ghcr.io/kai-scheduler/kai-scheduler/kai-scheduler \
+    --version "$KAI_VERSION" --namespace "$KAI_NAMESPACE" --create-namespace -f values-kai.yaml
+
+# 2. Grove operator (grove.io + scheduler.grove.io CRDs ship in the chart's crds/ dir and
+#    install with it).
+helm upgrade --install grove oci://ghcr.io/ai-dynamo/grove/grove-charts \
+    --version "$GROVE_VERSION" --namespace "$GROVE_NAMESPACE" --create-namespace -f values-grove.yaml
+
+kubectl -n "$KAI_NAMESPACE" wait pods --all --for=condition=Ready --timeout=300s
+kubectl -n "$GROVE_NAMESPACE" rollout status deploy/grove-operator --timeout=300s
+
+# 3. If a Dynamo platform release exists, flip its Grove/KAI integration on so the Dynamo
+#    operator creates PodCliqueSets for multinode DynamoGraphDeployments. The chart version is
+#    read from the live release so this never moves the platform version. Safe to re-run.
+DYNAMO_CHART_VERSION=$(helm list -n "$DYNAMO_NAMESPACE" -f '^dynamo-platform$' -o json 2>/dev/null \
+    | python3 -c 'import sys,json; r=json.load(sys.stdin); print(r[0]["chart"].removeprefix("dynamo-platform-") if r else "")')
+if [ -n "$DYNAMO_CHART_VERSION" ]; then
+    echo "Enabling Grove + KAI integration on dynamo-platform-$DYNAMO_CHART_VERSION in $DYNAMO_NAMESPACE ..."
+    helm upgrade dynamo-platform \
+        "https://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/dynamo-platform-${DYNAMO_CHART_VERSION}.tgz" \
+        -n "$DYNAMO_NAMESPACE" --reuse-values \
+        --set global.grove.enabled=true \
+        --set global.kai-scheduler.enabled=true
+    kubectl -n "$DYNAMO_NAMESPACE" rollout status deploy/dynamo-platform-dynamo-operator-controller-manager --timeout=300s
+else
+    echo "No dynamo-platform release in $DYNAMO_NAMESPACE - skipping integration flip."
+    echo "After deploying Dynamo, re-run this script or set global.grove.enabled=true on that release."
+fi
+
+echo ""
+echo "Grove CRDs:"
+kubectl get crd | grep -E "grove.io"
+echo ""
+echo "KAI CRDs:"
+kubectl get crd | grep -E "kai.scheduler|scheduling.run.ai"
+echo ""
+kubectl -n "$GROVE_NAMESPACE" get pods
+kubectl -n "$KAI_NAMESPACE" get pods

--- a/Container-Root/eks/deployment/grove/remove.sh
+++ b/Container-Root/eks/deployment/grove/remove.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Remove Grove and the KAI scheduler and return the cluster to its pre-deploy state.
+# Counterpart of ./deploy.sh.
+
+export GROVE_NAMESPACE=${GROVE_NAMESPACE:-grove-system}
+export KAI_NAMESPACE=${KAI_NAMESPACE:-kai-scheduler}
+export DYNAMO_NAMESPACE=${DYNAMO_NAMESPACE:-dynamo-system}
+
+# 1. Flip Grove/KAI integration off on the Dynamo platform first, so the Dynamo operator stops
+#    reconciling PodCliqueSets before their CRDs disappear.
+DYNAMO_CHART_VERSION=$(helm list -n "$DYNAMO_NAMESPACE" -f '^dynamo-platform$' -o json 2>/dev/null \
+    | python3 -c 'import sys,json; r=json.load(sys.stdin); print(r[0]["chart"].removeprefix("dynamo-platform-") if r else "")')
+if [ -n "$DYNAMO_CHART_VERSION" ]; then
+    helm upgrade dynamo-platform \
+        "https://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/dynamo-platform-${DYNAMO_CHART_VERSION}.tgz" \
+        -n "$DYNAMO_NAMESPACE" --reuse-values \
+        --set global.grove.enabled=false \
+        --set global.kai-scheduler.enabled=false
+    kubectl -n "$DYNAMO_NAMESPACE" rollout status deploy/dynamo-platform-dynamo-operator-controller-manager --timeout=300s
+fi
+
+# 2. Delete Grove custom resources first so finalizers run while the Grove operator is alive.
+for CRD in $(kubectl get crd -o name | grep -E "grove.io"); do
+    RESOURCE=$(basename $CRD | cut -d. -f1)
+    kubectl delete $RESOURCE --all -A --ignore-not-found --timeout=120s
+done
+
+# 3. Uninstall both releases.
+helm delete grove -n "$GROVE_NAMESPACE" --ignore-not-found
+helm delete kai-scheduler -n "$KAI_NAMESPACE" --ignore-not-found
+
+# 4. Delete the CRDs (helm leaves chart-crds/ CRDs behind by design). Grove groups: grove.io +
+#    scheduler.grove.io. KAI groups: kai.scheduler + scheduling.run.ai.
+kubectl get crd -o name | grep -E "grove.io|kai.scheduler|scheduling.run.ai" | xargs -r kubectl delete
+
+# 5. Namespaces.
+kubectl delete namespace "$GROVE_NAMESPACE" --ignore-not-found --timeout=120s
+kubectl delete namespace "$KAI_NAMESPACE" --ignore-not-found --timeout=120s
+
+# 6. Verify zero residue - all of the following should print nothing.
+echo ""
+echo "Verifying removal (all of the following should be empty):"
+kubectl get crd | grep -E "grove.io|kai.scheduler|scheduling.run.ai"
+kubectl get namespace "$GROVE_NAMESPACE" 2>/dev/null
+kubectl get namespace "$KAI_NAMESPACE" 2>/dev/null
+helm list -A 2>/dev/null | grep -E "^grove|^kai-scheduler"
+echo "Done."

--- a/Container-Root/eks/deployment/grove/values-grove.yaml
+++ b/Container-Root/eks/deployment/grove/values-grove.yaml
@@ -1,0 +1,13 @@
+# Values for the standalone Grove operator release (chart: ghcr.io/ai-dynamo/grove/grove-charts).
+# Chart defaults are production-usable; only overrides that matter on EKS are surfaced here
+# (overridden further by custom-values.yaml if you keep one).
+
+# Grove operator replicas. Leader election is on by default in the chart, so >1 is safe.
+replicaCount: 1
+
+# Keep the operator off GPU nodes so it never competes with workload capacity.
+nodeSelector: {}
+tolerations: []
+
+# Webhook certificates are self-provisioned by the operator (certProvisionMode: auto in the
+# chart). No cert-manager dependency.

--- a/Container-Root/eks/deployment/grove/values-kai.yaml
+++ b/Container-Root/eks/deployment/grove/values-kai.yaml
@@ -1,0 +1,26 @@
+# Values for the standalone KAI scheduler release (chart: ghcr.io/kai-scheduler/kai-scheduler).
+# Chart defaults are production-usable; only overrides that matter on EKS are surfaced here
+# (overridden further by custom-values.yaml if you keep one).
+
+global:
+  # Keep scheduler components off GPU nodes so they never compete with workload capacity.
+  nodeSelector: {}
+  tolerations: []
+
+  # GPU sharing (fractional GPU) is off: Dynamo workloads request whole GPUs.
+  gpuSharing: false
+
+  # Enable when the cluster runs a node autoscaler (Karpenter / cluster-autoscaler) so KAI
+  # marks unschedulable pods for scale-up instead of holding them.
+  clusterAutoscaling: false
+
+# The chart's pre-install topology-migration hook copies Kueue Topology CRs into KAI Topology
+# CRs. On clusters where Kueue is installed WITH existing Topology objects the hook job can
+# fail its backoff (configmap hook-ordering mount race on first attempt) and mark the whole
+# release failed. Migration is optional and idempotent, so keep it out of the install path and
+# run it by hand when wanted:
+#   for T in $(kubectl get topologies.kueue.x-k8s.io -o name); do
+#     kubectl get $T -o go-template='apiVersion: kai.scheduler/v1{{"\n"}}kind: Topology{{"\n"}}metadata:{{"\n"}}  name: {{.metadata.name}}{{"\n"}}spec:{{"\n"}}  levels:{{"\n"}}{{range .spec.levels}}  - nodeLabel: "{{.nodeLabel}}"{{"\n"}}{{end}}' | kubectl apply -f -
+#   done
+topologyMigration:
+  enabled: false

--- a/Container-Root/eks/deployment/nvidia-dynamo/deploy.sh
+++ b/Container-Root/eks/deployment/nvidia-dynamo/deploy.sh
@@ -8,7 +8,7 @@
 # In-place upgrades are not supported (etcd 3.5->3.6 data-dir and kai-scheduler CRD conflicts).
 
 export DYNAMO_NAMESPACE=${DYNAMO_NAMESPACE:-dynamo-system}
-export DYNAMO_VERSION=${DYNAMO_VERSION:-"1.3.1"}
+export DYNAMO_VERSION=${DYNAMO_VERSION:-"1.4.0"}
 
 # The 1.3.x operator reconciles PodSnapshot/PodSnapshotContent but the chart tarball does not
 # ship those two CRDs (they normally come from a crd-apply init container). Apply them from the

--- a/Container-Root/eks/deployment/nvidia-dynamo/values.yaml
+++ b/Container-Root/eks/deployment/nvidia-dynamo/values.yaml
@@ -122,8 +122,11 @@ dynamo-operator:
       image:
         # -- Official NVIDIA Dynamo operator image repository
         repository: "nvcr.io/nvidia/ai-dynamo/kubernetes-operator"
-        # -- Image tag (leave empty to use chart default)
-        tag: 1.3.1
+        # -- Image tag. Leave empty: the chart then uses its own appVersion, which is the
+        # only combination the chart guarantees (a pinned tag breaks when DYNAMO_VERSION moves —
+        # e.g. the 1.4.0 chart passes --operator-image, a flag the 1.3.1 manager binary lacks,
+        # and the operator CrashLoops with "flag provided but not defined").
+        tag: ""
         # -- Image pull policy - when to pull the image
         pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## What

Per the plan to retry Grove on the current Dynamo release (Slack, 2026-08-20):

**`nvidia-dynamo/`**
- `deploy.sh`: default `DYNAMO_VERSION` 1.3.1 → **1.4.0** (chart verified live on NGC helm; the podsnapshot CRD pre-apply loop confirmed working at the `v1.4.0` git tag).
- `values.yaml`: **unpin the operator image tag** (empty → chart appVersion). Root cause worth knowing: a pinned `1.3.1` tag under the 1.4.0 chart CrashLoops the operator — the 1.4.0 chart passes `--operator-image`, a flag the 1.3.1 manager binary does not define (`flag provided but not defined: -operator-image`). Empty tag is the only combination the chart guarantees across version moves.

**`grove/` (new)** — standalone Grove + KAI scheduler deploy/remove in the same `deploy.sh`/`remove.sh`/values pattern:
- Installs KAI (`oci://ghcr.io/kai-scheduler/kai-scheduler/kai-scheduler` v0.13.4) and Grove (`oci://ghcr.io/ai-dynamo/grove/grove-charts` v0.1.0-alpha.12-rc1) as separate releases — the platform chart's own NOTE recommends separate installs for production. Version defaults match the dynamo-platform-1.4.0 `Chart.lock` pair, so the combination is the one NVIDIA tests together.
- `deploy.sh` then flips `global.grove.enabled` + `global.kai-scheduler.enabled` on an existing `dynamo-platform` release (chart version read from the live release, so the platform version never moves); `remove.sh` flips them back before deleting CRDs, and has the same zero-residue verification as `nvidia-dynamo/remove.sh`.
- `values-kai.yaml` disables the chart's pre-install `topology-migration` hook: on a cluster with existing Kueue Topology CRs the hook job failed its backoff and marked the whole release `failed`. Migration is optional + idempotent; the manual one-liner is documented in the values file.

## Verified live (shared EKS cluster, ap-southeast-3, 2026-08-20)

1. `nvidia-dynamo/remove.sh` — full purge of the prior 1.3.1 platform, zero-residue checks pass (no nvidia.com dynamo/podsnapshot CRDs, namespace gone, no PVCs).
2. `DYNAMO_VERSION=1.4.0 nvidia-dynamo/deploy.sh` — operator, etcd, NATS all Ready; operator running `nvcr.io/nvidia/ai-dynamo/kubernetes-operator:1.4.0`; all 9 CRDs re-created.
3. `grove/deploy.sh` — grove-operator Running (grove.io + scheduler.grove.io CRDs installed), all 7 KAI components Running (operator, scheduler, admission, binder, pod-grouper, podgroup-controller, queue-controller), and the platform operator config now shows `grove: enabled: true` + `kaiScheduler: enabled: true`.

Next step (separate PR): agg/disagg manifests exercising Grove PodCliqueSets for multinode deployments.