### PR TITLE
nemotron/ultra: extend the NVFP4 Quack FP8 disable to all vLLM worker templates

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/deployment.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/deployment.yaml-template
@@ -215,6 +215,12 @@ spec:
             # is unaffected (Unquantized MoE doesn't use these cubins), so this is inert for BF16.
             - { name: FLASHINFER_CUBIN_DIR, value: /tmp/flashinfer_cubins }
             - { name: VLLM_LOGGING_LEVEL, value: INFO }
+            # NVFP4 on sm100: vllm_omni's Quack/CuTeDSL FP8 scaled-mm monkey-patch defaults
+            # ON, but its tuned-compile helper cannot spawn inside vLLM's daemonic TP workers
+            # ("daemonic processes are not allowed to have children") -> exception + FlashInfer
+            # fallback on EVERY GEMM call, nothing caches, and decode crawls at ~0.05-0.1 tok/s
+            # while looking "stuck". Force it off; BF16 never enters this path (no-op there).
+            - { name: VLLM_OMNI_USE_QUACK_FP8, value: "0" }
           ports: [ { containerPort: 9090, name: dyn-system } ]
           startupProbe:
             httpGet: { path: /health, port: 9090 }

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/dgd-v1beta1.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/dgd-v1beta1.yaml-template
@@ -210,6 +210,12 @@ spec:
                 - { name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS, value: "1800" }
                 - { name: HF_MODULES_CACHE, value: /tmp/hf_cache/modules }
                 - { name: VLLM_LOGGING_LEVEL, value: INFO }
+                # NVFP4 on sm100: vllm_omni's Quack/CuTeDSL FP8 scaled-mm monkey-patch defaults
+                # ON, but its tuned-compile helper cannot spawn inside vLLM's daemonic TP workers
+                # ("daemonic processes are not allowed to have children") -> exception + FlashInfer
+                # fallback on EVERY GEMM call, nothing caches, and decode crawls at ~0.05-0.1 tok/s
+                # while looking "stuck". Force it off; BF16 never enters this path (no-op there).
+                - { name: VLLM_OMNI_USE_QUACK_FP8, value: "0" }
                 # NVFP4 cubin dir is handled in the golden image (build-time chmod); no env needed.
               # Port MUST be named "system": the operator injects readiness/liveness probes
               # that target the named port; any other name fails with

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/dgd.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/dgd.yaml-template
@@ -184,6 +184,12 @@ spec:
             - { name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS, value: "1800" }
             - { name: HF_MODULES_CACHE, value: /tmp/hf_cache/modules }
             - { name: VLLM_LOGGING_LEVEL, value: INFO }
+            # NVFP4 on sm100: vllm_omni's Quack/CuTeDSL FP8 scaled-mm monkey-patch defaults
+            # ON, but its tuned-compile helper cannot spawn inside vLLM's daemonic TP workers
+            # ("daemonic processes are not allowed to have children") -> exception + FlashInfer
+            # fallback on EVERY GEMM call, nothing caches, and decode crawls at ~0.05-0.1 tok/s
+            # while looking "stuck". Force it off; BF16 never enters this path (no-op there).
+            - { name: VLLM_OMNI_USE_QUACK_FP8, value: "0" }
             # NVFP4 cubin dir is handled in the golden image (build-time chmod); no env needed.
           # Port MUST be named "system": the operator injects readiness/liveness probes
           # that target the named port; any other name fails with

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws-ep.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws-ep.yaml-template
@@ -152,6 +152,12 @@ spec:
               - { name: HF_HOME, value: /tmp/hf_cache }
               - { name: HF_MODULES_CACHE, value: /tmp/hf_cache/modules }
               - { name: VLLM_LOGGING_LEVEL, value: INFO }
+              # NVFP4 on sm100: vllm_omni's Quack/CuTeDSL FP8 scaled-mm monkey-patch defaults
+              # ON, but its tuned-compile helper cannot spawn inside vLLM's daemonic TP workers
+              # ("daemonic processes are not allowed to have children") -> exception + FlashInfer
+              # fallback on EVERY GEMM call, nothing caches, and decode crawls at ~0.05-0.1 tok/s
+              # while looking "stuck". Force it off; BF16 never enters this path (no-op there).
+              - { name: VLLM_OMNI_USE_QUACK_FP8, value: "0" }
               # 550B BF16 weight loading from Lustre exceeds the default 600s engine timeout.
               # Prefetch (~10 min) + safetensors load (~30 min) requires >= 2400s.
               - { name: VLLM_ENGINE_READY_TIMEOUT_S, value: "2400" }
