### PR TITLE
nemotron/ultra: Grove-rendered DGD templates for agg (multinode) and disagg

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/.env
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/.env
@@ -11,7 +11,7 @@ export DOLLAR='$'
 export NAMESPACE=${NAMESPACE:-default}
 export DEPLOYMENT_NAME=${DEPLOYMENT_NAME:-nemotron3-ultra-550b-agg}
 
-# MANIFEST_TYPE=deployment|lws|lws-ep|dgd|dgd-v1beta1
+# MANIFEST_TYPE=deployment|lws|lws-ep|dgd|dgd-v1beta1|dgd-grove
 #   deployment : plain Deployment, 1 worker node, TP8/PP1 (simplest)
 #   lws        : LeaderWorkerSet, one engine TP8/PP2 across 2 nodes
 #   lws-ep     : EP16 aggregated - LWS DP2 x TP8 with --enable-expert-parallel (EP degree 16)
@@ -23,6 +23,12 @@ export DEPLOYMENT_NAME=${DEPLOYMENT_NAME:-nemotron3-ultra-550b-agg}
 #                "nvidia.com/v1alpha1 DynamoGraphDeployment is deprecated" warning, and to be
 #                ready for the operator release that flips the CRD's storage version. Keep
 #                benchmarking on ONE of the two within a single results table.
+#   dgd-grove  : MULTINODE aggregated - the lws engine shape (one engine, TP8 x PP
+#                NODE_COUNT_PER_WORKER across that many nodes) expressed as a v1beta1 DGD
+#                with multinode.nodeCount, rendered by the operator as a Grove PodCliqueSet
+#                and gang-scheduled by kai-scheduler. Needs Dynamo >= 1.4.0 platform AND
+#                ../../../grove (Grove + KAI) installed; see the template header for what
+#                is and is not yet validated on this path.
 # NONE of these disaggregate prefill from decode - that is ../disagg (every template there
 # carries --kv-transfer-config). lws-ep in particular is AGGREGATED wide-EP, so report its
 # numbers as AGGREGATED. ../disagg/.env offers the SAME NAME `lws-ep` for the DISAGGREGATED
@@ -44,6 +50,11 @@ export GPU_PER_WORKER=${GPU_PER_WORKER:-8}
 # it, do not assume it, or the GPU pods sit Pending on Insufficient vpc.amazonaws.com/efa:
 #   kubectl get node <node> -o jsonpath='{.status.allocatable.vpc\.amazonaws\.com/efa}{"\n"}'
 export EFA_PER_WORKER=${EFA_PER_WORKER:-16}
+
+# dgd-grove only: nodes per multinode worker group. The engine spans
+# NODE_COUNT_PER_WORKER full nodes as TP${GPU_PER_WORKER} x PP${NODE_COUNT_PER_WORKER}
+# (PP grows with the node count; TP stays inside the node).
+export NODE_COUNT_PER_WORKER=${NODE_COUNT_PER_WORKER:-2}
 
 # lws-ep only: data-parallel group size; EP degree = EP_DP_SIZE * GPU_PER_WORKER.
 # The model's expert count must be divisible by the EP degree (Nemotron-3-Ultra 512 experts

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/dgd-grove.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/dgd-grove.yaml-template
@@ -56,9 +56,13 @@
 #      slice got clean Libfabric init and then hung in the first cross-node
 #      collective. Grove-proven shape = whole nodes.
 #
-# /dev/shm: the dshm emptyDir below is carried AS-RUN from the proven Grove
-# smoke on the 1.4.0 operator. (The single-node dgd-v1beta1 template omits it
-# because the 1.3.x operator owned that mount; 1.4.0 merged ours cleanly.)
+# /dev/shm: sized via the component-level `sharedMemorySize` CRD field, NOT a
+# podTemplate dshm emptyDir. The 1.4.0 operator always manages its own tmpfs at
+# /dev/shm (CRD doc: nil = 8Gi default, "0" disables) and a podTemplate mount at
+# that path is silently dropped — the CRD field is the only reliable knob.
+# 64Gi was verified injected on Grove-rendered pods in the live 550B disagg run
+# (2026-08-20); TP${GPU_PER_WORKER} intra-node ranks move activations through
+# /dev/shm, so do not shrink it below the proven value for the 550B.
 #
 # =============================================================================
 ---
@@ -134,6 +138,9 @@ spec:
     - name: VllmWorker
       type: worker
       replicas: 1
+      # Operator-managed /dev/shm tmpfs (see header) — verified injected at this
+      # size on Grove-rendered pods in the live 550B disagg run.
+      sharedMemorySize: 64Gi
       multinode:
         nodeCount: ${NODE_COUNT_PER_WORKER}
       podTemplate:
@@ -154,9 +161,6 @@ spec:
                   topologyKey: kubernetes.io/hostname
           volumes:
             - { name: fsx-pvc, persistentVolumeClaim: { claimName: fsx-pvc } }
-            # AS-RUN in the proven Grove smoke; TP${GPU_PER_WORKER} intra-node ranks
-            # move activations through /dev/shm and the operator default is too small.
-            - { name: dshm, emptyDir: { medium: Memory, sizeLimit: 64Gi } }
           containers:
             - name: main
               image: ${REGISTRY}${IMAGE}${TAG}
@@ -223,7 +227,6 @@ spec:
               # thresholds — watch the first 550B run before trusting them.
               volumeMounts:
                 - { name: fsx-pvc, mountPath: /shared }
