### PR TITLE
nemotron/ultra: pin FlashInfer CUTLASS MoE backend for BF16 (vLLM 0.26 decode ITL fix)

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/.env
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/.env
@@ -112,6 +112,35 @@ export MODEL_PATH="${MODEL_PATH:-/shared/models/hf/${MODEL_NAME}}"
 # One guarded export, keeping runai_streamer as the value that was actually in force.
 export LOAD_FORMAT="${LOAD_FORMAT:-runai_streamer}"
 
+# ---- MoE backend pin (identical block in ../disagg/.env; vLLM 0.23->0.26 decode ITL regression) ----
+# vLLM PR #43853 (landed v0.24, so it is in TAG=":1.4.0-patched" / vLLM 0.26 but NOT in
+# ":1.3.1-patched" / vLLM 0.23) let the TRTLLM-gen monolithic BF16 MoE kernel accept NON-GATED
+# (relu2) MoE models - exactly what Nemotron-3-Ultra is. 0.26 therefore auto-selects
+# TrtLlmBf16ExpertsMonolithic on all 48 MoE layers where 0.23 auto-selected FlashInfer CUTLASS.
+# The new kernel is FASTER on-GPU (-46% MoE kernel time) but adds ~+176us HOST cost per
+# vllm::moe_forward_shared call (48 calls per decode step); under TP8 the launching rank's host
+# stall gates every layer and the other 7 GPUs spin in allreduce -> decode ITL ~+20% while GPUs
+# read 100% busy. Measured three-way on the identical profiled 128-token temp-0 window (B200
+# TP8/PP1, same node): decode step p50 114.7ms (0.23) -> 130.8ms (0.26) -> 117.0ms (0.26 + this
+# pin), output byte-identical across all three legs. Filed upstream with the full kernel table:
+# https://github.com/vllm-project/vllm/issues/53472 - drop this pin when the upstream backend
+# selection becomes decode-shape-aware.
+# Tradeoff (deliberate): stock 0.26 prefill was ~19% FASTER on the new path (the same fixed
+# host cost amortizes over 1024 prefill tokens while keeping the GPU win); the pin returns
+# prefill to 0.23-class too. Pin only if ITL is what you optimize for.
+# Tag-flip safe: --moe-backend is a vLLM CLI arg on BOTH image lines (present at v0.23.0) and
+# "flashinfer_cutlass" is a valid explicit oracle choice on both; on ":1.3.1-patched" it pins
+# what 0.23 auto-selects anyway - which also keeps 1.3.1-vs-1.4.0 A/Bs single-variable.
+# NVFP4 is UNMEASURED here (different oracle, different default; the regression was established
+# on BF16), so non-BF16 model names derive an EMPTY default and keep vLLM's auto selection; opt
+# in explicitly with MOE_BACKEND_FLAG="--moe-backend flashinfer_cutlass".
+# Auto-derived from MODEL_NAME; override MOE_BACKEND_FLAG='' to force stock auto selection.
+case "${MODEL_NAME}" in
+  *Nemotron*BF16*|*nemotron*BF16*) _MOE_BACKEND_DEFAULT="--moe-backend flashinfer_cutlass" ;;
+  *)                               _MOE_BACKEND_DEFAULT="" ;;
+esac
+export MOE_BACKEND_FLAG="${MOE_BACKEND_FLAG-${_MOE_BACKEND_DEFAULT}}"
+
 # ---- Cold-start warmup (identical block and identical knobs in ../disagg/.env) ----
 # A fresh pod's FIRST requests pay a one-time Triton JIT of the Mamba DECODE kernels
 # (_selective_scan_update / _causal_conv1d_update): startup only warms the PREFILL SSD path,

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/deployment.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/deployment.yaml-template
@@ -189,7 +189,7 @@ spec:
                 --max-model-len 4096 \
                 --gpu-memory-utilization 0.97 \
                 --enforce-eager \
-                --trust-remote-code \
+                --trust-remote-code ${MOE_BACKEND_FLAG} \
                 --mamba-cache-mode align
           env:
             - { name: DYNAMO_BACKEND, value: vllm }

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/dgd-grove.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/dgd-grove.yaml-template
@@ -192,7 +192,7 @@ spec:
                     --tensor-parallel-size ${GPU_PER_WORKER} \
                     --pipeline-parallel-size ${NODE_COUNT_PER_WORKER} \
                     --max-model-len 4096 --gpu-memory-utilization 0.97 --enforce-eager \