@@ -268,6 +274,12 @@ spec:
               - { name: HF_HOME, value: /tmp/hf_cache }
               - { name: HF_MODULES_CACHE, value: /tmp/hf_cache/modules }
               - { name: VLLM_LOGGING_LEVEL, value: INFO }
+              # NVFP4 on sm100: vllm_omni's Quack/CuTeDSL FP8 scaled-mm monkey-patch defaults
+              # ON, but its tuned-compile helper cannot spawn inside vLLM's daemonic TP workers
+              # ("daemonic processes are not allowed to have children") -> exception + FlashInfer
+              # fallback on EVERY GEMM call, nothing caches, and decode crawls at ~0.05-0.1 tok/s
+              # while looking "stuck". Force it off; BF16 never enters this path (no-op there).
+              - { name: VLLM_OMNI_USE_QUACK_FP8, value: "0" }
               # 550B BF16 weight loading from Lustre exceeds the default 600s engine timeout.
               - { name: VLLM_ENGINE_READY_TIMEOUT_S, value: "2400" }
               # Raise the multiproc-executor RPC deadline (default 300s): a JIT-heavy first

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws.yaml-template
@@ -171,6 +171,12 @@ spec:
               - { name: HF_HOME, value: /tmp/hf_cache }
               - { name: HF_MODULES_CACHE, value: /tmp/hf_cache/modules }
               - { name: VLLM_LOGGING_LEVEL, value: INFO }
+              # NVFP4 on sm100: vllm_omni's Quack/CuTeDSL FP8 scaled-mm monkey-patch defaults
+              # ON, but its tuned-compile helper cannot spawn inside vLLM's daemonic TP workers
+              # ("daemonic processes are not allowed to have children") -> exception + FlashInfer
+              # fallback on EVERY GEMM call, nothing caches, and decode crawls at ~0.05-0.1 tok/s
+              # while looking "stuck". Force it off; BF16 never enters this path (no-op there).
+              - { name: VLLM_OMNI_USE_QUACK_FP8, value: "0" }
               # EFA / libfabric
               - { name: FI_PROVIDER, value: efa }
               - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
@@ -298,6 +304,11 @@ spec:
               # Match the leader: raise the execute_model RPC deadline so a JIT-heavy first
               # concurrent decode step can't trip the 300s default and kill this worker's shard.
               - { name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS, value: "1800" }
+              # NVFP4 on sm100: same Quack/CuTeDSL FP8 fix as the leader — engine ranks the
+              # raylet spawns on this node inherit this container's env. The measured failure
+              # was in multiproc TP workers; keep the Quack patch off on every rank so NVFP4
+              # behavior is uniform across shapes. BF16 never enters this path (no-op there).
+              - { name: VLLM_OMNI_USE_QUACK_FP8, value: "0" }
               - { name: HF_HOME, value: /tmp/hf_cache }
               - { name: HF_MODULES_CACHE, value: /tmp/hf_cache/modules }
               - { name: FI_PROVIDER, value: efa }

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/deployment.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/deployment.yaml-template
@@ -69,6 +69,12 @@ spec:
             - { name: HF_HOME, value: /tmp/hf_cache }
             - { name: HF_MODULES_CACHE, value: /tmp/hf_cache/modules }
             - { name: VLLM_LOGGING_LEVEL, value: INFO }
+            # NVFP4 on sm100: vllm_omni's Quack/CuTeDSL FP8 scaled-mm monkey-patch defaults
+            # ON, but its tuned-compile helper cannot spawn inside vLLM's daemonic TP workers
+            # ("daemonic processes are not allowed to have children") -> exception + FlashInfer
+            # fallback on EVERY GEMM call, nothing caches, and decode crawls at ~0.05-0.1 tok/s
+            # while looking "stuck". Force it off; BF16 never enters this path (no-op there).
+            - { name: VLLM_OMNI_USE_QUACK_FP8, value: "0" }
             - { name: VLLM_SSM_CONV_STATE_LAYOUT, value: DS }
             - { name: FI_PROVIDER, value: efa }
             - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
@@ -198,6 +204,12 @@ spec:
             - { name: HF_HOME, value: /tmp/hf_cache }
             - { name: HF_MODULES_CACHE, value: /tmp/hf_cache/modules }
             - { name: VLLM_LOGGING_LEVEL, value: INFO }