-                - { name: dshm, mountPath: /dev/shm }
               resources:
                 requests:
                   cpu: "${CPU_PER_WORKER}"

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/dgd-grove.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/dgd-grove.yaml-template
@@ -1,0 +1,237 @@
+# =============================================================================
+# Nemotron-3 Ultra 550B AGGREGATED, MULTINODE via Grove — DynamoGraphDeployment
+# =============================================================================
+#
+# Author: Anton Alexander
+#
+# This is the Grove-native counterpart of lws.yaml-template: ONE engine spanning
+# ${NODE_COUNT_PER_WORKER} GPU nodes (TP${GPU_PER_WORKER} x PP${NODE_COUNT_PER_WORKER}),
+# expressed as a single v1beta1 DGD with `multinode.nodeCount` instead of a
+# LeaderWorkerSet. The Dynamo operator (1.4.0+, Grove enabled) renders the whole
+# graph as one grove.io PodCliqueSet: the frontend becomes a PodClique, the
+# multinode worker becomes a PodCliqueScalingGroup with leader/worker cliques,
+# and the whole set is GANG-SCHEDULED as a PodGang by kai-scheduler — the graph
+# schedules all-or-nothing, so partial capacity can never strand a half-booted
+# engine holding GPUs.
+#
+#   MANIFEST_TYPE=dgd-grove ./run.sh
+#
+# Prerequisites (both in this repo, apply in order):
+#   1. eks/deployment/nvidia-dynamo  — Dynamo platform >= 1.4.0 (operator/etcd/NATS)
+#   2. eks/deployment/grove          — standalone Grove + KAI scheduler releases;
+#      its deploy.sh also flips global.grove.enabled + global.kai-scheduler.enabled
+#      on the platform release so the operator starts rendering DGDs through Grove.
+# Without step 2 the operator falls back to its non-Grove renderer and `multinode`
+# components render via LWS — this file then requires LWS to be installed.
+#
+# VALIDATION STATUS (be honest with yourself before benchmarking):
+#   PROVEN 2026-08-20 on a 2x p5en.48xlarge EKS cluster (Dynamo 1.4.0, PR #93
+#   evidence): the full Grove chain for exactly this shape — DGD Ready=True,
+#   PodCliqueSet 1/1, PodGang created, every pod scheduled by kai-scheduler,
+#   leader/worker cliques with stable per-clique hostnames as the torch
+#   distributed init method, cross-node engine traffic on EFA
+#   ("Using network Libfabric" x8, zero Socket fallback), real completions served.
+#   That run used a small plumbing model (TP16/PP1). The 550B checkpoint has NOT
+#   yet been run through THIS template; TP8/PP2 is its engine shape proven E2E on
+#   lws.yaml-template. Run one live smoke before quoting numbers from this file.
+#
+#   The cold-start warmup block the other agg templates carry is intentionally
+#   ABSENT here: in a clique the warmer would launch on every rank pod, and its
+#   leader-only health gate has not been validated through the operator's
+#   multinode wiring. BF16 never needed it; before benchmarking NVFP4 through
+#   this template, add it back leader-guarded once the live run establishes
+#   which pod answers the dyn-system port.
+#
+#   Image: the Grove smoke ran nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.4.0-efa.
+#   The .env default (1.3.1-patched) has NOT been run through the operator's
+#   multinode bootstrap; if the ranks fail to join, try
+#   REGISTRY=nvcr.io/nvidia/ai-dynamo/ IMAGE=vllm-runtime TAG=":1.4.0-efa" first.
+#
+# Two negatives already paid for on this path — do not rediscover them:
+#   1. EFA must be allocated as the FULL node complement (${EFA_PER_WORKER}=all
+#      NICs the device plugin advertises). A partial NIC slice makes libfabric
+#      device-list init fail in-pod (ibv_open_device errno 2 on unallocated
+#      devices) and aws-ofi-nccl silently falls back to Socket.
+#   2. Full-node GPU pods only (nvidia.com/gpu: 8 on p5en). A half-node 4-GPU
+#      slice got clean Libfabric init and then hung in the first cross-node
+#      collective. Grove-proven shape = whole nodes.
+#
+# /dev/shm: the dshm emptyDir below is carried AS-RUN from the proven Grove
+# smoke on the 1.4.0 operator. (The single-node dgd-v1beta1 template omits it
+# because the 1.3.x operator owned that mount; 1.4.0 merged ours cleanly.)
+#
+# =============================================================================
+---
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: ${DEPLOYMENT_NAME}
+  namespace: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}
+spec:
+  backendFramework: vllm
+  env:
+    - { name: DYNAMO_BACKEND, value: vllm }
+    - { name: ETCD_ENDPOINTS, value: "${ETCD_URL}" }
+    - { name: NATS_SERVER,    value: "${NATS_URL}" }
+    # /tmp, NOT /shared: pods run uid 1000 and /shared is root-owned — the frontend
+    # dies registering the model ("Failed to create cache directory /shared/hf_cache/hub:
+    # Permission denied") and /v1/models stays empty -> every request 404s.
+    - { name: HF_HOME,        value: /tmp/hf_cache }
+  components:
+    # ---- Frontend (router, CPU-only; renders as its own PodClique) ---------
+    - name: Frontend
+      type: frontend
+      replicas: 1
+      podTemplate:
+        spec:
+          nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_FRONTEND} }
+          volumes:
+            - { name: fsx-pvc, persistentVolumeClaim: { claimName: fsx-pvc } }
+          containers:
+            # The operator merges its defaults into the container named exactly "main";
+            # any other container is a user-managed sidecar.
+            - name: main
+              resources:
+                requests: { cpu: "2", memory: 4Gi }
+                limits:   { cpu: "4", memory: 8Gi }
+              image: ${REGISTRY}${IMAGE}${TAG}
+              imagePullPolicy: Always
+              command: ["/bin/bash", "-c"]
+              args:
+                - |-
+                  # ---- Node-fault preflight: duplicate pod address (podIP == hostIP) ----
+                  # The CNI can hand this sandbox the node's own kubelet InternalIP; cluster DNS
+                  # then never answers for the pod, so NATS/etcd are unreachable. A container
+                  # RESTART CANNOT CLEAR IT (restarts reuse the sandbox, CNI ADD is not
+                  # re-invoked) - the pod object has to be deleted.
+                  if [ -n "${DOLLAR}{POD_IP:-}" ] && [ "${DOLLAR}{POD_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
+                    echo "[frontend] FATAL: pod IP ${DOLLAR}POD_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                    echo "[frontend]        Cluster DNS cannot answer for this pod, so NATS/etcd are unreachable."
+                    echo "[frontend]        RESTARTING WILL NOT HELP - the sandbox keeps the address. Remedy:"
+                    echo "[frontend]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                    exit 1
+                  fi
+                  if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+                  exec python3 -m dynamo.frontend --http-port 8000 --http-host 0.0.0.0
+              env:
+                # Read only by the duplicate-address preflight in args above.
+                - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+                - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
+              ports: [{ containerPort: 8000, name: http }]
+              # NOTE: no readinessProbe here — the operator injects its own frontend probe;
+              # adding ours makes the API server reject the generated pod
+              # ("may not specify more than 1 handler type").
+              volumeMounts:
+                - { name: fsx-pvc, mountPath: /shared }
+    # ---- Multinode aggregated worker: ONE engine across ${NODE_COUNT_PER_WORKER} nodes ----
+    # `multinode.nodeCount` is the whole Grove delta vs dgd-v1beta1: the operator turns
+    # this component into a PodCliqueScalingGroup (leader clique + worker clique), gives
+    # the leader a stable hostname the ranks use as the distributed init method, and
+    # gang-schedules the group. Engine world size = TP x PP =
+    # ${GPU_PER_WORKER} x ${NODE_COUNT_PER_WORKER} GPUs = ${NODE_COUNT_PER_WORKER} full nodes.
+    - name: VllmWorker
+      type: worker
+      replicas: 1
+      multinode:
+        nodeCount: ${NODE_COUNT_PER_WORKER}
+      podTemplate:
+        spec:
+          nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_WORKER} }
+          tolerations:
+            - { key: nvidia.com/gpu, operator: Exists, effect: NoSchedule }
+            - { key: vpc.amazonaws.com/efa, operator: Exists, effect: NoSchedule }
+          affinity:
+            # Belt-and-suspenders (full-node GPU requests already forbid co-location).
+            # Keyed to the operator-applied label — VERIFIED present on Grove-rendered
+            # pods; app.kubernetes.io/part-of passthrough onto Grove pods is not.
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchLabels:
+                      nvidia.com/dynamo-graph-deployment-name: ${DEPLOYMENT_NAME}
+                  topologyKey: kubernetes.io/hostname
+          volumes:
+            - { name: fsx-pvc, persistentVolumeClaim: { claimName: fsx-pvc } }
+            # AS-RUN in the proven Grove smoke; TP${GPU_PER_WORKER} intra-node ranks
+            # move activations through /dev/shm and the operator default is too small.
+            - { name: dshm, emptyDir: { medium: Memory, sizeLimit: 64Gi } }
+          containers:
+            - name: main
+              image: ${REGISTRY}${IMAGE}${TAG}
+              imagePullPolicy: Always
+              securityContext: { capabilities: { add: ["IPC_LOCK"] } }
+              command: ["/bin/bash", "-c"]
+              args:
+                - |-
+                  set -u
+                  unset HPCX_DIR HPCX_MPI_DIR HPCX_HOME HPCX_UCX_DIR HPCX_SHARP_DIR \
+                        HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
+                  if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+                  if [ -n "${DOLLAR}{POD_IP:-}" ] && [ "${DOLLAR}{POD_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
+                    echo "[worker] FATAL: pod IP ${DOLLAR}POD_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                    echo "[worker]        Cluster DNS cannot answer for this pod, so NATS/etcd are unreachable."
+                    echo "[worker]        RESTARTING WILL NOT HELP - the sandbox keeps the address. Remedy:"
+                    echo "[worker]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                    exit 1
+                  fi
+                  # TP stays inside each node (${GPU_PER_WORKER} GPUs); PP spans the
+                  # ${NODE_COUNT_PER_WORKER} clique members — the engine shape proven E2E for
+                  # the 550B on lws.yaml-template. The rank bootstrap itself is the operator's
+                  # (leader-clique hostname), not ours.
+                  exec python3 -m dynamo.vllm \
+                    --model ${MODEL_PATH} \
+                    --served-model-name ${MODEL_NAME} \
+                    --load-format ${LOAD_FORMAT} \
+                    --tensor-parallel-size ${GPU_PER_WORKER} \
+                    --pipeline-parallel-size ${NODE_COUNT_PER_WORKER} \
+                    --max-model-len 4096 --gpu-memory-utilization 0.97 --enforce-eager \
+                    --trust-remote-code \
+                    --mamba-cache-mode align
+              env:
+                # Read only by the duplicate-address preflight in args above.
+                - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+                - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
+                - { name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS, value: "1800" }
+                - { name: HF_MODULES_CACHE, value: /tmp/hf_cache/modules }
+                - { name: VLLM_LOGGING_LEVEL, value: INFO }
+                # ---- Cross-node engine traffic over EFA (NCCL -> aws-ofi-nccl -> libfabric).
+                # This block is what lws.yaml-template carries for the same 2-node engine;
+                # values verified live in the Grove smoke (Libfabric x8, Socket 0).
+                - { name: FI_PROVIDER, value: efa }
+                - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
+                - { name: FI_EFA_FORK_SAFE, value: "1" }
+                - { name: FI_HMEM_CUDA_USE_DMABUF, value: "1" }
+                - { name: OFI_NCCL_FORCE_NUM_RAILS, value: "4" }
+                - { name: NCCL_NET_PLUGIN, value: ofi }
+                - { name: NCCL_TUNER_PLUGIN, value: ofi }
+                - { name: NCCL_NVLS_ENABLE, value: "0" }
+                - { name: NCCL_CUMEM_ENABLE, value: "1" }
+                - { name: NCCL_SOCKET_IFNAME, value: "^lo,docker,veth,eni,pod-id-link0" }
+                # Keep INIT,NET on: it is how you PROVE the engine rode EFA and not the
+                # Socket fallback ("Using network Libfabric" per rank, channels via
+                # NET/Libfabric/GDRDMA). Drop to WARN only after that check.
+                - { name: NCCL_DEBUG, value: INFO }
+                - { name: NCCL_DEBUG_SUBSYS, value: "INIT,NET" }
+              # NOTE: no explicit ports/startupProbe here, unlike dgd-v1beta1. In a
+              # multinode clique the SAME container spec lands on leader AND worker rank
+              # pods; only the leader answers the dyn-system health port, so a probe here
+              # would hold every worker rank NotReady forever. The operator injects
+              # multinode-aware probes (proven: DGD reached Ready=True in the smoke).
+              # A cold ~1 TB BF16 Lustre load has NOT been timed against those injected
+              # thresholds — watch the first 550B run before trusting them.
+              volumeMounts:
+                - { name: fsx-pvc, mountPath: /shared }
+                - { name: dshm, mountPath: /dev/shm }
+              resources:
+                requests:
+                  cpu: "${CPU_PER_WORKER}"
+                  memory: ${MEM_PER_WORKER}
+                  nvidia.com/gpu: "${GPU_PER_WORKER}"
+                  vpc.amazonaws.com/efa: "${EFA_PER_WORKER}"
+                limits:
+                  cpu: "${CPU_PER_WORKER}"
+                  memory: ${MEM_PER_WORKER}
+                  nvidia.com/gpu: "${GPU_PER_WORKER}"
+                  vpc.amazonaws.com/efa: "${EFA_PER_WORKER}"

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/.env
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/.env
@@ -11,7 +11,7 @@ export DOLLAR='$'
 export NAMESPACE=${NAMESPACE:-default}
 export DEPLOYMENT_NAME=${DEPLOYMENT_NAME:-nemotron3-ultra-550b-disagg}
 
-# MANIFEST_TYPE=deployment|lws-2pp|lws-pp2|lws-ep|dgd|dgd-v1beta1
+# MANIFEST_TYPE=deployment|lws-2pp|lws-pp2|lws-ep|dgd|dgd-v1beta1|dgd-grove
 #   deployment : plain Deployments, 1 prefill + 1 decode node, TP8/PP1 each (simplest)
 #   lws-2pp    : LeaderWorkerSet, prefill TP8/PP2 (2 nodes) + decode 2x TP8/PP1 (2x PP1 decode pods)
 #   lws-pp2    : LeaderWorkerSet, symmetrical PP2 - prefill AND decode each TP8/PP2 across 2 nodes
@@ -26,6 +26,11 @@ export DEPLOYMENT_NAME=${DEPLOYMENT_NAME:-nemotron3-ultra-550b-disagg}
 #                "nvidia.com/v1alpha1 DynamoGraphDeployment is deprecated" warning, and to be
 #                ready for the operator release that flips the CRD's storage version. Keep
 #                benchmarking on ONE of the two within a single results table.
+#   dgd-grove  : the dgd-v1beta1 topology (1 prefill + 1 decode node, TP8/PP1 each) rendered
+#                through Grove: on a Dynamo >= 1.4.0 operator with Grove + KAI installed
+#                (../../../grove) the whole graph becomes one PodCliqueSet and is
+#                GANG-scheduled - prefill can no longer boot alone and squat GPUs waiting
+#                for a decode node. See the template header for validation status.
 #
 # EVERY template in this folder splits prefill from decode (all carry --kv-transfer-config with
 # NixlConnector) - including lws-ep. ../agg/.env offers the SAME NAME `lws-ep` for the

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd-grove.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd-grove.yaml-template
@@ -27,10 +27,15 @@
 # VALIDATION STATUS:
 #   The Grove chain (PodCliqueSet -> PodCliques -> PodGang, kai-scheduler on every
 #   pod, EFA-not-Socket transport) is PROVEN live 2026-08-20 on 2x p5en.48xlarge
-#   with Dynamo 1.4.0 (PR #93 evidence). The engine + KV shape here is byte-for-byte
-#   the dgd-v1beta1 one, which is E2E-proven for the 550B. The COMBINATION —
-#   this disagg spec rendered through Grove — has not had its own live run yet;
-#   smoke it once before quoting numbers.
+#   with Dynamo 1.4.0 (PR #93 evidence). This exact disagg topology — 550B
+#   Nemotron-3 Ultra, 1 prefill + 1 decode (TP8/PP1 each), Grove-rendered DGD
+#   gang-scheduled by kai, STOCK vllm-runtime:1.4.0-efa — is also PROVEN live
+#   2026-08-20 on the same pair: DGD Ready=True in ~9 min, coherent completions,
+#   KV over EFA verified (decode rdma_read +3.061 GB matching NIXL telemetry
+#   48 x 60.82 MB to 0.0015%, LIBFABRIC x8 on both roles, zero transfer
+#   failures). That run applied a directly-authored DGD of the same shape; the
+#   envsubst render of THIS file has not itself been applied yet — smoke it once
+#   before quoting numbers from it.
 #
 #   Scaling a ROLE across nodes (e.g. PP2 prefill) is expressible here by adding
 #   `multinode: { nodeCount: N }` to that component (see ../agg/dgd-grove.yaml-template
@@ -44,6 +49,10 @@
 #     nvidia.com/dynamo-graph-deployment-name (VERIFIED present on Grove-rendered
 #     pods) instead of app.kubernetes.io/part-of, whose passthrough onto
 #     Grove-rendered pods is unverified.
+#   - sharedMemorySize: 64Gi on both workers (dgd-v1beta1 leaves it unset =
+#     operator's 8Gi default). 64Gi is what the proven 550B Grove run set and
+#     verified injected; the CRD field is the only /dev/shm knob the operator
+#     honors (podTemplate mounts there are silently dropped).
 #   - Everything else — env, probes, warmup, KV transfer config, resources —
 #     is carried unchanged, single-node components keep their explicit
 #     startupProbe/dyn-system wiring (each role's pod IS its engine here, no
@@ -112,6 +121,10 @@ spec:
     - name: VllmPrefillWorker
       type: prefill
       replicas: 1
+      # Operator-managed /dev/shm tmpfs (CRD field; nil defaults to 8Gi and a
+      # podTemplate mount at /dev/shm is silently dropped). 64Gi is the value
+      # verified injected in the live 550B run — do not shrink it for the 550B.
+      sharedMemorySize: 64Gi
       podTemplate:
         spec:
           nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_WORKER} }