-                    --trust-remote-code \
+                    --trust-remote-code ${MOE_BACKEND_FLAG} \
                     --mamba-cache-mode align
               env:
                 # Read only by the duplicate-address preflight in args above.

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/dgd-v1beta1.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/dgd-v1beta1.yaml-template
@@ -191,7 +191,7 @@ spec:
                     --load-format ${LOAD_FORMAT} \
                     --tensor-parallel-size ${GPU_PER_WORKER} --pipeline-parallel-size 1 \
                     --max-model-len 4096 --gpu-memory-utilization 0.97 --enforce-eager \
-                    --trust-remote-code \
+                    --trust-remote-code ${MOE_BACKEND_FLAG} \
                     --mamba-cache-mode align
               env:
                 # Read only by the duplicate-address preflight in args above.

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/dgd.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/dgd.yaml-template
@@ -165,7 +165,7 @@ spec:
                 --load-format ${LOAD_FORMAT} \
                 --tensor-parallel-size ${GPU_PER_WORKER} --pipeline-parallel-size 1 \
                 --max-model-len 4096 --gpu-memory-utilization 0.97 --enforce-eager \
-                --trust-remote-code \
+                --trust-remote-code ${MOE_BACKEND_FLAG} \
                 --mamba-cache-mode align
           env:
             # Read only by the duplicate-address preflight in args above.

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws-ep.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws-ep.yaml-template
@@ -141,7 +141,7 @@ spec:
                   --max-model-len 8192 \
                   --gpu-memory-utilization 0.92 \
                   --enforce-eager \
-                  --trust-remote-code \
+                  --trust-remote-code ${MOE_BACKEND_FLAG} \
                   --mamba-cache-mode align \
                   --no-disable-hybrid-kv-cache-manager \
                   --host 0.0.0.0 --port 8000
@@ -266,7 +266,7 @@ spec:
                   --max-model-len 8192 \
                   --gpu-memory-utilization 0.92 \
                   --enforce-eager \
-                  --trust-remote-code \
+                  --trust-remote-code ${MOE_BACKEND_FLAG} \
                   --mamba-cache-mode align \
                   --no-disable-hybrid-kv-cache-manager
             env:

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/lws.yaml-template
@@ -148,7 +148,7 @@ spec:
                   --max-model-len 8192 \
                   --gpu-memory-utilization 0.92 \
                   --enforce-eager \
-                  --trust-remote-code \
+                  --trust-remote-code ${MOE_BACKEND_FLAG} \
                   --mamba-cache-mode align
             env:
               - { name: DYNAMO_BACKEND, value: vllm }

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/.env
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/.env
@@ -107,6 +107,35 @@ case "${MODEL_NAME}" in
 esac
 export MAMBA_FLAGS="${MAMBA_FLAGS-${_MAMBA_DEFAULT}}"
 
