### PR TITLE
Pre-create RuntimeClass nvidia in the grove deploy script

### DIFF
--- a/Container-Root/eks/deployment/grove/deploy.sh
+++ b/Container-Root/eks/deployment/grove/deploy.sh
@@ -16,6 +16,19 @@ export KAI_NAMESPACE=${KAI_NAMESPACE:-kai-scheduler}
 export KAI_VERSION=${KAI_VERSION:-"v0.13.4"}
 export DYNAMO_NAMESPACE=${DYNAMO_NAMESPACE:-dynamo-system}
 
+# 0. RuntimeClass "nvidia": KAI's admission webhook injects runtimeClassName: nvidia into every
+#    GPU-requesting pod (runtimeenforcement plugin, default admission.gpuPodRuntimeClassName).
+#    Upstream expects the NVIDIA GPU-Operator to have created that RuntimeClass; EKS / HyperPod
+#    GPU AMIs bake the driver + containerd nvidia runtime into the node instead, so the object
+#    does not exist and the API server rejects every GPU pod at create with
+#    'RuntimeClass "nvidia" not found' (Dynamo workers included — the only visible symptom is a
+#    gang stuck Pending behind a GPU-less frontend). Pre-create it; skipped when one already
+#    exists (e.g. GPU-Operator clusters). To disable the injection instead, set
+#    admission.gpuPodRuntimeClassName=null on the KAI release.
+if ! kubectl get runtimeclass nvidia >/dev/null 2>&1; then
+    kubectl apply -f runtimeclass-nvidia.yaml
+fi
+
 # 1. KAI scheduler first: Grove PodGangs schedule best with gang scheduling available.
 helm upgrade --install kai-scheduler oci://ghcr.io/kai-scheduler/kai-scheduler/kai-scheduler \
     --version "$KAI_VERSION" --namespace "$KAI_NAMESPACE" --create-namespace -f values-kai.yaml

--- a/Container-Root/eks/deployment/grove/remove.sh
+++ b/Container-Root/eks/deployment/grove/remove.sh
@@ -38,11 +38,17 @@ kubectl get crd -o name | grep -E "grove.io|kai.scheduler|scheduling.run.ai" | x
 kubectl delete namespace "$GROVE_NAMESPACE" --ignore-not-found --timeout=120s
 kubectl delete namespace "$KAI_NAMESPACE" --ignore-not-found --timeout=120s
 
-# 6. Verify zero residue - all of the following should print nothing.
+# 6. RuntimeClass nvidia — only the one deploy.sh created (marker label); a RuntimeClass owned
+#    by the GPU-Operator is left alone. Only KAI's injection references it, so with KAI gone it
+#    has no remaining consumer.
+kubectl delete runtimeclass -l app.kubernetes.io/created-by=aws-do-eks-grove-deploy --ignore-not-found
+
+# 7. Verify zero residue - all of the following should print nothing.
 echo ""
 echo "Verifying removal (all of the following should be empty):"
 kubectl get crd | grep -E "grove.io|kai.scheduler|scheduling.run.ai"
 kubectl get namespace "$GROVE_NAMESPACE" 2>/dev/null
 kubectl get namespace "$KAI_NAMESPACE" 2>/dev/null
 helm list -A 2>/dev/null | grep -E "^grove|^kai-scheduler"
+kubectl get runtimeclass -l app.kubernetes.io/created-by=aws-do-eks-grove-deploy --no-headers 2>/dev/null
 echo "Done."

--- a/Container-Root/eks/deployment/grove/runtimeclass-nvidia.yaml
+++ b/Container-Root/eks/deployment/grove/runtimeclass-nvidia.yaml
@@ -1,0 +1,23 @@
+# RuntimeClass that KAI's admission webhook expects to exist on the cluster.
+#
+# KAI injects `runtimeClassName: nvidia` into every GPU-requesting pod at create time
+# (admission runtimeenforcement plugin, helm value admission.gpuPodRuntimeClassName,
+# default "nvidia"). Upstream assumes the NVIDIA GPU-Operator created this RuntimeClass
+# (KAI README prerequisites). EKS / HyperPod GPU AMIs bake the NVIDIA driver and the
+# containerd "nvidia" runtime handler into the node instead of running the GPU-Operator,
+# so the RuntimeClass object never exists and the API server rejects every mutated pod:
+#   pods "..." is forbidden: pod rejected: RuntimeClass "nvidia" not found
+#
+# The handler below must match the containerd runtime name on the GPU nodes; EKS
+# accelerated AMIs and HyperPod GPU AMIs configure it as "nvidia" via the NVIDIA
+# container toolkit.
+#
+# The created-by label marks this object as script-managed so remove.sh deletes only
+# this one and never a RuntimeClass owned by the GPU-Operator.
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: nvidia
+  labels:
+    app.kubernetes.io/created-by: aws-do-eks-grove-deploy
+handler: nvidia


### PR DESCRIPTION
## What

`grove/deploy.sh` now pre-creates a `RuntimeClass nvidia` (new `runtimeclass-nvidia.yaml`, skipped when the cluster already has one), and `grove/remove.sh` deletes only the script-created object via its marker label.

## Why

KAI-scheduler's admission webhook (`mutating-kai-admission`, pod CREATE) runs a `runtimeenforcement` plugin that injects `runtimeClassName: nvidia` into **every GPU-requesting pod** that doesn't already set one — helm value `admission.gpuPodRuntimeClassName`, default `nvidia` ([source, v0.13.4](https://github.com/NVIDIA/KAI-Scheduler/blob/v0.13.4/pkg/admission/webhook/v1alpha2/runtimeenforcement/runtime_enforcement.go)). Upstream expects the [NVIDIA GPU-Operator](https://github.com/NVIDIA/KAI-Scheduler/tree/v0.13.4#prerequisites) to have created that RuntimeClass.

EKS and HyperPod GPU AMIs bake the NVIDIA driver + containerd `nvidia` runtime handler into the node instead of running the GPU-Operator, so the RuntimeClass **object** never exists and the API server rejects every mutated pod at create:

```
RuntimeClass "nvidia" not found
```

Observed live on a HyperPod EKS B200 cluster (kai-scheduler v0.13.4, dynamo 1.4.0): grove-operator `ERR_CREATE_POD` for both vllmworker cliques, PodGang stuck Pending forever, and the only visible symptom a GPU-less frontend pod sitting SchedulingGated — the frontend requests no GPU so it is never mutated.

## Notes

- The `handler: nvidia` matches the containerd runtime name the NVIDIA container toolkit configures on EKS accelerated / HyperPod GPU AMIs.
- The alternative is disabling the injection with `--set admission.gpuPodRuntimeClassName=null` on the KAI release (upstream's documented path for GPU-Operator-less clusters); pre-creating the RuntimeClass was chosen because NVIDIA's Dynamo recipes also hardcode `runtimeClassName: nvidia` in pod specs, so the object fixes that whole class of manifests too.
- `remove.sh` never deletes a RuntimeClass owned by the GPU-Operator (marker-label-scoped delete), keeping the leave-as-found contract.