+            # NVFP4 on sm100: vllm_omni's Quack/CuTeDSL FP8 scaled-mm monkey-patch defaults
+            # ON, but its tuned-compile helper cannot spawn inside vLLM's daemonic TP workers
+            # ("daemonic processes are not allowed to have children") -> exception + FlashInfer
+            # fallback on EVERY GEMM call, nothing caches, and decode crawls at ~0.05-0.1 tok/s
+            # while looking "stuck". Force it off; BF16 never enters this path (no-op there).
+            - { name: VLLM_OMNI_USE_QUACK_FP8, value: "0" }
             - { name: VLLM_SSM_CONV_STATE_LAYOUT, value: DS }
             - { name: FI_PROVIDER, value: efa }
             - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd-v1beta1.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd-v1beta1.yaml-template
@@ -179,6 +179,12 @@ spec:
                 - { name: VLLM_LOGGING_LEVEL, value: INFO }
                 - { name: VLLM_SSM_CONV_STATE_LAYOUT, value: DS }
                 - { name: FLASHINFER_DISABLE_VERSION_CHECK, value: "1" }
+                # NVFP4 on sm100: vllm_omni's Quack/CuTeDSL FP8 scaled-mm monkey-patch defaults
+                # ON, but its tuned-compile helper cannot spawn inside vLLM's daemonic TP workers
+                # ("daemonic processes are not allowed to have children") -> exception + FlashInfer
+                # fallback on EVERY GEMM call, nothing caches, and decode crawls at ~0.05-0.1 tok/s
+                # while looking "stuck". Force it off; BF16 never enters this path (no-op there).
+                - { name: VLLM_OMNI_USE_QUACK_FP8, value: "0" }
                 - { name: FI_PROVIDER, value: efa }
                 - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
                 - { name: FI_EFA_FORK_SAFE, value: "1" }
@@ -312,6 +318,12 @@ spec:
                 - { name: VLLM_LOGGING_LEVEL, value: INFO }
                 - { name: VLLM_SSM_CONV_STATE_LAYOUT, value: DS }
                 - { name: FLASHINFER_DISABLE_VERSION_CHECK, value: "1" }
+                # NVFP4 on sm100: vllm_omni's Quack/CuTeDSL FP8 scaled-mm monkey-patch defaults
+                # ON, but its tuned-compile helper cannot spawn inside vLLM's daemonic TP workers
+                # ("daemonic processes are not allowed to have children") -> exception + FlashInfer
+                # fallback on EVERY GEMM call, nothing caches, and decode crawls at ~0.05-0.1 tok/s
+                # while looking "stuck". Force it off; BF16 never enters this path (no-op there).
+                - { name: VLLM_OMNI_USE_QUACK_FP8, value: "0" }
                 - { name: FI_PROVIDER, value: efa }
                 - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
                 - { name: FI_EFA_FORK_SAFE, value: "1" }

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd.yaml-template
@@ -136,6 +136,12 @@ spec:
             - { name: VLLM_LOGGING_LEVEL, value: INFO }
             - { name: VLLM_SSM_CONV_STATE_LAYOUT, value: DS }
             - { name: FLASHINFER_DISABLE_VERSION_CHECK, value: "1" }
+            # NVFP4 on sm100: vllm_omni's Quack/CuTeDSL FP8 scaled-mm monkey-patch defaults
+            # ON, but its tuned-compile helper cannot spawn inside vLLM's daemonic TP workers
+            # ("daemonic processes are not allowed to have children") -> exception + FlashInfer
+            # fallback on EVERY GEMM call, nothing caches, and decode crawls at ~0.05-0.1 tok/s
+            # while looking "stuck". Force it off; BF16 never enters this path (no-op there).
+            - { name: VLLM_OMNI_USE_QUACK_FP8, value: "0" }
             - { name: FI_PROVIDER, value: efa }
             - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
             - { name: FI_EFA_FORK_SAFE, value: "1" }
@@ -268,6 +274,12 @@ spec:
             - { name: VLLM_LOGGING_LEVEL, value: INFO }
             - { name: VLLM_SSM_CONV_STATE_LAYOUT, value: DS }
             - { name: FLASHINFER_DISABLE_VERSION_CHECK, value: "1" }