+# ---- MoE backend pin (identical block in ../agg/.env; vLLM 0.23->0.26 decode ITL regression) ----
+# vLLM PR #43853 (landed v0.24, so it is in TAG=":1.4.0-patched" / vLLM 0.26 but NOT in
+# ":1.3.1-patched" / vLLM 0.23) let the TRTLLM-gen monolithic BF16 MoE kernel accept NON-GATED
+# (relu2) MoE models - exactly what Nemotron-3-Ultra is. 0.26 therefore auto-selects
+# TrtLlmBf16ExpertsMonolithic on all 48 MoE layers where 0.23 auto-selected FlashInfer CUTLASS.
+# The new kernel is FASTER on-GPU (-46% MoE kernel time) but adds ~+176us HOST cost per
+# vllm::moe_forward_shared call (48 calls per decode step); under TP8 the launching rank's host
+# stall gates every layer and the other 7 GPUs spin in allreduce -> decode ITL ~+20% while GPUs
+# read 100% busy. Measured three-way on the identical profiled 128-token temp-0 window (B200
+# TP8/PP1, same node): decode step p50 114.7ms (0.23) -> 130.8ms (0.26) -> 117.0ms (0.26 + this
+# pin), output byte-identical across all three legs. Filed upstream with the full kernel table:
+# https://github.com/vllm-project/vllm/issues/53472 - drop this pin when the upstream backend
+# selection becomes decode-shape-aware.
+# Tradeoff (deliberate): stock 0.26 prefill was ~19% FASTER on the new path (the same fixed
+# host cost amortizes over 1024 prefill tokens while keeping the GPU win); the pin returns
+# prefill to 0.23-class too. Pin only if ITL is what you optimize for.
+# Tag-flip safe: --moe-backend is a vLLM CLI arg on BOTH image lines (present at v0.23.0) and
+# "flashinfer_cutlass" is a valid explicit oracle choice on both; on ":1.3.1-patched" it pins
+# what 0.23 auto-selects anyway - which also keeps 1.3.1-vs-1.4.0 A/Bs single-variable.
+# NVFP4 is UNMEASURED here (different oracle, different default; the regression was established
+# on BF16), so non-BF16 model names derive an EMPTY default and keep vLLM's auto selection; opt
+# in explicitly with MOE_BACKEND_FLAG="--moe-backend flashinfer_cutlass".
+# Auto-derived from MODEL_NAME; override MOE_BACKEND_FLAG='' to force stock auto selection.
+case "${MODEL_NAME}" in
+  *Nemotron*BF16*|*nemotron*BF16*) _MOE_BACKEND_DEFAULT="--moe-backend flashinfer_cutlass" ;;
+  *)                               _MOE_BACKEND_DEFAULT="" ;;
+esac
+export MOE_BACKEND_FLAG="${MOE_BACKEND_FLAG-${_MOE_BACKEND_DEFAULT}}"
+
 # ---- cold-start warmup (identical block and identical knobs in ../agg/.env) ----
 # A fresh pod's FIRST requests pay a one-time Triton JIT of the Mamba DECODE kernels
 # (_selective_scan_update / _causal_conv1d_update): startup only warms the PREFILL SSD path,

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/deployment.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/deployment.yaml-template
@@ -54,7 +54,7 @@ spec:
                 --served-model-name ${MODEL_NAME} \
                 --tensor-parallel-size ${GPU_PER_WORKER} --pipeline-parallel-size 1 \
                 --max-model-len 4096 --gpu-memory-utilization 0.97 --enforce-eager \
-                --trust-remote-code ${MAMBA_FLAGS} \
+                --trust-remote-code ${MAMBA_FLAGS} ${MOE_BACKEND_FLAG} \
                 --load-format runai_streamer \
                 --disaggregation-mode prefill \
                 --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"],"kv_lease_duration":${KV_LEASE_DURATION}}}'
@@ -184,7 +184,7 @@ spec:
                 --served-model-name ${MODEL_NAME} \
                 --tensor-parallel-size ${GPU_PER_WORKER} --pipeline-parallel-size 1 \
                 --max-model-len 4096 --gpu-memory-utilization 0.97 --enforce-eager \
-                --trust-remote-code ${MAMBA_FLAGS} \
+                --trust-remote-code ${MAMBA_FLAGS} ${MOE_BACKEND_FLAG} \
                 --load-format runai_streamer \
                 --disaggregation-mode decode \
                 --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"],"kv_lease_duration":${KV_LEASE_DURATION}}}'

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd-grove.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd-grove.yaml-template
@@ -166,7 +166,7 @@ spec:
                     --served-model-name ${MODEL_NAME} \
                     --tensor-parallel-size ${GPU_PER_WORKER} --pipeline-parallel-size 1 \
                     --max-model-len 4096 --gpu-memory-utilization 0.97 --enforce-eager \
-                    --trust-remote-code ${MAMBA_FLAGS} \
+                    --trust-remote-code ${MAMBA_FLAGS} ${MOE_BACKEND_FLAG} \
                     --load-format runai_streamer \
                     --disaggregation-mode prefill \
                     --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"],"kv_lease_duration":${KV_LEASE_DURATION}}}'
@@ -309,7 +309,7 @@ spec:
                     --served-model-name ${MODEL_NAME} \
                     --tensor-parallel-size ${GPU_PER_WORKER} --pipeline-parallel-size 1 \
                     --max-model-len 4096 --gpu-memory-utilization 0.97 --enforce-eager \
-                    --trust-remote-code ${MAMBA_FLAGS} \
+                    --trust-remote-code ${MAMBA_FLAGS} ${MOE_BACKEND_FLAG} \
                     --load-format runai_streamer \
                     --disaggregation-mode decode \
                     --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"],"kv_lease_duration":${KV_LEASE_DURATION}}}'

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd-v1beta1.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd-v1beta1.yaml-template
@@ -163,7 +163,7 @@ spec:
                     --served-model-name ${MODEL_NAME} \
                     --tensor-parallel-size ${GPU_PER_WORKER} --pipeline-parallel-size 1 \
                     --max-model-len 4096 --gpu-memory-utilization 0.97 --enforce-eager \
