### PR TITLE
nemotron/ultra: disable vllm_omni Quack FP8 in the dgd-grove templates (NVFP4 slow-decode fix)

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/dgd-grove.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/dgd-grove.yaml-template
@@ -201,6 +201,12 @@ spec:
                 - { name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS, value: "1800" }
                 - { name: HF_MODULES_CACHE, value: /tmp/hf_cache/modules }
                 - { name: VLLM_LOGGING_LEVEL, value: INFO }
+                # NVFP4 on sm100: vllm_omni's Quack/CuTeDSL FP8 scaled-mm monkey-patch defaults
+                # ON, but its tuned-compile helper cannot spawn inside vLLM's daemonic TP workers
+                # ("daemonic processes are not allowed to have children") -> exception + FlashInfer
+                # fallback on EVERY GEMM call, nothing caches, and decode crawls at ~0.05-0.1 tok/s
+                # while looking "stuck". Force it off; BF16 never enters this path (no-op there).
+                - { name: VLLM_OMNI_USE_QUACK_FP8, value: "0" }
                 # ---- Cross-node engine traffic over EFA (NCCL -> aws-ofi-nccl -> libfabric).
                 # This block is what lws.yaml-template carries for the same 2-node engine;
                 # values verified live in the Grove smoke (Libfabric x8, Socket 0).

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd-grove.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd-grove.yaml-template
@@ -182,6 +182,12 @@ spec:
                 - { name: VLLM_LOGGING_LEVEL, value: INFO }
                 - { name: VLLM_SSM_CONV_STATE_LAYOUT, value: DS }
                 - { name: FLASHINFER_DISABLE_VERSION_CHECK, value: "1" }
+                # NVFP4 on sm100: vllm_omni's Quack/CuTeDSL FP8 scaled-mm monkey-patch defaults
+                # ON, but its tuned-compile helper cannot spawn inside vLLM's daemonic TP workers
+                # ("daemonic processes are not allowed to have children") -> exception + FlashInfer
+                # fallback on EVERY GEMM call, nothing caches, and decode crawls at ~0.05-0.1 tok/s
+                # while looking "stuck". Force it off; BF16 never enters this path (no-op there).
+                - { name: VLLM_OMNI_USE_QUACK_FP8, value: "0" }
                 - { name: FI_PROVIDER, value: efa }
                 - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
                 - { name: FI_EFA_FORK_SAFE, value: "1" }
@@ -319,6 +325,12 @@ spec:
                 - { name: VLLM_LOGGING_LEVEL, value: INFO }
                 - { name: VLLM_SSM_CONV_STATE_LAYOUT, value: DS }
                 - { name: FLASHINFER_DISABLE_VERSION_CHECK, value: "1" }
+                # NVFP4 on sm100: vllm_omni's Quack/CuTeDSL FP8 scaled-mm monkey-patch defaults
+                # ON, but its tuned-compile helper cannot spawn inside vLLM's daemonic TP workers
+                # ("daemonic processes are not allowed to have children") -> exception + FlashInfer
+                # fallback on EVERY GEMM call, nothing caches, and decode crawls at ~0.05-0.1 tok/s
+                # while looking "stuck". Force it off; BF16 never enters this path (no-op there).
+                - { name: VLLM_OMNI_USE_QUACK_FP8, value: "0" }
                 - { name: FI_PROVIDER, value: efa }
                 - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
                 - { name: FI_EFA_FORK_SAFE, value: "1" }


### PR DESCRIPTION
## What

Adds `VLLM_OMNI_USE_QUACK_FP8=0` to the vLLM worker env in the two dgd-grove templates:
- `disagg/dgd-grove.yaml-template` — both prefill and decode workers
- `agg/dgd-grove.yaml-template` — the multinode worker

This is the runnable fix for the "request appears to be stuck" NVFP4 disagg symptom on the B200 cluster (2026-08-22).

## Root cause

vllm_omni 0.26.0rc1 (baked into the NGC 1.4.0 base under `dynamo-vllm-efa:1.4.0-patched`) monkey-patches FlashInfer's FP8 scaled-mm to try Quack/CuTeDSL GEMM first, **default-ON on sm100 (B200)**. Quack's `tuned=True` compile helper spawns a child process, which is illegal inside vLLM's daemonic TP workers (`daemonic processes are not allowed to have children`). The patch throws and falls back to FlashInfer **on every GEMM call** — the failure never caches — so NVFP4 decode crawls at ~0.05–0.1 tok/s (~10–20 s/token) while the request looks hung. The KV/NIXL transfer path itself is healthy (prefill completes, decode shows a normal external prefix-cache hit rate).

Differential that isolated it: same image, same dgd-grove template, same hardware with the **BF16** 550B checkpoint = ITL 107 ms and zero quack warnings. Quantization was the only delta.

## Why hard-coded rather than a .env knob

`VLLM_OMNI_USE_QUACK_FP8` is checked before the sm100 default in vllm_omni's `quack_enabled()`, so `0` cleanly forces the stock FlashInfer path. These templates always run multiproc TP workers, where the Quack compile can never succeed — there is no configuration in which `1` works here. BF16 never enters the FP8 scaled-mm path, so the env is a no-op for BF16 deploys.

## Testing

- Rendered both templates through the `run.sh` envsubst path and re-parsed the YAML: env lands on the intended containers (disagg ×2, agg ×1), value `"0"`.
- The env fix itself was verified live against the stuck deployment's logs this morning (per-GEMM quack warnings + throughput lines) before being recommended.

Note: an already-running DGD needs a delete + re-apply to pick up the env.

## Possible follow-up

The sibling templates in the same dirs (`dgd.yaml-template`, `dgd-v1beta1.yaml-template`, `lws*.yaml-template`, `deployment.yaml-template`) share the same worker env pattern and would want the same line if used with NVFP4. Scoped this PR to the dgd-grove pair that hit the issue — happy to sweep the rest in a follow-up if wanted.