+            # NVFP4 on sm100: vllm_omni's Quack/CuTeDSL FP8 scaled-mm monkey-patch defaults
+            # ON, but its tuned-compile helper cannot spawn inside vLLM's daemonic TP workers
+            # ("daemonic processes are not allowed to have children") -> exception + FlashInfer
+            # fallback on EVERY GEMM call, nothing caches, and decode crawls at ~0.05-0.1 tok/s
+            # while looking "stuck". Force it off; BF16 never enters this path (no-op there).
+            - { name: VLLM_OMNI_USE_QUACK_FP8, value: "0" }
             - { name: FI_PROVIDER, value: efa }
             - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
             - { name: FI_EFA_FORK_SAFE, value: "1" }

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-2pp.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-2pp.yaml-template
@@ -156,6 +156,12 @@ spec:
               - { name: VLLM_USE_RAY_V2_EXECUTOR_BACKEND, value: "1" }
               - { name: VLLM_SSM_CONV_STATE_LAYOUT, value: DS }
               - { name: FLASHINFER_DISABLE_VERSION_CHECK, value: "1" }
+              # NVFP4 on sm100: vllm_omni's Quack/CuTeDSL FP8 scaled-mm monkey-patch defaults
+              # ON, but its tuned-compile helper cannot spawn inside vLLM's daemonic TP workers
+              # ("daemonic processes are not allowed to have children") -> exception + FlashInfer
+              # fallback on EVERY GEMM call, nothing caches, and decode crawls at ~0.05-0.1 tok/s
+              # while looking "stuck". Force it off; BF16 never enters this path (no-op there).
+              - { name: VLLM_OMNI_USE_QUACK_FP8, value: "0" }
               - { name: FI_PROVIDER, value: efa }
               - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
               - { name: FI_EFA_FORK_SAFE, value: "1" }
@@ -245,6 +251,11 @@ spec:
               - { name: HF_HOME, value: /shared/hf_cache }
               - { name: VLLM_SSM_CONV_STATE_LAYOUT, value: DS }
               - { name: FLASHINFER_DISABLE_VERSION_CHECK, value: "1" }
+              # NVFP4 on sm100: same Quack/CuTeDSL FP8 fix as the leader — engine ranks the
+              # raylet spawns on this node inherit this container's env. The measured failure
+              # was in multiproc TP workers; keep the Quack patch off on every rank so NVFP4
+              # behavior is uniform across shapes. BF16 never enters this path (no-op there).
+              - { name: VLLM_OMNI_USE_QUACK_FP8, value: "0" }
               - { name: FI_PROVIDER, value: efa }
               - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
               - { name: FI_EFA_FORK_SAFE, value: "1" }
@@ -439,6 +450,12 @@ spec:
               - { name: VLLM_LOGGING_LEVEL, value: INFO }
               - { name: VLLM_SSM_CONV_STATE_LAYOUT, value: DS }
               - { name: FLASHINFER_DISABLE_VERSION_CHECK, value: "1" }
+              # NVFP4 on sm100: vllm_omni's Quack/CuTeDSL FP8 scaled-mm monkey-patch defaults
+              # ON, but its tuned-compile helper cannot spawn inside vLLM's daemonic TP workers
+              # ("daemonic processes are not allowed to have children") -> exception + FlashInfer
+              # fallback on EVERY GEMM call, nothing caches, and decode crawls at ~0.05-0.1 tok/s
+              # while looking "stuck". Force it off; BF16 never enters this path (no-op there).
+              - { name: VLLM_OMNI_USE_QUACK_FP8, value: "0" }
               - { name: FI_PROVIDER, value: efa }
               - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
               - { name: FI_EFA_FORK_SAFE, value: "1" }

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-ep.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-ep.yaml-template
@@ -186,6 +186,12 @@ spec:
               - { name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS, value: "1800" }
               - { name: VLLM_ENGINE_READY_TIMEOUT_S, value: "2400" }
               - { name: FLASHINFER_DISABLE_VERSION_CHECK, value: "1" }
+              # NVFP4 on sm100: vllm_omni's Quack/CuTeDSL FP8 scaled-mm monkey-patch defaults
+              # ON, but its tuned-compile helper cannot spawn inside vLLM's daemonic TP workers
+              # ("daemonic processes are not allowed to have children") -> exception + FlashInfer
+              # fallback on EVERY GEMM call, nothing caches, and decode crawls at ~0.05-0.1 tok/s
+              # while looking "stuck". Force it off; BF16 never enters this path (no-op there).
+              - { name: VLLM_OMNI_USE_QUACK_FP8, value: "0" }
               - { name: FI_PROVIDER, value: efa }
               - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
               - { name: FI_EFA_FORK_SAFE, value: "1" }