-                    --trust-remote-code ${MAMBA_FLAGS} \
+                    --trust-remote-code ${MAMBA_FLAGS} ${MOE_BACKEND_FLAG} \
                     --load-format runai_streamer \
                     --disaggregation-mode prefill \
                     --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"],"kv_lease_duration":${KV_LEASE_DURATION}}}'
@@ -302,7 +302,7 @@ spec:
                     --served-model-name ${MODEL_NAME} \
                     --tensor-parallel-size ${GPU_PER_WORKER} --pipeline-parallel-size 1 \
                     --max-model-len 4096 --gpu-memory-utilization 0.97 --enforce-eager \
-                    --trust-remote-code ${MAMBA_FLAGS} \
+                    --trust-remote-code ${MAMBA_FLAGS} ${MOE_BACKEND_FLAG} \
                     --load-format runai_streamer \
                     --disaggregation-mode decode \
                     --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"],"kv_lease_duration":${KV_LEASE_DURATION}}}'

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd.yaml-template
@@ -120,7 +120,7 @@ spec:
                 --served-model-name ${MODEL_NAME} \
                 --tensor-parallel-size ${GPU_PER_WORKER} --pipeline-parallel-size 1 \
                 --max-model-len 4096 --gpu-memory-utilization 0.97 --enforce-eager \
-                --trust-remote-code ${MAMBA_FLAGS} \
+                --trust-remote-code ${MAMBA_FLAGS} ${MOE_BACKEND_FLAG} \
                 --load-format runai_streamer \
                 --disaggregation-mode prefill \
                 --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"],"kv_lease_duration":${KV_LEASE_DURATION}}}'
@@ -258,7 +258,7 @@ spec:
                 --served-model-name ${MODEL_NAME} \
                 --tensor-parallel-size ${GPU_PER_WORKER} --pipeline-parallel-size 1 \
                 --max-model-len 4096 --gpu-memory-utilization 0.97 --enforce-eager \
-                --trust-remote-code ${MAMBA_FLAGS} \
+                --trust-remote-code ${MAMBA_FLAGS} ${MOE_BACKEND_FLAG} \
                 --load-format runai_streamer \
                 --disaggregation-mode decode \
                 --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"],"kv_lease_duration":${KV_LEASE_DURATION}}}'

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-2pp.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-2pp.yaml-template
@@ -136,7 +136,7 @@ spec:
                   --max-model-len 8192 \
                   --gpu-memory-utilization 0.92 \
                   --enforce-eager \
-                  --trust-remote-code \
+                  --trust-remote-code ${MOE_BACKEND_FLAG} \
                   ${MAMBA_FLAGS} \
                   --load-format runai_streamer \
                   --disaggregation-mode prefill \
@@ -429,7 +429,7 @@ spec:
                   --max-model-len 8192 \
                   --gpu-memory-utilization 0.98 \
                   --enforce-eager \
-                  --trust-remote-code \
+                  --trust-remote-code ${MOE_BACKEND_FLAG} \
                   ${MAMBA_FLAGS} \
                   --load-format runai_streamer \
                   --disaggregation-mode decode \

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-ep.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-ep.yaml-template
@@ -165,7 +165,7 @@ spec:
                   --max-model-len 8192 \
                   --gpu-memory-utilization 0.92 \
                   --enforce-eager \
-                  --trust-remote-code \
+                  --trust-remote-code ${MOE_BACKEND_FLAG} \
                   ${MAMBA_FLAGS} \
                   --load-format runai_streamer \
                   --disaggregation-mode prefill \
@@ -315,7 +315,7 @@ spec:
                   --max-model-len 8192 \
                   --gpu-memory-utilization 0.92 \
                   --enforce-eager \
-                  --trust-remote-code \
+                  --trust-remote-code ${MOE_BACKEND_FLAG} \
                   ${MAMBA_FLAGS} \
                   --load-format runai_streamer \
                   --disaggregation-mode prefill \
@@ -528,7 +528,7 @@ spec:
                   --max-model-len 8192 \
                   --gpu-memory-utilization 0.92 \
                   --enforce-eager \
-                  --trust-remote-code \
+                  --trust-remote-code ${MOE_BACKEND_FLAG} \
                   ${MAMBA_FLAGS} \
                   --load-format runai_streamer \
                   --disaggregation-mode decode \
@@ -681,7 +681,7 @@ spec:
                   --max-model-len 8192 \
                   --gpu-memory-utilization 0.92 \
                   --enforce-eager \