@@ -201,6 +214,8 @@ spec:
     - name: VllmDecodeWorker
       type: decode
       replicas: 1
+      # Same operator-managed /dev/shm sizing as prefill (see that comment).
+      sharedMemorySize: 64Gi
       podTemplate:
         spec:
           nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_WORKER} }

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd-grove.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd-grove.yaml-template
@@ -1,0 +1,332 @@
+# =============================================================================
+# Nemotron-3 Ultra disaggregated P/D via Grove — DynamoGraphDeployment, v1beta1
+# =============================================================================
+#
+# Author: Anton Alexander
+#
+# Same topology as dgd-v1beta1.yaml-template — 1 prefill node + 1 decode node,
+# TP${GPU_PER_WORKER}/PP1 per role, KV prefill->decode over EFA RDMA via NIXL
+# LIBFABRIC — rendered through Grove. On a Dynamo >= 1.4.0 operator with Grove
+# enabled, the WHOLE graph becomes one grove.io PodCliqueSet (frontend, prefill,
+# decode each a PodClique) and is GANG-SCHEDULED as a PodGang by kai-scheduler.
+# That is the operational win over dgd-v1beta1 on a busy cluster: prefill can
+# no longer come up alone, hold ${GPU_PER_WORKER} GPUs and wait forever for a
+# decode node that never frees — the graph schedules all-or-nothing, and KAI
+# queues it as one unit.
+#
+#   MANIFEST_TYPE=dgd-grove ./run.sh
+#
+# Prerequisites (both in this repo, apply in order):
+#   1. eks/deployment/nvidia-dynamo  — Dynamo platform >= 1.4.0 (operator/etcd/NATS)
+#   2. eks/deployment/grove          — standalone Grove + KAI releases; its deploy.sh
+#      flips global.grove.enabled + global.kai-scheduler.enabled on the platform
+#      release so the operator renders DGDs through Grove.
+# Without step 2 the operator uses its non-Grove renderer and this file behaves
+# exactly like dgd-v1beta1.yaml-template (same spec, no gang scheduling).
+#
+# VALIDATION STATUS:
+#   The Grove chain (PodCliqueSet -> PodCliques -> PodGang, kai-scheduler on every
+#   pod, EFA-not-Socket transport) is PROVEN live 2026-08-20 on 2x p5en.48xlarge
+#   with Dynamo 1.4.0 (PR #93 evidence). The engine + KV shape here is byte-for-byte
+#   the dgd-v1beta1 one, which is E2E-proven for the 550B. The COMBINATION —
+#   this disagg spec rendered through Grove — has not had its own live run yet;
+#   smoke it once before quoting numbers.
+#
+#   Scaling a ROLE across nodes (e.g. PP2 prefill) is expressible here by adding
+#   `multinode: { nodeCount: N }` to that component (see ../agg/dgd-grove.yaml-template
+#   for the pattern), but that combination is UNVALIDATED through the DGD path —
+#   lws-2pp.yaml-template remains the proven PP2-prefill artifact. Decode stays
+#   PP1 regardless: PP>1 decode deadlocks the hybrid-Mamba 550B (its header
+#   explains why).
+#
+# Differences vs dgd-v1beta1.yaml-template, and why:
+#   - podAntiAffinity is keyed to the operator-applied label
+#     nvidia.com/dynamo-graph-deployment-name (VERIFIED present on Grove-rendered
+#     pods) instead of app.kubernetes.io/part-of, whose passthrough onto
+#     Grove-rendered pods is unverified.
+#   - Everything else — env, probes, warmup, KV transfer config, resources —
+#     is carried unchanged, single-node components keep their explicit
+#     startupProbe/dyn-system wiring (each role's pod IS its engine here, no
+#     leader/worker split to worry about).
+# =============================================================================
+---
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: ${DEPLOYMENT_NAME}
+  namespace: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}
+spec:
+  backendFramework: vllm
+  env:
+    - { name: DYNAMO_BACKEND, value: vllm }
+    - { name: ETCD_ENDPOINTS, value: "${ETCD_URL}" }
+    - { name: NATS_SERVER,    value: "${NATS_URL}" }
+    # /tmp, NOT /shared: pods run uid 1000 and /shared is root-owned - the frontend
+    # dies registering the model ("Failed to create cache directory /shared/hf_cache/hub:
+    # Permission denied") and /v1/models stays empty -> every request 404s.
+    - { name: HF_HOME,        value: /tmp/hf_cache }
+  components:
+    # ---- Frontend (router, CPU-only; its own PodClique in the gang) --------
+    - name: Frontend
+      type: frontend
+      replicas: 1
+      podTemplate:
+        spec:
+          nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_FRONTEND} }
+          volumes:
+            - { name: fsx-pvc, persistentVolumeClaim: { claimName: fsx-pvc } }
+          containers:
+            # The name MUST be "main" - that is the container the operator merges its
+            # image/command/env/ports/probe defaults into.
+            - name: main
+              image: ${REGISTRY}${IMAGE}${TAG}
+              imagePullPolicy: Always
+              command: ["/bin/bash", "-c"]
+              args:
+                - |-
+                  if [ -n "${DOLLAR}{POD_IP:-}" ] && [ "${DOLLAR}{POD_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
+                    echo "[frontend] FATAL: pod IP ${DOLLAR}POD_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                    echo "[frontend]        Cluster DNS cannot answer for this pod, so NATS/etcd are unreachable."
+                    echo "[frontend]        RESTARTING WILL NOT HELP - the sandbox keeps the address. Remedy:"
+                    echo "[frontend]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                    exit 1
+                  fi
+                  if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+                  exec python3 -m dynamo.frontend --http-port 8000 --http-host 0.0.0.0
+              env:
+                - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+                - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
+              ports: [{ containerPort: 8000, name: http }]
+              # The frontend reads the model dir (config/tokenizer, not weights) to build the
+              # preprocessor when workers register a local path - without this mount the model
+              # never appears in /v1/models.
+              volumeMounts:
+                - { name: fsx-pvc, mountPath: /shared }
+              resources:
+                requests: { cpu: "2", memory: 4Gi }
+                limits:   { cpu: "4", memory: 8Gi }
+              # NOTE: no readinessProbe here - the operator injects its own frontend probe.
+    # ---- Prefill worker (TP${GPU_PER_WORKER}/PP1, 1 node) ---------
+    - name: VllmPrefillWorker
+      type: prefill
+      replicas: 1
+      podTemplate:
+        spec:
+          nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_WORKER} }
+          tolerations:
+            - { key: nvidia.com/gpu, operator: Exists, effect: NoSchedule }
+            - { key: vpc.amazonaws.com/efa, operator: Exists, effect: NoSchedule }
+          affinity:
+            # Keyed to the operator label (verified on Grove-rendered pods) — see header.
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchLabels:
+                      nvidia.com/dynamo-graph-deployment-name: ${DEPLOYMENT_NAME}
+                  topologyKey: kubernetes.io/hostname
+          volumes:
+            - { name: fsx-pvc, persistentVolumeClaim: { claimName: fsx-pvc } }
+            - { name: gdrdrv, hostPath: { path: /dev/gdrdrv, type: CharDevice } }
+          containers:
+            - name: main
+              image: ${REGISTRY}${IMAGE}${TAG}
+              imagePullPolicy: Always
+              securityContext: { capabilities: { add: ["IPC_LOCK"] } }
+              command: ["/bin/bash", "-c"]
+              args:
+                - |-
+                  set -u
+                  unset HPCX_DIR HPCX_MPI_DIR HPCX_HOME HPCX_UCX_DIR HPCX_SHARP_DIR \
+                        HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
+                  if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+                  if [ -n "${DOLLAR}{POD_IP:-}" ] && [ "${DOLLAR}{POD_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
+                    echo "[prefill] FATAL: pod IP ${DOLLAR}POD_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                    echo "[prefill]        Cluster DNS cannot answer for this pod, so NATS/etcd are unreachable."
+                    echo "[prefill]        RESTARTING WILL NOT HELP - the sandbox keeps the address. Remedy:"
+                    echo "[prefill]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                    exit 1
+                  fi
+                  exec python3 -m dynamo.vllm \
+                    --model ${MODEL_PATH} \
+                    --served-model-name ${MODEL_NAME} \
+                    --tensor-parallel-size ${GPU_PER_WORKER} --pipeline-parallel-size 1 \
+                    --max-model-len 4096 --gpu-memory-utilization 0.97 --enforce-eager \
+                    --trust-remote-code ${MAMBA_FLAGS} \
+                    --load-format runai_streamer \
+                    --disaggregation-mode prefill \
+                    --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"],"kv_lease_duration":${KV_LEASE_DURATION}}}'
+              env:
+                # Read only by the duplicate-address preflight in args above.
+                - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+                - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
+                - { name: DYN_SYSTEM_ENABLED, value: "true" }
+                - { name: DYN_SYSTEM_PORT, value: "9091" }
+                # Same value as decode: a prefill-side compile under a concurrent opening must not
+                # trip the 300s execute_model default either.
+                - { name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS, value: "1800" }
+                - { name: VLLM_LOGGING_LEVEL, value: INFO }
+                - { name: VLLM_SSM_CONV_STATE_LAYOUT, value: DS }
+                - { name: FLASHINFER_DISABLE_VERSION_CHECK, value: "1" }
+                - { name: FI_PROVIDER, value: efa }
+                - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
+                - { name: FI_EFA_FORK_SAFE, value: "1" }
+                - { name: FI_HMEM_CUDA_USE_DMABUF, value: "1" }
+                - { name: FI_EFA_ENABLE_SHM, value: "0" }
+                - { name: FI_EFA_ENABLE_SHM_TRANSFER, value: "0" }
+                - { name: NIXL_LIBFABRIC_MAX_RAILS, value: "1" }
+                - { name: NIXL_SKIP_TOPOLOGY_CHECK, value: "1" }
+                - { name: NCCL_NET_PLUGIN, value: ofi }
+                - { name: NCCL_TUNER_PLUGIN, value: ofi }
+                - { name: OFI_NCCL_FORCE_NUM_RAILS, value: "4" }
+              # Port MUST be named "system": the operator injects readiness/liveness probes
+              # that target the named port; any other name fails with
+              # 'strconv.Atoi: parsing "system"' and the worker never goes Ready.
+              ports: [{ containerPort: 9091, name: system }]
+              startupProbe:
+                httpGet: { path: /health, port: 9091 }
+                periodSeconds: 30
+                timeoutSeconds: 10
+                failureThreshold: 240
+              volumeMounts:
+                - { name: fsx-pvc, mountPath: /shared }
+                - { name: gdrdrv, mountPath: /dev/gdrdrv }
+              resources:
+                requests: { cpu: "${CPU_PER_WORKER}", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+                limits:   { cpu: "${CPU_PER_WORKER}", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+    # ---- Decode worker (TP${GPU_PER_WORKER}/PP1, 1 node) ----------
+    # PP1 is deliberate, do not "scale" this role with multinode: PP>1 decode
+    # deadlocks the hybrid-Mamba 550B (see lws-2pp.yaml-template header).
+    - name: VllmDecodeWorker
+      type: decode
+      replicas: 1
+      podTemplate:
+        spec:
+          nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_WORKER} }
+          tolerations:
+            - { key: nvidia.com/gpu, operator: Exists, effect: NoSchedule }
+            - { key: vpc.amazonaws.com/efa, operator: Exists, effect: NoSchedule }
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchLabels:
+                      nvidia.com/dynamo-graph-deployment-name: ${DEPLOYMENT_NAME}
+                  topologyKey: kubernetes.io/hostname
+          volumes:
+            - { name: fsx-pvc, persistentVolumeClaim: { claimName: fsx-pvc } }
+            - { name: gdrdrv, hostPath: { path: /dev/gdrdrv, type: CharDevice } }
+          containers:
+            - name: main
+              image: ${REGISTRY}${IMAGE}${TAG}
+              imagePullPolicy: Always
+              securityContext: { capabilities: { add: ["IPC_LOCK"] } }
+              command: ["/bin/bash", "-c"]
+              args:
+                - |-
+                  set -u
+                  unset HPCX_DIR HPCX_MPI_DIR HPCX_HOME HPCX_UCX_DIR HPCX_SHARP_DIR \
+                        HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
+                  if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+                  if [ -n "${DOLLAR}{POD_IP:-}" ] && [ "${DOLLAR}{POD_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
+                    echo "[decode] FATAL: pod IP ${DOLLAR}POD_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                    echo "[decode]        Cluster DNS cannot answer for this pod, so NATS/etcd are unreachable."
+                    echo "[decode]        RESTARTING WILL NOT HELP - the sandbox keeps the address. Remedy:"
+                    echo "[decode]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                    exit 1
+                  fi
+                  # Cold-start warmup (detached)
+                  (
+                    FE="http://${DEPLOYMENT_NAME}-frontend.${NAMESPACE}.svc.cluster.local:8000"
+                    # Gate on THIS pod's dyn-system /health: the frontend answers /v1/models 200 long
+                    # before the engine has loaded, so gating on the frontend alone fires the warmup at
+                    # a dead engine and compiles nothing.
+                    LH="http://localhost:${DOLLAR}{DYN_SYSTEM_PORT:-9092}/health"
+                    WARMUP_CONCURRENCY=${DOLLAR}{WARMUP_CONCURRENCY:-10}
+                    WARMUP_ENABLED=${DOLLAR}{WARMUP_ENABLED:-auto}
+                    case "${DOLLAR}WARMUP_ENABLED" in
+                      auto) case "${MODEL_NAME}" in
+                              *NVFP4*|*nvfp4*) : ;;
+                              *) echo "[warmup] ${MODEL_NAME} is not NVFP4; warmup not needed, skipping (non-fatal)"; exit 0 ;;
+                            esac ;;
+                      0|false|no) echo "[warmup] WARMUP_ENABLED=${DOLLAR}WARMUP_ENABLED; skipping (non-fatal)"; exit 0 ;;
+                    esac
+                    if ! command -v curl >/dev/null 2>&1; then
+                      echo "[warmup] curl not present; skipping cold-start warmup (non-fatal)"
+                    else
+                      warmed=0
+                      for i in ${DOLLAR}(seq 1 360); do
+                        if curl -sf -o /dev/null --max-time 5 "${DOLLAR}LH" 2>/dev/null \
+                           && curl -sf --max-time 5 "${DOLLAR}FE/v1/models" 2>/dev/null | grep -q "${MODEL_NAME}"; then
+                          echo "[warmup] engine ready (own /health 200 + model registered); priming batch=1 Mamba decode kernel (one-time JIT, ~4min)"
+                          curl -s -o /dev/null --max-time 900 "${DOLLAR}FE/v1/completions" \
+                            -H 'Content-Type: application/json' \
+                            -d "{\"model\":\"${MODEL_NAME}\",\"prompt\":\"warmup\",\"max_tokens\":4,\"temperature\":0}" \
+                            && echo "[warmup] batch=1 warm; priming concurrent batch buckets 1..${DOLLAR}WARMUP_CONCURRENCY" \
+                            || echo "[warmup] batch=1 warmup returned non-zero (non-fatal)"
+                          for j in ${DOLLAR}(seq 1 "${DOLLAR}WARMUP_CONCURRENCY"); do
+                            curl -s -o /dev/null --max-time 900 "${DOLLAR}FE/v1/completions" \
+                              -H 'Content-Type: application/json' \
+                              -d "{\"model\":\"${MODEL_NAME}\",\"prompt\":\"warmup\",\"max_tokens\":4,\"temperature\":0}" &
+                          done
+                          wait
+                          echo "[warmup] concurrent batch buckets warm; benchmark opening will be fast"
+                          warmed=1
+                          break
+                        fi
+                        sleep 5
+                      done
+                      # Fail LOUD if the gate never opened (still non-fatal to the pod): falling out of
+                      # this loop silently is indistinguishable from "warmed up fine", and the next
+                      # benchmark would quietly pay the JIT tax again.
+                      [ "${DOLLAR}warmed" = 1 ] || echo "[warmup] gave up after 30min waiting for ${DOLLAR}LH 200 + ${MODEL_NAME} in ${DOLLAR}FE/v1/models; the FIRST benchmark requests will pay the Mamba JIT (non-fatal)"
+                    fi
+                  ) &
+                  exec python3 -m dynamo.vllm \
+                    --model ${MODEL_PATH} \
+                    --served-model-name ${MODEL_NAME} \
+                    --tensor-parallel-size ${GPU_PER_WORKER} --pipeline-parallel-size 1 \
+                    --max-model-len 4096 --gpu-memory-utilization 0.97 --enforce-eager \
+                    --trust-remote-code ${MAMBA_FLAGS} \
+                    --load-format runai_streamer \
+                    --disaggregation-mode decode \
+                    --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"],"kv_lease_duration":${KV_LEASE_DURATION}}}'
+              env:
+                # Read only by the duplicate-address preflight in args above.
+                - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+                - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
+                - { name: DYN_SYSTEM_ENABLED, value: "true" }
+                - { name: DYN_SYSTEM_PORT, value: "9092" }
+                - { name: WARMUP_ENABLED, value: "${WARMUP_ENABLED}" }
+                - { name: WARMUP_CONCURRENCY, value: "${WARMUP_CONCURRENCY}" }
+                - { name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS, value: "1800" }
+                - { name: VLLM_LOGGING_LEVEL, value: INFO }
+                - { name: VLLM_SSM_CONV_STATE_LAYOUT, value: DS }
+                - { name: FLASHINFER_DISABLE_VERSION_CHECK, value: "1" }
+                - { name: FI_PROVIDER, value: efa }
+                - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
+                - { name: FI_EFA_FORK_SAFE, value: "1" }
+                - { name: FI_HMEM_CUDA_USE_DMABUF, value: "1" }
+                - { name: FI_EFA_ENABLE_SHM, value: "0" }
+                - { name: FI_EFA_ENABLE_SHM_TRANSFER, value: "0" }
+                - { name: NIXL_LIBFABRIC_MAX_RAILS, value: "1" }
+                - { name: NIXL_SKIP_TOPOLOGY_CHECK, value: "1" }
+                - { name: NCCL_NET_PLUGIN, value: ofi }
+                - { name: NCCL_TUNER_PLUGIN, value: ofi }
+                - { name: OFI_NCCL_FORCE_NUM_RAILS, value: "4" }
+              # Port MUST be named "system": the operator injects readiness/liveness probes
+              # that target the named port; any other name fails with
+              # 'strconv.Atoi: parsing "system"' and the worker never goes Ready.
+              ports: [{ containerPort: 9092, name: system }]
+              startupProbe:
+                httpGet: { path: /health, port: 9092 }
+                periodSeconds: 30
+                timeoutSeconds: 10
+                failureThreshold: 240
+              volumeMounts:
+                - { name: fsx-pvc, mountPath: /shared }
+                - { name: gdrdrv, mountPath: /dev/gdrdrv }
+              resources:
+                requests: { cpu: "${CPU_PER_WORKER}", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+                limits:   { cpu: "${CPU_PER_WORKER}", memory: 1000Gi, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }


### PR DESCRIPTION
## What

The agg and disagg manifests for the Grove path (follow-up to #93), in the existing `.env` + `envsubst` template structure:

**`agg/dgd-grove.yaml-template`** — the `lws.yaml-template` engine shape (ONE engine, TP8 x PP${NODE_COUNT_PER_WORKER} across that many full nodes) expressed as a v1beta1 DGD with `multinode.nodeCount`. On a 1.4.0+ operator with Grove + KAI installed (`eks/deployment/grove`, #93) the operator renders it as a PodCliqueSet with a leader/worker PodCliqueScalingGroup and kai-scheduler gang-schedules the whole graph — a half-booted engine can no longer strand GPUs.

**`disagg/dgd-grove.yaml-template`** — the `dgd-v1beta1` topology (1 prefill + 1 decode, TP8/PP1, NIXL LIBFABRIC KV over EFA) rendered through Grove for gang scheduling: prefill can no longer boot alone and squat a node waiting for a decode node that never frees.

**`.env` (both dirs)** — `dgd-grove` added to the `MANIFEST_TYPE` registry; `NODE_COUNT_PER_WORKER` (agg, default 2) controls the multinode span. Usage: `MANIFEST_TYPE=dgd-grove ./run.sh`.

**`/dev/shm` via the CRD, not a volume:** the 1.4.0 operator always manages its own tmpfs at /dev/shm (component-level `sharedMemorySize`; nil = 8Gi default) and silently drops a podTemplate mount at that path. Both templates set `sharedMemorySize: 64Gi` — the value the live 550B run set and verified injected.

## Validation status (stated in each template header too)

- **Grove chain, this exact rendering path:** PROVEN live 2026-08-20 on 2x p5en.48xlarge, Dynamo 1.4.0 (#93 evidence) — DGD Ready=True, PodCliqueSet/PodGang created, every pod scheduled by kai-scheduler, cross-node traffic on EFA (Libfabric x8, zero Socket fallback), real completions.
- **Disagg topology at full scale:** PROVEN live 2026-08-20 — 550B Nemotron-3 Ultra, 1P+1D TP8/PP1, STOCK `vllm-runtime:1.4.0-efa`, Grove/kai gang-scheduled. Ready in ~9 min, coherent completions, KV over EFA verified: decode `rdma_read_bytes` +3.061 GB matching NIXL telemetry (48 x 60.82 MB) to 0.0015%, LIBFABRIC x8 on both roles, zero transfer failures.
- **Not yet run, headers say so:** the envsubst render of these exact files (the 550B proof applied a directly-authored DGD of the same shape); the 550B through the agg multinode template (its TP8/PP2 engine shape is E2E-proven on `lws.yaml-template`, the Grove chain on a plumbing model); PP2-prefill through the DGD path (`lws-2pp` remains the proven PP2 artifact).

Both templates envsubst-render to clean YAML with no unresolved variables (agg: worker `multinode.nodeCount=2` TP8/PP2; disagg: 1P+1D, `sharedMemorySize: 64Gi` on every GPU component).