@@ -328,6 +334,12 @@ spec:
               - { name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS, value: "1800" }
               - { name: VLLM_ENGINE_READY_TIMEOUT_S, value: "2400" }
               - { name: FLASHINFER_DISABLE_VERSION_CHECK, value: "1" }
+              # NVFP4 on sm100: vllm_omni's Quack/CuTeDSL FP8 scaled-mm monkey-patch defaults
+              # ON, but its tuned-compile helper cannot spawn inside vLLM's daemonic TP workers
+              # ("daemonic processes are not allowed to have children") -> exception + FlashInfer
+              # fallback on EVERY GEMM call, nothing caches, and decode crawls at ~0.05-0.1 tok/s
+              # while looking "stuck". Force it off; BF16 never enters this path (no-op there).
+              - { name: VLLM_OMNI_USE_QUACK_FP8, value: "0" }
               - { name: FI_PROVIDER, value: efa }
               - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
               - { name: FI_EFA_FORK_SAFE, value: "1" }
@@ -538,6 +550,12 @@ spec:
               - { name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS, value: "1800" }
               - { name: VLLM_ENGINE_READY_TIMEOUT_S, value: "2400" }
               - { name: FLASHINFER_DISABLE_VERSION_CHECK, value: "1" }
+              # NVFP4 on sm100: vllm_omni's Quack/CuTeDSL FP8 scaled-mm monkey-patch defaults
+              # ON, but its tuned-compile helper cannot spawn inside vLLM's daemonic TP workers
+              # ("daemonic processes are not allowed to have children") -> exception + FlashInfer
+              # fallback on EVERY GEMM call, nothing caches, and decode crawls at ~0.05-0.1 tok/s
+              # while looking "stuck". Force it off; BF16 never enters this path (no-op there).
+              - { name: VLLM_OMNI_USE_QUACK_FP8, value: "0" }
               - { name: FI_PROVIDER, value: efa }
               - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
               - { name: FI_EFA_FORK_SAFE, value: "1" }
@@ -682,6 +700,12 @@ spec:
               - { name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS, value: "1800" }
               - { name: VLLM_ENGINE_READY_TIMEOUT_S, value: "2400" }
               - { name: FLASHINFER_DISABLE_VERSION_CHECK, value: "1" }
+              # NVFP4 on sm100: vllm_omni's Quack/CuTeDSL FP8 scaled-mm monkey-patch defaults
+              # ON, but its tuned-compile helper cannot spawn inside vLLM's daemonic TP workers
+              # ("daemonic processes are not allowed to have children") -> exception + FlashInfer
+              # fallback on EVERY GEMM call, nothing caches, and decode crawls at ~0.05-0.1 tok/s
+              # while looking "stuck". Force it off; BF16 never enters this path (no-op there).
+              - { name: VLLM_OMNI_USE_QUACK_FP8, value: "0" }
               - { name: FI_PROVIDER, value: efa }
               - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
               - { name: FI_EFA_FORK_SAFE, value: "1" }

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-pp2.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-pp2.yaml-template
@@ -151,6 +151,12 @@ spec:
               - { name: DYN_SYSTEM_ENABLED, value: "true" }
               - { name: DYN_SYSTEM_PORT, value: "9091" }
               - { name: VLLM_LOGGING_LEVEL, value: INFO }
+              # NVFP4 on sm100: vllm_omni's Quack/CuTeDSL FP8 scaled-mm monkey-patch defaults
+              # ON, but its tuned-compile helper cannot spawn inside vLLM's daemonic TP workers
+              # ("daemonic processes are not allowed to have children") -> exception + FlashInfer
+              # fallback on EVERY GEMM call, nothing caches, and decode crawls at ~0.05-0.1 tok/s
+              # while looking "stuck". Force it off; BF16 never enters this path (no-op there).
+              - { name: VLLM_OMNI_USE_QUACK_FP8, value: "0" }
               - { name: VLLM_SSM_CONV_STATE_LAYOUT, value: DS }
               - { name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS, value: "1800" }
               - { name: VLLM_USE_RAY_COMPILED_DAG, value: "0"}
@@ -249,6 +255,11 @@ spec:
               - { name: HF_HOME, value: /shared/hf_cache }
               - { name: VLLM_SSM_CONV_STATE_LAYOUT, value: DS }
               - { name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS, value: "1800" }