-                  --trust-remote-code \
+                  --trust-remote-code ${MOE_BACKEND_FLAG} \
                   ${MAMBA_FLAGS} \
                   --load-format runai_streamer \
                   --disaggregation-mode decode \

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-pp2.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/lws-pp2.yaml-template
@@ -136,7 +136,7 @@ spec:
                   --max-model-len 8192 \
                   --gpu-memory-utilization 0.92 \
                   --enforce-eager \
-                  --trust-remote-code \
+                  --trust-remote-code ${MOE_BACKEND_FLAG} \
                   ${MAMBA_FLAGS} \
                   --load-format runai_streamer \
                   --disaggregation-mode prefill \
@@ -447,7 +447,7 @@ spec:
                   --max-model-len 8192 \
                   --gpu-memory-utilization 0.92 \
                   --enforce-eager \
-                  --trust-remote-code \
+                  --trust-remote-code ${MOE_BACKEND_FLAG} \
                   ${MAMBA_FLAGS} \
                   --load-format runai_streamer \
                   --disaggregation-mode decode \


### PR DESCRIPTION
## What

Adds a `MOE_BACKEND_FLAG` knob to the nemotron/ultra `.env` files (agg + disagg) that pins `--moe-backend flashinfer_cutlass` on the BF16 Nemotron templates, applied at all 23 vLLM worker launch sites across the 13 agg/ + disagg/ templates. This closes the ~20% decode ITL regression between the `:1.3.1-patched` (vLLM 0.23) and `:1.4.0-patched` (vLLM 0.26) images at the deployment layer, so 1.4.0 serves with 0.23-class ITL.

## Why (measured)

vLLM PR #43853 (v0.24) let the TRTLLM-gen monolithic BF16 MoE kernel accept non-gated (relu2) MoE models — exactly what Nemotron-3-Ultra is. vLLM 0.26 therefore auto-selects `TrtLlmBf16ExpertsMonolithic` on all 48 MoE layers where 0.23 auto-selected FlashInfer CUTLASS. The new kernel is *faster on-GPU* (−46% MoE kernel time) but adds ~+176µs of **host** cost per `vllm::moe_forward_shared` call (48 calls per decode step); under TP8 the launching rank's host stall gates every layer and the other 7 GPUs spin in allreduce — decode ITL ~+20% while GPUs read 100% busy.

Three-way A/B on the identical profiled 128-token temp-0 decode window (B200 TP8/PP1, same node, torch.profiler):

| leg | decode step p50 |
|---|---|
| 1.3.1-patched (vLLM 0.23) | 114.7 ms |
| 1.4.0-patched (vLLM 0.26) | 130.8 ms |
| 1.4.0-patched + this pin | **117.0 ms** |

Output is byte-identical across all three legs — speed only, no behavior change. Filed upstream with the full per-kernel table: vllm-project/vllm#53472. Drop this pin when the upstream backend selection becomes decode-shape-aware.

## Tradeoff (deliberate)

Stock 0.26 prefill was ~19% *faster* on the new path (the same fixed host cost amortizes over 1024 prefill tokens while keeping the GPU win); the pin returns prefill to 0.23-class too. The pin optimizes for ITL.

## Design

- **`MAMBA_FLAGS` pattern**: auto-derived from `MODEL_NAME` — Nemotron BF16 → `--moe-backend flashinfer_cutlass`; anything else (including NVFP4, which is **unmeasured** and has a different selection oracle) → empty, keeping vLLM's auto selection. Override with `MOE_BACKEND_FLAG=''` (force stock) or an explicit value (opt NVFP4 in).
- **Tag-flip safe**: `--moe-backend` is a vLLM CLI arg on both image lines (present at v0.23.0) and `flashinfer_cutlass` is a valid explicit oracle choice on both; on `:1.3.1-patched` it pins what 0.23 auto-selects anyway — which also keeps 1.3.1-vs-1.4.0 A/Bs single-variable.
- **Anchor**: the `--trust-remote-code` line of each launch block (exactly one per launch site, verified 1:1).

## Verification

Render gate, all PASS: every template × {BF16, NVFP4} rendered through the same `source .env | envsubst` path `run.sh` uses; `yaml.safe_load_all` parses; flag count == launch-site count on BF16 and == 0 on NVFP4; no unrendered `${MOE_BACKEND_FLAG}` survives; `bash -n` clean on every embedded launch script; `MOE_BACKEND_FLAG=''` and the non-Nemotron `MODEL_NAME` escape hatch both render flag-free.