+              # NVFP4 on sm100: same Quack/CuTeDSL FP8 fix as the leader — engine ranks the
+              # raylet spawns on this node inherit this container's env. The measured failure
+              # was in multiproc TP workers; keep the Quack patch off on every rank so NVFP4
+              # behavior is uniform across shapes. BF16 never enters this path (no-op there).
+              - { name: VLLM_OMNI_USE_QUACK_FP8, value: "0" }
               - { name: VLLM_USE_RAY_COMPILED_DAG, value: "0" }
               - { name: FI_PROVIDER, value: efa }
               - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
@@ -454,6 +465,12 @@ spec:
               - { name: WARMUP_CONCURRENCY, value: "${WARMUP_CONCURRENCY}" }
               - { name: VLLM_SSM_CONV_STATE_LAYOUT, value: DS }
               - { name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS, value: "1800" }
+              # NVFP4 on sm100: vllm_omni's Quack/CuTeDSL FP8 scaled-mm monkey-patch defaults
+              # ON, but its tuned-compile helper cannot spawn inside vLLM's daemonic TP workers
+              # ("daemonic processes are not allowed to have children") -> exception + FlashInfer
+              # fallback on EVERY GEMM call, nothing caches, and decode crawls at ~0.05-0.1 tok/s
+              # while looking "stuck". Force it off; BF16 never enters this path (no-op there).
+              - { name: VLLM_OMNI_USE_QUACK_FP8, value: "0" }
               - { name: VLLM_USE_RAY_COMPILED_DAG, value: "0" }
               - { name: FI_PROVIDER, value: efa }
               - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
@@ -547,6 +564,11 @@ spec:
               - { name: HF_HOME, value: /shared/hf_cache }
               - { name: VLLM_SSM_CONV_STATE_LAYOUT, value: DS }
               - { name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS, value: "1800" }
+              # NVFP4 on sm100: same Quack/CuTeDSL FP8 fix as the leader — engine ranks the
+              # raylet spawns on this node inherit this container's env. The measured failure
+              # was in multiproc TP workers; keep the Quack patch off on every rank so NVFP4
+              # behavior is uniform across shapes. BF16 never enters this path (no-op there).
+              - { name: VLLM_OMNI_USE_QUACK_FP8, value: "0" }
               - { name: VLLM_USE_RAY_COMPILED_DAG, value: "0" }
               - { name: ETCD_ENDPOINTS, value: "${ETCD_URL}" }
               - { name: NATS_SERVER, value: "${NATS_URL}" }


### PR DESCRIPTION
Follow-up to #98 (dgd-grove only), answering "does this fix need to be applied to any of the other templates?" — **yes, all of them that run vLLM workers.**

## Why every sibling template needs it
All 11 remaining templates in `agg/` and `disagg/` (`deployment`, `dgd`, `dgd-v1beta1`, `lws`, `lws-ep`, `lws-2pp`, `lws-pp2`) launch the same `${REGISTRY}${IMAGE}${TAG}` image — default `dynamo-vllm-efa:1.4.0-patched`, which bakes `vllm_omni` 0.26.0rc1. Serving an NVFP4 checkpoint on sm100/B200 from any of them hits the same bug #98 fixed: the Quack/CuTeDSL FP8 scaled-mm monkey-patch (default-ON on sm100) tries to spawn its tuned-compile child inside vLLM's daemonic TP workers, throws `daemonic processes are not allowed to have children` on every GEMM call, and decode crawls at ~0.05–0.1 tok/s while looking hung.

## Coverage — 24 env placements across 11 templates
- One `VLLM_OMNI_USE_QUACK_FP8=0` block per **GPU worker container**, with the same provenance comment as #98.
- **Ray worker-group containers included** (`agg/lws`, `disagg/lws-2pp`, `disagg/lws-pp2`): engine ranks the raylet spawns there inherit the container env. The measured failure was in multiproc TP workers; the Ray shapes get the env so NVFP4 behavior is uniform across every template (their comment variant states this honestly).
- **Frontends excluded** (CPU router, no GEMMs — same exclusion as #98). `test/aiperf-sweep` untouched (python:3.12-slim load client).
- No-op for BF16 (never enters the FP8 scaled-mm path) and on non-sm100 GPUs, so H100/H200 use is unaffected.

## Verification
All 11 templates rendered through the `run.sh` envsubst path (`.env` sourced, `DOLLAR` handling intact) and re-parsed as YAML; each rendered manifest carries exactly the expected env count in its worker env lists (agg: 1/1/1/2/2, disagg: 2/2/2/3/4/4). Existing deployments need a workload delete + re-apply to pick the env up.