### PR TITLE
nemotron/ultra: dgd-grove-pp2 and dgd-grove-ep variants (symmetric PP2 + EP16 as Grove-rendered DGDs)

### DIFF
--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/README.md
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/README.md
@@ -64,12 +64,17 @@ The folder decides whether prefill and decode are split; `MANIFEST_TYPE` decides
 | `agg/` | `lws-ep` | wide expert parallelism, DP`EP_DP_SIZE` x TP8 (EP16 by default) | 2 | no |
 | `agg/` | `dgd` | `DynamoGraphDeployment`, one worker (needs the Dynamo operator) | 1 | no |
 | `agg/` | `dgd-v1beta1` | the same deployment on the `nvidia.com/v1beta1` API instead of the deprecated `v1alpha1` | 1 | no |
+| `agg/` | `dgd-grove` | the `lws` engine shape (one engine, TP8 x PP`NODE_COUNT_PER_WORKER`) as a `v1beta1` DGD with `multinode.nodeCount`, Grove-rendered and gang-scheduled (needs Dynamo >= 1.4.0 + Grove/KAI) | `NODE_COUNT_PER_WORKER` (2) | no |
+| `agg/` | `dgd-grove-ep` | the `lws-ep` shape (wide EP, DP`EP_DP_SIZE` x TP8) as a Grove-rendered DGD; the operator injects the DP coordination — unproven pending live smoke, see the template header | `EP_DP_SIZE` (2) | no |
 | `disagg/` | `deployment` | 1 prefill + 1 decode, TP8/PP1 each | 2 | yes |
 | `disagg/` | `lws-2pp` | prefill TP8/PP2 + 2x decode TP8/PP1 | 4 | yes |
 | `disagg/` | `lws-pp2` | symmetrical PP2: prefill AND decode each TP8/PP2 | 4 | yes |
 | `disagg/` | `lws-ep` | wide expert parallelism **per role**: prefill DP`EP_DP_SIZE` x TP8 + decode DP`EP_DP_SIZE` x TP8 (EP16 each by default) | 2 x `EP_DP_SIZE` (4) | yes |
 | `disagg/` | `dgd` | `DynamoGraphDeployment` prefill + decode (needs the Dynamo operator) | 2 | yes |
 | `disagg/` | `dgd-v1beta1` | the same deployment on the `nvidia.com/v1beta1` API instead of the deprecated `v1alpha1` | 2 | yes |
+| `disagg/` | `dgd-grove` | the `dgd-v1beta1` topology Grove-rendered and gang-scheduled as one PodGang (needs Dynamo >= 1.4.0 + Grove/KAI) | 2 | yes |
+| `disagg/` | `dgd-grove-pp2` | the `lws-pp2` shape (symmetric PP2 per role) as a Grove-rendered DGD, both workers `multinode.nodeCount` — requires the `:1.4.0-patched` image (stock vLLM 0.26 refuses PP>1 + hybrid-KV); unvalidated through the operator path, see the template header | 2 x `NODE_COUNT_PER_WORKER` (4) | yes |
+| `disagg/` | `dgd-grove-ep` | the `lws-ep` shape (EP16 per role) as a Grove-rendered DGD; the operator injects the DP coordination — unproven pending live smoke, see the template header | 2 x `EP_DP_SIZE` (4) | yes |
 
 `MANIFEST_TYPE` names the template file directly. For example, if MANIFEST_TYPE=dgd, then `run.sh` replaces all variables in dgd.yaml-template with values from .env, producing `dgd.yaml`, then executes `kubectl apply -f ./dgd.yaml`. The `./stop.sh` script executes `kubectl delete -f ./dgd.yaml` correspondingly. 
 

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/README.md
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/README.md
@@ -65,7 +65,7 @@ The folder decides whether prefill and decode are split; `MANIFEST_TYPE` decides
 | `agg/` | `dgd` | `DynamoGraphDeployment`, one worker (needs the Dynamo operator) | 1 | no |
 | `agg/` | `dgd-v1beta1` | the same deployment on the `nvidia.com/v1beta1` API instead of the deprecated `v1alpha1` | 1 | no |
 | `agg/` | `dgd-grove` | the `lws` engine shape (one engine, TP8 x PP`NODE_COUNT_PER_WORKER`) as a `v1beta1` DGD with `multinode.nodeCount`, Grove-rendered and gang-scheduled (needs Dynamo >= 1.4.0 + Grove/KAI) | `NODE_COUNT_PER_WORKER` (2) | no |
-| `agg/` | `dgd-grove-ep` | the `lws-ep` shape (wide EP, DP`EP_DP_SIZE` x TP8) as a Grove-rendered DGD; the operator injects the DP coordination — unproven pending live smoke, see the template header | `EP_DP_SIZE` (2) | no |
+| `agg/` | `dgd-grove-ep` | the `lws-ep` shape (wide EP, DP`EP_DP_SIZE` x TP8) as a Grove-rendered DGD; the operator injects the DP coordination — proven live 2026-08-24, see the template header | `EP_DP_SIZE` (2) | no |
 | `disagg/` | `deployment` | 1 prefill + 1 decode, TP8/PP1 each | 2 | yes |
 | `disagg/` | `lws-2pp` | prefill TP8/PP2 + 2x decode TP8/PP1 | 4 | yes |
 | `disagg/` | `lws-pp2` | symmetrical PP2: prefill AND decode each TP8/PP2 | 4 | yes |
@@ -73,8 +73,8 @@ The folder decides whether prefill and decode are split; `MANIFEST_TYPE` decides
 | `disagg/` | `dgd` | `DynamoGraphDeployment` prefill + decode (needs the Dynamo operator) | 2 | yes |
 | `disagg/` | `dgd-v1beta1` | the same deployment on the `nvidia.com/v1beta1` API instead of the deprecated `v1alpha1` | 2 | yes |
 | `disagg/` | `dgd-grove` | the `dgd-v1beta1` topology Grove-rendered and gang-scheduled as one PodGang (needs Dynamo >= 1.4.0 + Grove/KAI) | 2 | yes |
-| `disagg/` | `dgd-grove-pp2` | the `lws-pp2` shape (symmetric PP2 per role) as a Grove-rendered DGD, both workers `multinode.nodeCount` — requires the `:1.4.0-patched` image (stock vLLM 0.26 refuses PP>1 + hybrid-KV); unvalidated through the operator path, see the template header | 2 x `NODE_COUNT_PER_WORKER` (4) | yes |
-| `disagg/` | `dgd-grove-ep` | the `lws-ep` shape (EP16 per role) as a Grove-rendered DGD; the operator injects the DP coordination — unproven pending live smoke, see the template header | 2 x `EP_DP_SIZE` (4) | yes |
+| `disagg/` | `dgd-grove-pp2` | the `lws-pp2` shape (symmetric PP2 per role) as a Grove-rendered DGD, both workers `multinode.nodeCount` — requires the `:1.4.0-patched` image (stock vLLM 0.26 refuses PP>1 + hybrid-KV); proven live 2026-08-24 through the operator path, see the template header | 2 x `NODE_COUNT_PER_WORKER` (4) | yes |
+| `disagg/` | `dgd-grove-ep` | the `lws-ep` shape (EP16 per role) as a Grove-rendered DGD; the operator injects the DP coordination — proven live 2026-08-24, see the template header | 2 x `EP_DP_SIZE` (4) | yes |
 
 `MANIFEST_TYPE` names the template file directly. For example, if MANIFEST_TYPE=dgd, then `run.sh` replaces all variables in dgd.yaml-template with values from .env, producing `dgd.yaml`, then executes `kubectl apply -f ./dgd.yaml`. The `./stop.sh` script executes `kubectl delete -f ./dgd.yaml` correspondingly. 
 

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/.env
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/.env
@@ -21,7 +21,7 @@ export DOLLAR='$'
 export NAMESPACE=${NAMESPACE:-default}
 export DEPLOYMENT_NAME=${DEPLOYMENT_NAME:-nemotron3-ultra-550b-agg}
 
-# MANIFEST_TYPE=deployment|lws|lws-ep|dgd|dgd-v1beta1|dgd-grove
+# MANIFEST_TYPE=deployment|lws|lws-ep|dgd|dgd-v1beta1|dgd-grove|dgd-grove-ep
 #   deployment : plain Deployment, 1 worker node, TP8/PP1 (simplest)
 #   lws        : LeaderWorkerSet, one engine TP8/PP2 across 2 nodes
 #   lws-ep     : EP16 aggregated - LWS DP2 x TP8 with --enable-expert-parallel (EP degree 16)
@@ -39,6 +39,12 @@ export DEPLOYMENT_NAME=${DEPLOYMENT_NAME:-nemotron3-ultra-550b-agg}
 #                and gang-scheduled by kai-scheduler. Needs Dynamo >= 1.4.0 platform AND
 #                ../../../grove (Grove + KAI) installed; see the template header for what
 #                is and is not yet validated on this path.
+#   dgd-grove-ep: the lws-ep topology (AGGREGATED wide-EP, one engine DP EP_DP_SIZE x TP8 with
+#                --enable-expert-parallel, EP degree 16 by default) as a Grove-rendered v1beta1
+#                DGD: the worker carries multinode.nodeCount=EP_DP_SIZE and the OPERATOR injects
+#                vLLM's DP coordination (hybrid-lb - a DIFFERENT coordination mode than the
+#                external-lb wiring lws-ep proved). Same prerequisites as dgd-grove. EP under
+#                Grove is UNPROVEN pending live smoke; lws-ep is the proven EP16-agg artifact.
 # NONE of these disaggregate prefill from decode - that is ../disagg (every template there
 # carries --kv-transfer-config). lws-ep in particular is AGGREGATED wide-EP, so report its
 # numbers as AGGREGATED. ../disagg/.env offers the SAME NAME `lws-ep` for the DISAGGREGATED
@@ -66,7 +72,8 @@ export EFA_PER_WORKER=${EFA_PER_WORKER:-16}
 # (PP grows with the node count; TP stays inside the node).
 export NODE_COUNT_PER_WORKER=${NODE_COUNT_PER_WORKER:-2}
 
-# lws-ep only: data-parallel group size; EP degree = EP_DP_SIZE * GPU_PER_WORKER.
+# lws-ep and dgd-grove-ep: data-parallel group size; EP degree = EP_DP_SIZE * GPU_PER_WORKER.
+# dgd-grove-ep also uses it as the worker's multinode.nodeCount (one DP rank per node).
 # The model's expert count must be divisible by the EP degree (Nemotron-3-Ultra 512 experts
 # / EP16 = 32 per rank, exact; Mixtral's 8 experts cannot run EP16).
 export EP_DP_SIZE=${EP_DP_SIZE:-2}

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/dgd-grove-ep.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/dgd-grove-ep.yaml-template
@@ -153,16 +153,11 @@ spec:
           tolerations:
             - { key: nvidia.com/gpu, operator: Exists, effect: NoSchedule }
             - { key: vpc.amazonaws.com/efa, operator: Exists, effect: NoSchedule }
-          affinity:
-            # Belt-and-suspenders (full-node GPU requests already forbid co-location).
-            # Keyed to the operator-applied label — VERIFIED present on Grove-rendered
-            # pods; app.kubernetes.io/part-of passthrough onto Grove pods is not.
-            podAntiAffinity:
-              requiredDuringSchedulingIgnoredDuringExecution:
-                - labelSelector:
-                    matchLabels:
-                      nvidia.com/dynamo-graph-deployment-name: ${DEPLOYMENT_NAME}
-                  topologyKey: kubernetes.io/hostname
+          # No worker anti-affinity, deliberately: each worker requests all 8 GPUs,
+          # so two workers can never share a node anyway -- and a whole-DGD
+          # anti-affinity key makes the gang UNSCHEDULABLE on GPU-only clusters
+          # (4 workers + co-located frontend mutually anti-affine on 4 nodes;
+          # measured kai-scheduler reject, B200 HyperPod 2026-08-24).
           volumes:
             - { name: fsx-pvc, persistentVolumeClaim: { claimName: fsx-pvc } }
           containers:

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/dgd-grove-ep.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/dgd-grove-ep.yaml-template
@@ -1,0 +1,260 @@
+# =============================================================================
+# Nemotron-3 Ultra 550B AGGREGATED wide-EP via Grove — DynamoGraphDeployment
+# =============================================================================
+#
+# Author: Anton Alexander
+#
+# The agg lws-ep topology — ONE logical engine, DP${EP_DP_SIZE} x
+# TP${GPU_PER_WORKER} with --enable-expert-parallel (EP degree =
+# EP_DP_SIZE * GPU_PER_WORKER, 16 by default), TP inside each node's NVLink
+# domain, the MoE all-to-all across nodes over EFA — expressed as a v1beta1
+# DGD whose worker carries `multinode.nodeCount: ${EP_DP_SIZE}`. The operator
+# renders it as a Grove PodCliqueSet and kai-scheduler gang-schedules
+# frontend + ${EP_DP_SIZE} rank pods as one PodGang. No P/D disaggregation, so
+# NIXL is not involved (and the PP>1 hybrid-Mamba path is structurally absent).
+#
+#   MANIFEST_TYPE=dgd-grove-ep ./run.sh
+#
+# SAME NAME AS ../disagg/dgd-grove-ep.yaml-template, DIFFERENT MODE — the
+# FOLDER is the discriminator, exactly as with lws-ep. Report numbers from this
+# file as EP16 AGGREGATED.
+#
+# Prerequisites: same as dgd-grove.yaml-template (Dynamo >= 1.4.0 platform via
+# ../../../nvidia-dynamo, then Grove + KAI via ../../../grove).
+#
+# TWO structural deltas vs the proven agg/lws-ep cell — read before comparing:
+#   1. WORKER BINARY: lws-ep runs native `vllm serve` (the leader IS the
+#      OpenAI API server on :8000). Under the operator the worker runs
+#      `python3 -m dynamo.vllm` and registers with the graph's own Frontend
+#      component — dynamo.vllm passes the same vLLM engine args through, so
+#      the ENGINE args below mirror lws-ep verbatim; the serving surface moves
+#      to the Frontend PodClique (no --host/--port here, and ../test/*.sh
+#      resolves the real ${DEPLOYMENT_NAME}-frontend Service instead of the
+#      alias Service lws-ep needs).
+#   2. DP COORDINATION: lws-ep wires vLLM EXTERNAL-LB DP by hand (leader =
+#      DP rank 0 + coordinator on :29550, workers --headless
+#      --data-parallel-start-rank N). Here the OPERATOR wires DP: seeing
+#      --data-parallel-size ${EP_DP_SIZE} with TP*PP*DP > the pod's 8 GPUs it
+#      injects per rank pod
+#        --data-parallel-hybrid-lb --data-parallel-size-local 1
+#        --data-parallel-start-rank <rank> --data-parallel-address
+#        <leader-clique hostname> --data-parallel-rpc-port 13445
+#      right after the `python3 -m dynamo.vllm` token in THIS script. Do NOT
+#      add those flags here (duplicates), and do NOT add any other
+#      `python3 ... vllm` line to this script (the injection regex would
+#      corrupt it). HONEST DIFFERENCE: hybrid-lb is not the coordination mode
+#      lws-ep proved.
+#
+# VALIDATION STATUS (be honest before quoting numbers):
+#   - EP16 aggregated (DP2/TP8/EP16 over EFA): PROVEN under LWS (agg/lws-ep,
+#     measured 550B serving, NET/OFI efa both nodes, socket_fallback=0).
+#   - Grove multinode: PROVEN for TP/PP engine sharding (dgd-grove headers).
+#   - EP/DP under Grove multinode — THIS template — is UNPROVEN: no live run
+#     has exercised the operator's hybrid-lb DP injection with
+#     --enable-expert-parallel. LWS supplied the DP-group leader wiring via
+#     the LWS leader env; Grove is proven for TP/PP multinode only. Do not
+#     claim this works until a live smoke passes; lws-ep remains the proven
+#     EP16-agg artifact.
+#
+# Gotchas carried from the learnings corpus:
+#   - sharedMemorySize CRD field is the ONLY /dev/shm knob (64Gi = the
+#     live-verified 550B value); podTemplate dshm mounts are silently dropped.
+#   - runtimeVersionOverride: required by the 1.4.0 admission webhook when TAG
+#     is not parseable semver; ":1.4.0-patched" parses, custom ECR test tags
+#     usually do not — uncomment on both components if you point TAG at one.
+#   - Gang crash-loop triage: read the previous-container log of the attempt
+#     that got FURTHEST; the Gloo/TCPStore strand errors are secondary.
+#   - ../test/.env MANIFEST_TYPE must be set to dgd-grove-ep for benchmark
+#     artifacts to land under this manifest's FSx path (stale-MANIFEST_TYPE
+#     trap; verify with run-meta.json observed.workloads, never the path).
+#
+# Like lws-ep (and unlike the other agg templates) there is NO --load-format
+# here: the proven lws-ep leg loaded with vLLM's default path, and adding
+# runai_streamer would make a 1.4.0-vs-LWS A/B two-variable. The cold-start
+# warmup block is intentionally ABSENT for the same multinode-clique reason as
+# agg/dgd-grove.yaml-template; BF16 (the default) never needed it. No explicit
+# ports/probes on the worker either — the operator injects multinode-aware
+# probes; a template probe would hold every worker rank NotReady forever.
+# =============================================================================
+---
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: ${DEPLOYMENT_NAME}
+  namespace: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}
+spec:
+  backendFramework: vllm
+  env:
+    - { name: DYNAMO_BACKEND, value: vllm }
+    - { name: ETCD_ENDPOINTS, value: "${ETCD_URL}" }
+    - { name: NATS_SERVER,    value: "${NATS_URL}" }
+    # /tmp, NOT /shared: pods run uid 1000 and /shared is root-owned — the frontend
+    # dies registering the model ("Failed to create cache directory /shared/hf_cache/hub:
+    # Permission denied") and /v1/models stays empty -> every request 404s.
+    - { name: HF_HOME,        value: /tmp/hf_cache }
+  components:
+    # ---- Frontend (router, CPU-only; renders as its own PodClique) ---------
+    # Verbatim from dgd-grove.yaml-template.
+    - name: Frontend
+      type: frontend
+      replicas: 1
+      # runtimeVersionOverride: "1.4.0"   # uncomment for a non-semver custom TAG (see header)
+      podTemplate:
+        spec:
+          nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_FRONTEND} }
+          volumes:
+            - { name: fsx-pvc, persistentVolumeClaim: { claimName: fsx-pvc } }
+          containers:
+            # The operator merges its defaults into the container named exactly "main";
+            # any other container is a user-managed sidecar.
+            - name: main
+              resources:
+                requests: { cpu: "2", memory: 4Gi }
+                limits:   { cpu: "4", memory: 8Gi }
+              image: ${REGISTRY}${IMAGE}${TAG}
+              imagePullPolicy: Always
+              command: ["/bin/bash", "-c"]
+              args:
+                - |-
+                  if [ -n "${DOLLAR}{POD_IP:-}" ] && [ "${DOLLAR}{POD_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
+                    echo "[frontend] FATAL: pod IP ${DOLLAR}POD_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                    echo "[frontend]        Cluster DNS cannot answer for this pod, so NATS/etcd are unreachable."
+                    echo "[frontend]        RESTARTING WILL NOT HELP - the sandbox keeps the address. Remedy:"
+                    echo "[frontend]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                    exit 1
+                  fi
+                  if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+                  exec python3 -m dynamo.frontend --http-port 8000 --http-host 0.0.0.0
+              env:
+                # Read only by the duplicate-address preflight in args above.
+                - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+                - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
+              ports: [{ containerPort: 8000, name: http }]
+              # NOTE: no readinessProbe here — the operator injects its own frontend probe.
+              volumeMounts:
+                - { name: fsx-pvc, mountPath: /shared }
+    # ---- Multinode aggregated wide-EP worker: ONE engine, one DP rank (TP8)
+    # per node across ${EP_DP_SIZE} nodes, EP spanning them over EFA ----------
+    - name: VllmWorker
+      type: worker
+      replicas: 1
+      # Operator-managed /dev/shm tmpfs (CRD field; the only knob the operator
+      # honors — podTemplate mounts at /dev/shm are silently dropped). 64Gi is
+      # the value verified injected in the live 550B Grove run.
+      sharedMemorySize: 64Gi
+      # runtimeVersionOverride: "1.4.0"   # uncomment for a non-semver custom TAG (see header)
+      multinode:
+        nodeCount: ${EP_DP_SIZE}
+      podTemplate:
+        spec:
+          nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_WORKER} }
+          tolerations:
+            - { key: nvidia.com/gpu, operator: Exists, effect: NoSchedule }
+            - { key: vpc.amazonaws.com/efa, operator: Exists, effect: NoSchedule }
+          affinity:
+            # Belt-and-suspenders (full-node GPU requests already forbid co-location).
+            # Keyed to the operator-applied label — VERIFIED present on Grove-rendered
+            # pods; app.kubernetes.io/part-of passthrough onto Grove pods is not.
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchLabels:
+                      nvidia.com/dynamo-graph-deployment-name: ${DEPLOYMENT_NAME}
+                  topologyKey: kubernetes.io/hostname
+          volumes:
+            - { name: fsx-pvc, persistentVolumeClaim: { claimName: fsx-pvc } }
+          containers:
+            - name: main
+              image: ${REGISTRY}${IMAGE}${TAG}
+              imagePullPolicy: Always
+              securityContext: { capabilities: { add: ["IPC_LOCK"] } }
+              command: ["/bin/bash", "-c"]
+              args:
+                - |-
+                  set -u
+                  unset HPCX_DIR HPCX_MPI_DIR HPCX_HOME HPCX_UCX_DIR HPCX_SHARP_DIR \
+                        HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
+                  if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+                  if [ -n "${DOLLAR}{POD_IP:-}" ] && [ "${DOLLAR}{POD_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
+                    echo "[worker] FATAL: pod IP ${DOLLAR}POD_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                    echo "[worker]        Cluster DNS cannot answer for this pod, so NATS/etcd are unreachable."
+                    echo "[worker]        RESTARTING WILL NOT HELP - the sandbox keeps the address. Remedy:"
+                    echo "[worker]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                    exit 1
+                  fi
+                  # Gloo bind interface: data_parallel_size > 1 runs the per-step DP-padding
+                  # all-reduce on the Gloo CPU group cross-node; same derive-and-FATAL guard
+                  # lws-ep carries (Gloo needs a SINGLE concrete iface, not NCCL's ^exclude list).
+                  export GLOO_SOCKET_IFNAME=${DOLLAR}{GLOO_SOCKET_IFNAME:-${DOLLAR}(ip -o -4 route show default | awk '{print ${DOLLAR}5; exit}')}
+                  GLOO_BIND_IP=${DOLLAR}(ip -o -4 addr show dev "${DOLLAR}GLOO_SOCKET_IFNAME" 2>/dev/null | awk '{print ${DOLLAR}4; exit}' | cut -d/ -f1)
+                  echo "[worker] GLOO_SOCKET_IFNAME=${DOLLAR}GLOO_SOCKET_IFNAME bind=${DOLLAR}GLOO_BIND_IP"
+                  case "${DOLLAR}{GLOO_BIND_IP:-}" in
+                    ""|127.*) echo "[worker] FATAL: GLOO_SOCKET_IFNAME=${DOLLAR}GLOO_SOCKET_IFNAME has no routable IPv4 (got '${DOLLAR}GLOO_BIND_IP'); the cross-node DP-padding all-reduce would bind loopback. Exiting for a clean restart."; exit 1 ;;
+                  esac
+                  # TP stays inside each node; DP/EP spans the ${EP_DP_SIZE} clique members —
+                  # the engine shape proven E2E for the 550B on lws-ep. The DP coordination
+                  # flags (hybrid-lb, size-local, start-rank, address, rpc port) are INJECTED
+                  # by the operator right after the dynamo.vllm token below — keep this the
+                  # only python...vllm line (header).
+                  exec python3 -m dynamo.vllm \
+                    --model ${MODEL_PATH} \
+                    --served-model-name ${MODEL_NAME} \
+                    --tensor-parallel-size ${GPU_PER_WORKER} \
+                    --data-parallel-size ${EP_DP_SIZE} \
+                    --enable-expert-parallel \
+                    --pipeline-parallel-size 1 \
+                    --max-model-len 8192 \
+                    --gpu-memory-utilization 0.92 \
+                    --enforce-eager \
+                    --trust-remote-code ${MOE_BACKEND_FLAG} \
+                    --mamba-cache-mode align \
+                    --no-disable-hybrid-kv-cache-manager
+              env:
+                # Read only by the duplicate-address preflight in args above.
+                - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+                - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
+                - { name: HF_MODULES_CACHE, value: /tmp/hf_cache/modules }
+                - { name: VLLM_LOGGING_LEVEL, value: INFO }
+                # NVFP4 on sm100: vllm_omni's Quack/CuTeDSL FP8 scaled-mm monkey-patch defaults
+                # ON, but its tuned-compile helper cannot spawn inside vLLM's daemonic TP workers
+                # ("daemonic processes are not allowed to have children") -> exception + FlashInfer
+                # fallback on EVERY GEMM call, nothing caches, and decode crawls at ~0.05-0.1 tok/s
+                # while looking "stuck". Force it off; BF16 never enters this path (no-op there).
+                - { name: VLLM_OMNI_USE_QUACK_FP8, value: "0" }
+                # 550B BF16 weight loading from Lustre exceeds the default 600s engine timeout.
+                - { name: VLLM_ENGINE_READY_TIMEOUT_S, value: "2400" }
+                # Raise the multiproc-executor RPC deadline (default 300s): a JIT-heavy first
+                # concurrent NVFP4 decode step can exceed it and kill EngineCore. Harmless in
+                # steady state.
+                - { name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS, value: "1800" }
+                # ---- Cross-node MoE all-to-all over EFA (NCCL -> aws-ofi-nccl -> libfabric).
+                # Same block as lws-ep, values verified in the measured EP16 run.
+                - { name: FI_PROVIDER, value: efa }
+                - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
+                - { name: FI_EFA_FORK_SAFE, value: "1" }
+                - { name: NCCL_NET_PLUGIN, value: ofi }
+                - { name: NCCL_TUNER_PLUGIN, value: ofi }
+                - { name: NCCL_NVLS_ENABLE, value: "0" }
+                - { name: NCCL_SOCKET_IFNAME, value: "^lo,docker,veth,eni,pod-id-link0" }
+                # Keep INIT,NET on: it is how you PROVE the all-to-all rode EFA and not the
+                # Socket fallback. Drop to WARN only after that check.
+                - { name: NCCL_DEBUG, value: INFO }
+                - { name: NCCL_DEBUG_SUBSYS, value: "INIT,NET" }
+              # NOTE: no ports/startupProbe on a multinode component — the operator injects
+              # multinode-aware probes; a template probe would hold every worker rank
+              # NotReady forever (see agg/dgd-grove.yaml-template).
+              volumeMounts:
+                - { name: fsx-pvc, mountPath: /shared }
+              resources:
+                requests:
+                  cpu: "${CPU_PER_WORKER}"
+                  memory: ${MEM_PER_WORKER}
+                  nvidia.com/gpu: "${GPU_PER_WORKER}"
+                  vpc.amazonaws.com/efa: "${EFA_PER_WORKER}"
+                limits:
+                  cpu: "${CPU_PER_WORKER}"
+                  memory: ${MEM_PER_WORKER}
+                  nvidia.com/gpu: "${GPU_PER_WORKER}"
+                  vpc.amazonaws.com/efa: "${EFA_PER_WORKER}"

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/dgd-grove-ep.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/dgd-grove-ep.yaml-template
@@ -137,7 +137,7 @@ spec:
                 - { name: fsx-pvc, mountPath: /shared }
     # ---- Multinode aggregated wide-EP worker: ONE engine, one DP rank (TP8)
     # per node across ${EP_DP_SIZE} nodes, EP spanning them over EFA ----------
-    - name: VllmWorker
+    - name: worker
       type: worker
       replicas: 1
       # Operator-managed /dev/shm tmpfs (CRD field; the only knob the operator

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/dgd-grove-ep.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/agg/dgd-grove-ep.yaml-template
@@ -49,12 +49,12 @@
 #   - EP16 aggregated (DP2/TP8/EP16 over EFA): PROVEN under LWS (agg/lws-ep,
 #     measured 550B serving, NET/OFI efa both nodes, socket_fallback=0).
 #   - Grove multinode: PROVEN for TP/PP engine sharding (dgd-grove headers).
-#   - EP/DP under Grove multinode — THIS template — is UNPROVEN: no live run
-#     has exercised the operator's hybrid-lb DP injection with
-#     --enable-expert-parallel. LWS supplied the DP-group leader wiring via
-#     the LWS leader env; Grove is proven for TP/PP multinode only. Do not
-#     claim this works until a live smoke passes; lws-ep remains the proven
-#     EP16-agg artifact.
+#   - EP/DP under Grove multinode — THIS template — PROVEN live 2026-08-24:
+#     the operator's hybrid-lb DP injection observed verbatim in both rank
+#     pods' live args alongside --enable-expert-parallel (DP2 x TP8 = EP16,
+#     EngineCore_DP0 and DP1 both initialized), greedy output byte-identical
+#     to the agg deployment control, warm aiperf c=10 ISL1024/OSL512 100 req
+#     0 err: TTFT p50 379 ms / ITL p50 108.5 ms / 91.6 output tok/s.
 #
 # Gotchas carried from the learnings corpus:
 #   - sharedMemorySize CRD field is the ONLY /dev/shm knob (64Gi = the

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/.env
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/.env
@@ -21,7 +21,7 @@ export DOLLAR='$'
 export NAMESPACE=${NAMESPACE:-default}
 export DEPLOYMENT_NAME=${DEPLOYMENT_NAME:-nemotron3-ultra-550b-disagg}
 
-# MANIFEST_TYPE=deployment|lws-2pp|lws-pp2|lws-ep|dgd|dgd-v1beta1|dgd-grove
+# MANIFEST_TYPE=deployment|lws-2pp|lws-pp2|lws-ep|dgd|dgd-v1beta1|dgd-grove|dgd-grove-pp2|dgd-grove-ep
 #   deployment : plain Deployments, 1 prefill + 1 decode node, TP8/PP1 each (simplest)
 #   lws-2pp    : LeaderWorkerSet, prefill TP8/PP2 (2 nodes) + decode 2x TP8/PP1 (2x PP1 decode pods)
 #   lws-pp2    : LeaderWorkerSet, symmetrical PP2 - prefill AND decode each TP8/PP2 across 2 nodes
@@ -41,6 +41,18 @@ export DEPLOYMENT_NAME=${DEPLOYMENT_NAME:-nemotron3-ultra-550b-disagg}
 #                (../../../grove) the whole graph becomes one PodCliqueSet and is
 #                GANG-scheduled - prefill can no longer boot alone and squat GPUs waiting
 #                for a decode node. See the template header for validation status.
+#   dgd-grove-pp2: the lws-pp2 topology (symmetric PP2 - prefill AND decode each
+#                TP8/PP NODE_COUNT_PER_WORKER across that many nodes) as a Grove-rendered
+#                v1beta1 DGD: both workers carry multinode.nodeCount and the operator injects
+#                the rank bootstrap. HARD image requirement: TAG=":1.4.0-patched" - stock
+#                vLLM 0.26 refuses PP>1 + hybrid-KV at worker init (NotImplementedError in the
+#                NIXL worker); there is no stock-tag fallback for this one. UNVALIDATED live
+#                through the operator path until a smoke run; lws-pp2 is the proven PP2 artifact.
+#   dgd-grove-ep: the lws-ep topology (EP16 per role + P/D split, 2 * EP_DP_SIZE nodes) as a
+#                Grove-rendered v1beta1 DGD: each role carries multinode.nodeCount=EP_DP_SIZE
+#                and the OPERATOR injects vLLM's DP coordination (hybrid-lb - a DIFFERENT
+#                coordination mode than the external-lb wiring lws-ep proved). EP under Grove is
+#                UNPROVEN pending live smoke; lws-ep is the proven EP16-disagg artifact.
 #
 # EVERY template in this folder splits prefill from decode (all carry --kv-transfer-config with
 # NixlConnector) - including lws-ep. ../agg/.env offers the SAME NAME `lws-ep` for the
@@ -50,12 +62,19 @@ export DEPLOYMENT_NAME=${DEPLOYMENT_NAME:-nemotron3-ultra-550b-disagg}
 #
 export MANIFEST_TYPE=${MANIFEST_TYPE:-dgd}
 
-# EP (MANIFEST_TYPE=lws-ep) only: per-role data-parallel group size;
+# EP (MANIFEST_TYPE=lws-ep or dgd-grove-ep) only: per-role data-parallel group size;
 # EP degree = EP_DP_SIZE * GPU_PER_WORKER, applied INDEPENDENTLY to prefill and to decode.
+# dgd-grove-ep also uses it as each role's multinode.nodeCount (one DP rank per node).
 # The model's expert count must be divisible by the EP degree (Nemotron-3-Ultra + Qwen3-235B: yes;
 # Mixtral's 8 experts: no - it cannot run EP16).
 # Node cost = 2 * EP_DP_SIZE GPU nodes (prefill group + decode group), so the default is 4 nodes.
 export EP_DP_SIZE=${EP_DP_SIZE:-2}
+
+# dgd-grove-pp2 only: nodes per multinode worker group, applied to BOTH roles. Each role's
+# engine spans NODE_COUNT_PER_WORKER full nodes as TP GPU_PER_WORKER x PP NODE_COUNT_PER_WORKER
+# (PP grows with the node count; TP stays inside the node) - the same knob, same meaning as
+# ../agg/.env's. Node cost = 2 * NODE_COUNT_PER_WORKER GPU nodes.
+export NODE_COUNT_PER_WORKER=${NODE_COUNT_PER_WORKER:-2}
 
 # ---- Cluster shape ----
 # All ${VAR:-default} so a different accelerator is a one-liner and needs no edit here:

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd-grove-ep.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd-grove-ep.yaml-template
@@ -150,15 +150,11 @@ spec:
           tolerations:
             - { key: nvidia.com/gpu, operator: Exists, effect: NoSchedule }
             - { key: vpc.amazonaws.com/efa, operator: Exists, effect: NoSchedule }
-          affinity:
-            # Keyed to the operator-applied label (VERIFIED present on Grove-rendered
-            # pods; app.kubernetes.io/part-of passthrough is not).
-            podAntiAffinity:
-              requiredDuringSchedulingIgnoredDuringExecution:
-                - labelSelector:
-                    matchLabels:
-                      nvidia.com/dynamo-graph-deployment-name: ${DEPLOYMENT_NAME}
-                  topologyKey: kubernetes.io/hostname
+          # No worker anti-affinity, deliberately: each worker requests all 8 GPUs,
+          # so two workers can never share a node anyway -- and a whole-DGD
+          # anti-affinity key makes the gang UNSCHEDULABLE on GPU-only clusters
+          # (4 workers + co-located frontend mutually anti-affine on 4 nodes;
+          # measured kai-scheduler reject, B200 HyperPod 2026-08-24).
           volumes:
             - { name: fsx-pvc, persistentVolumeClaim: { claimName: fsx-pvc } }
             - { name: gdrdrv, hostPath: { path: /dev/gdrdrv, type: CharDevice } }
@@ -259,13 +255,11 @@ spec:
           tolerations:
             - { key: nvidia.com/gpu, operator: Exists, effect: NoSchedule }
             - { key: vpc.amazonaws.com/efa, operator: Exists, effect: NoSchedule }
-          affinity:
-            podAntiAffinity:
-              requiredDuringSchedulingIgnoredDuringExecution:
-                - labelSelector:
-                    matchLabels:
-                      nvidia.com/dynamo-graph-deployment-name: ${DEPLOYMENT_NAME}
-                  topologyKey: kubernetes.io/hostname
+          # No worker anti-affinity, deliberately: each worker requests all 8 GPUs,
+          # so two workers can never share a node anyway -- and a whole-DGD
+          # anti-affinity key makes the gang UNSCHEDULABLE on GPU-only clusters
+          # (4 workers + co-located frontend mutually anti-affine on 4 nodes;
+          # measured kai-scheduler reject, B200 HyperPod 2026-08-24).
           volumes:
             - { name: fsx-pvc, persistentVolumeClaim: { claimName: fsx-pvc } }
             - { name: gdrdrv, hostPath: { path: /dev/gdrdrv, type: CharDevice } }

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd-grove-ep.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd-grove-ep.yaml-template
@@ -43,12 +43,14 @@
 # VALIDATION STATUS (be honest before quoting numbers):
 #   - EP16 per role + P/D split: PROVEN under LWS (disagg/lws-ep).
 #   - Grove multinode: PROVEN for TP/PP engine sharding (dgd-grove headers).
-#   - EP/DP under Grove multinode — THIS template — is UNPROVEN: no live run
-#     has exercised the operator's hybrid-lb DP injection with
-#     --enable-expert-parallel on this model. LWS supplied the DP-group leader
-#     wiring via the LWS leader env; Grove is proven for TP/PP multinode only.
-#     Do not claim this works until a live smoke passes; lws-ep remains the
-#     proven EP16-disagg artifact.
+#   - EP/DP under Grove multinode — THIS template — PROVEN live 2026-08-24:
+#     all 4 rank pods (prefill + decode, DP2 x TP8 = EP16 each role) ran the
+#     operator's hybrid-lb injection with --enable-expert-parallel (worker
+#     ranks EP0-EP15 visible in logs); NIXL compatibility handshake passed on
+#     both decode DP ranks; greedy output byte-identical to the lws-pp2
+#     control (no lws-ep capture exists — cross-parallelism coherence check);
+#     warm aiperf c=10 ISL1024/OSL512 100 req 0 err: TTFT p50 722 ms /
+#     ITL p50 109.1 ms / 90.6 output tok/s.
 #
 # Gotchas carried from the learnings corpus (same set as dgd-grove-pp2):
 #   - sharedMemorySize CRD field is the ONLY /dev/shm knob (64Gi = the

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd-grove-ep.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd-grove-ep.yaml-template
@@ -1,0 +1,348 @@
+# =============================================================================
+# Nemotron-3 Ultra — EP16 DISAGGREGATED via Grove — DynamoGraphDeployment, v1beta1
+# =============================================================================
+#
+# Author: Anton Alexander
+#
+# The disagg lws-ep topology — prefill DP${EP_DP_SIZE} x TP${GPU_PER_WORKER}
+# (EP degree = EP_DP_SIZE * GPU_PER_WORKER, 16 by default) + decode the same,
+# independently, with KV prefill->decode over EFA RDMA via NIXL LIBFABRIC —
+# rendered through Grove: each role carries `multinode.nodeCount: ${EP_DP_SIZE}`
+# and the whole graph (frontend + 2 x ${EP_DP_SIZE} GPU pods) gang-schedules as
+# one PodGang. 2 * ${EP_DP_SIZE} GPU nodes (default 4), PP stays 1 on both
+# roles (EP does not need PP, and PP>1 decode is its own template family).
+#
+#   MANIFEST_TYPE=dgd-grove-ep ./run.sh
+#
+# SAME NAME AS ../agg/dgd-grove-ep.yaml-template, DIFFERENT MODE — the FOLDER is
+# the discriminator, exactly as with lws-ep. This one splits prefill from decode
+# (--disaggregation-mode + --kv-transfer-config on both roles); ../agg's does not.
+#
+# Prerequisites: same as dgd-grove.yaml-template (Dynamo >= 1.4.0 platform via
+# ../../../nvidia-dynamo, then Grove + KAI via ../../../grove).
+#
+# DP COORDINATION (the whole delta vs lws-ep, read before debugging):
+#   lws-ep wires vLLM's EXTERNAL-LB data parallelism by hand: the LWS leader is
+#   DP rank 0 + coordinator (--data-parallel-address = its own IP, rpc port
+#   29550/29551) and each worker joins --headless with
+#   --data-parallel-start-rank ${DOLLAR}{LWS_WORKER_INDEX}.
+#   Here the OPERATOR wires DP: seeing --data-parallel-size ${EP_DP_SIZE} with
+#   TP*PP*DP > the pod's 8 GPUs, it injects per rank pod
+#     --data-parallel-hybrid-lb --data-parallel-size-local 1
+#     --data-parallel-start-rank <rank> --data-parallel-address <leader-clique
+#     hostname> --data-parallel-rpc-port 13445
+#   right after the `python3 -m dynamo.vllm` token in THIS script. Do NOT add
+#   those flags here (duplicates), and do NOT add any other `python3 ... vllm`
+#   line to this script (the injection regex would corrupt it).
+#   HONEST DIFFERENCE: hybrid-lb is NOT the mode lws-ep proved. Under hybrid-lb
+#   every rank runs its own local coordinator and Dynamo routes between ranks;
+#   under lws-ep's external-lb the leader coordinates and workers are headless.
+#   --enable-expert-parallel rides on top of DP identically in both, but the
+#   coordination path itself is different code.
+#
+# VALIDATION STATUS (be honest before quoting numbers):
+#   - EP16 per role + P/D split: PROVEN under LWS (disagg/lws-ep).
+#   - Grove multinode: PROVEN for TP/PP engine sharding (dgd-grove headers).
+#   - EP/DP under Grove multinode — THIS template — is UNPROVEN: no live run
+#     has exercised the operator's hybrid-lb DP injection with
+#     --enable-expert-parallel on this model. LWS supplied the DP-group leader
+#     wiring via the LWS leader env; Grove is proven for TP/PP multinode only.
+#     Do not claim this works until a live smoke passes; lws-ep remains the
+#     proven EP16-disagg artifact.
+#
+# Gotchas carried from the learnings corpus (same set as dgd-grove-pp2):
+#   - sharedMemorySize CRD field is the ONLY /dev/shm knob (64Gi = the
+#     live-verified 550B value); podTemplate dshm mounts are silently dropped.
+#   - runtimeVersionOverride: required by the 1.4.0 admission webhook when TAG
+#     is not parseable semver; ":1.4.0-patched" parses, custom ECR test tags
+#     usually do not — uncomment on all components if you point TAG at one.
+#   - Gang crash-loop triage: read the previous-container log of the attempt
+#     that got FURTHEST; the Gloo/TCPStore strand errors are secondary.
+#   - ../test/.env MANIFEST_TYPE must be set to dgd-grove-ep for benchmark
+#     artifacts to land under this manifest's FSx path (stale-MANIFEST_TYPE
+#     trap; verify with run-meta.json observed.workloads, never the path).
+#
+# Env parity note: the env blocks mirror disagg/lws-ep (the proven EP cell)
+# verbatim, minus the LWS leader-resolution machinery. The Grove-proven PP1
+# dgd-grove additionally sets FI_EFA_ENABLE_SHM{,_TRANSFER}=0; on this 4-node
+# anti-affine shape no two NIXL peers share a node, and lws-ep proved without
+# them, so they are omitted — add them first if NIXL init misbehaves.
+#
+# No warmup subshell and no ports/probes on the worker components — same
+# multinode-clique reasoning as dgd-grove-pp2.yaml-template's header.
+# =============================================================================
+---
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: ${DEPLOYMENT_NAME}
+  namespace: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}
+spec:
+  backendFramework: vllm
+  env:
+    - { name: DYNAMO_BACKEND, value: vllm }
+    - { name: ETCD_ENDPOINTS, value: "${ETCD_URL}" }
+    - { name: NATS_SERVER,    value: "${NATS_URL}" }
+    # /tmp, NOT /shared: pods run uid 1000 and /shared is root-owned - the frontend
+    # dies registering the model ("Failed to create cache directory /shared/hf_cache/hub:
+    # Permission denied") and /v1/models stays empty -> every request 404s.
+    - { name: HF_HOME,        value: /tmp/hf_cache }
+  components:
+    # ---- Frontend (router, CPU-only; its own PodClique in the gang) --------
+    # Verbatim from dgd-grove.yaml-template.
+    - name: Frontend
+      type: frontend
+      replicas: 1
+      # runtimeVersionOverride: "1.4.0"   # uncomment for a non-semver custom TAG (see header)
+      podTemplate:
+        spec:
+          nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_FRONTEND} }
+          volumes:
+            - { name: fsx-pvc, persistentVolumeClaim: { claimName: fsx-pvc } }
+          containers:
+            # The name MUST be "main" - that is the container the operator merges its
+            # image/command/env/ports/probe defaults into.
+            - name: main
+              image: ${REGISTRY}${IMAGE}${TAG}
+              imagePullPolicy: Always
+              command: ["/bin/bash", "-c"]
+              args:
+                - |-
+                  if [ -n "${DOLLAR}{POD_IP:-}" ] && [ "${DOLLAR}{POD_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
+                    echo "[frontend] FATAL: pod IP ${DOLLAR}POD_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                    echo "[frontend]        Cluster DNS cannot answer for this pod, so NATS/etcd are unreachable."
+                    echo "[frontend]        RESTARTING WILL NOT HELP - the sandbox keeps the address. Remedy:"
+                    echo "[frontend]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                    exit 1
+                  fi
+                  if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+                  exec python3 -m dynamo.frontend --http-port 8000 --http-host 0.0.0.0
+              env:
+                - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+                - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
+              ports: [{ containerPort: 8000, name: http }]
+              # The frontend reads the model dir (config/tokenizer, not weights) to build the
+              # preprocessor when workers register a local path - without this mount the model
+              # never appears in /v1/models.
+              volumeMounts:
+                - { name: fsx-pvc, mountPath: /shared }
+              resources:
+                requests: { cpu: "2", memory: 4Gi }
+                limits:   { cpu: "4", memory: 8Gi }
+              # NOTE: no readinessProbe here - the operator injects its own frontend probe.
+    # ---- Prefill: DP${EP_DP_SIZE} x TP${GPU_PER_WORKER}, EP degree
+    # EP_DP_SIZE * GPU_PER_WORKER; one DP rank per node, its own EP group ------
+    - name: VllmPrefillWorker
+      type: prefill
+      replicas: 1
+      # Operator-managed /dev/shm tmpfs (CRD field; the only knob the operator
+      # honors - podTemplate mounts at /dev/shm are silently dropped). 64Gi is
+      # the value verified injected in the live 550B Grove run.
+      sharedMemorySize: 64Gi
+      # runtimeVersionOverride: "1.4.0"   # uncomment for a non-semver custom TAG (see header)
+      multinode:
+        nodeCount: ${EP_DP_SIZE}
+      podTemplate:
+        spec:
+          nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_WORKER} }
+          tolerations:
+            - { key: nvidia.com/gpu, operator: Exists, effect: NoSchedule }
+            - { key: vpc.amazonaws.com/efa, operator: Exists, effect: NoSchedule }
+          affinity:
+            # Keyed to the operator-applied label (VERIFIED present on Grove-rendered
+            # pods; app.kubernetes.io/part-of passthrough is not).
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchLabels:
+                      nvidia.com/dynamo-graph-deployment-name: ${DEPLOYMENT_NAME}
+                  topologyKey: kubernetes.io/hostname
+          volumes:
+            - { name: fsx-pvc, persistentVolumeClaim: { claimName: fsx-pvc } }
+            - { name: gdrdrv, hostPath: { path: /dev/gdrdrv, type: CharDevice } }
+          containers:
+            - name: main
+              image: ${REGISTRY}${IMAGE}${TAG}
+              imagePullPolicy: Always
+              securityContext: { capabilities: { add: ["IPC_LOCK"] } }
+              command: ["/bin/bash", "-c"]
+              args:
+                - |-
+                  set -u
+                  unset HPCX_DIR HPCX_MPI_DIR HPCX_HOME HPCX_UCX_DIR HPCX_SHARP_DIR \
+                        HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
+                  if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+                  if [ -n "${DOLLAR}{POD_IP:-}" ] && [ "${DOLLAR}{POD_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
+                    echo "[prefill] FATAL: pod IP ${DOLLAR}POD_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                    echo "[prefill]        Cluster DNS cannot answer for this pod, so NATS/etcd are unreachable."
+                    echo "[prefill]        RESTARTING WILL NOT HELP - the sandbox keeps the address. Remedy:"
+                    echo "[prefill]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                    exit 1
+                  fi
+                  # Gloo bind interface: data_parallel_size > 1 runs the per-step DP-padding
+                  # all-reduce on the Gloo CPU group cross-node; same derive-and-FATAL guard
+                  # lws-ep carries.
+                  export GLOO_SOCKET_IFNAME=${DOLLAR}{GLOO_SOCKET_IFNAME:-${DOLLAR}(ip -o -4 route show default | awk '{print ${DOLLAR}5; exit}')}
+                  GLOO_BIND_IP=${DOLLAR}(ip -o -4 addr show dev "${DOLLAR}GLOO_SOCKET_IFNAME" 2>/dev/null | awk '{print ${DOLLAR}4; exit}' | cut -d/ -f1)
+                  echo "[prefill] GLOO_SOCKET_IFNAME=${DOLLAR}GLOO_SOCKET_IFNAME bind=${DOLLAR}GLOO_BIND_IP"
+                  case "${DOLLAR}{GLOO_BIND_IP:-}" in
+                    ""|127.*) echo "[prefill] FATAL: GLOO_SOCKET_IFNAME=${DOLLAR}GLOO_SOCKET_IFNAME has no routable IPv4 (got '${DOLLAR}GLOO_BIND_IP'); the cross-node DP-padding all-reduce would bind loopback. Exiting for a clean restart."; exit 1 ;;
+                  esac
+                  # DP coordination flags (hybrid-lb, size-local, start-rank, address, rpc
+                  # port) are INJECTED by the operator right after the dynamo.vllm token
+                  # below - keep this the only python...vllm line (header).
+                  exec python3 -m dynamo.vllm \
+                    --model ${MODEL_PATH} \
+                    --served-model-name ${MODEL_NAME} \
+                    --tensor-parallel-size ${GPU_PER_WORKER} \
+                    --data-parallel-size ${EP_DP_SIZE} \
+                    --enable-expert-parallel \
+                    --pipeline-parallel-size 1 \
+                    --max-model-len 8192 \
+                    --gpu-memory-utilization 0.92 \
+                    --enforce-eager \
+                    --trust-remote-code ${MOE_BACKEND_FLAG} \
+                    ${MAMBA_FLAGS} \
+                    --load-format runai_streamer \
+                    --disaggregation-mode prefill \
+                    --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"],"kv_lease_duration":${KV_LEASE_DURATION}}}'
+              env:
+                # Read only by the duplicate-address preflight in args above.
+                - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+                - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
+                - { name: VLLM_LOGGING_LEVEL, value: INFO }
+                - { name: VLLM_SSM_CONV_STATE_LAYOUT, value: DS }
+                - { name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS, value: "1800" }
+                # 550B BF16 weight loading from Lustre exceeds the default 600s engine timeout.
+                - { name: VLLM_ENGINE_READY_TIMEOUT_S, value: "2400" }
+                - { name: FLASHINFER_DISABLE_VERSION_CHECK, value: "1" }
+                # NVFP4 on sm100: vllm_omni's Quack/CuTeDSL FP8 scaled-mm monkey-patch defaults
+                # ON, but its tuned-compile helper cannot spawn inside vLLM's daemonic TP workers
+                # ("daemonic processes are not allowed to have children") -> exception + FlashInfer
+                # fallback on EVERY GEMM call, nothing caches, and decode crawls at ~0.05-0.1 tok/s
+                # while looking "stuck". Force it off; BF16 never enters this path (no-op there).
+                - { name: VLLM_OMNI_USE_QUACK_FP8, value: "0" }
+                - { name: FI_PROVIDER, value: efa }
+                - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
+                - { name: FI_EFA_FORK_SAFE, value: "1" }
+                - { name: FI_HMEM_CUDA_USE_DMABUF, value: "1" }
+                - { name: NIXL_LIBFABRIC_MAX_RAILS, value: "1" }
+                - { name: NIXL_SKIP_TOPOLOGY_CHECK, value: "1" }
+                - { name: NCCL_NET_PLUGIN, value: ofi }
+                - { name: NCCL_TUNER_PLUGIN, value: ofi }
+                - { name: OFI_NCCL_FORCE_NUM_RAILS, value: "4" }
+                - { name: NCCL_RUNTIME_CONNECT, value: "0" }
+                - { name: NCCL_NVLS_ENABLE, value: "0" }
+                - { name: NCCL_CUMEM_ENABLE, value: "1" }
+                - { name: NCCL_SOCKET_IFNAME, value: "^lo,docker,veth,eni" }
+              # NOTE: no ports/startupProbe on a multinode component (see header).
+              volumeMounts:
+                - { name: fsx-pvc, mountPath: /shared }
+                - { name: gdrdrv, mountPath: /dev/gdrdrv }
+              resources:
+                requests: { cpu: "${CPU_PER_WORKER}", memory: ${MEM_PER_WORKER}, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+                limits:   { cpu: "${CPU_PER_WORKER}", memory: ${MEM_PER_WORKER}, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+    # ---- Decode: its OWN DP${EP_DP_SIZE} x TP${GPU_PER_WORKER} EP group, same
+    # width, independent coordinator. PP stays 1 (EP does not need PP). --------
+    - name: VllmDecodeWorker
+      type: decode
+      replicas: 1
+      sharedMemorySize: 64Gi
+      # runtimeVersionOverride: "1.4.0"   # uncomment for a non-semver custom TAG (see header)
+      multinode:
+        nodeCount: ${EP_DP_SIZE}
+      podTemplate:
+        spec:
+          nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_WORKER} }
+          tolerations:
+            - { key: nvidia.com/gpu, operator: Exists, effect: NoSchedule }
+            - { key: vpc.amazonaws.com/efa, operator: Exists, effect: NoSchedule }
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchLabels:
+                      nvidia.com/dynamo-graph-deployment-name: ${DEPLOYMENT_NAME}
+                  topologyKey: kubernetes.io/hostname
+          volumes:
+            - { name: fsx-pvc, persistentVolumeClaim: { claimName: fsx-pvc } }
+            - { name: gdrdrv, hostPath: { path: /dev/gdrdrv, type: CharDevice } }
+          containers:
+            - name: main
+              image: ${REGISTRY}${IMAGE}${TAG}
+              imagePullPolicy: Always
+              securityContext: { capabilities: { add: ["IPC_LOCK"] } }
+              command: ["/bin/bash", "-c"]
+              args:
+                - |-
+                  set -u
+                  unset HPCX_DIR HPCX_MPI_DIR HPCX_HOME HPCX_UCX_DIR HPCX_SHARP_DIR \
+                        HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
+                  if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+                  if [ -n "${DOLLAR}{POD_IP:-}" ] && [ "${DOLLAR}{POD_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
+                    echo "[decode] FATAL: pod IP ${DOLLAR}POD_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                    echo "[decode]        Cluster DNS cannot answer for this pod, so NATS/etcd are unreachable."
+                    echo "[decode]        RESTARTING WILL NOT HELP - the sandbox keeps the address. Remedy:"
+                    echo "[decode]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                    exit 1
+                  fi
+                  export GLOO_SOCKET_IFNAME=${DOLLAR}{GLOO_SOCKET_IFNAME:-${DOLLAR}(ip -o -4 route show default | awk '{print ${DOLLAR}5; exit}')}
+                  GLOO_BIND_IP=${DOLLAR}(ip -o -4 addr show dev "${DOLLAR}GLOO_SOCKET_IFNAME" 2>/dev/null | awk '{print ${DOLLAR}4; exit}' | cut -d/ -f1)
+                  echo "[decode] GLOO_SOCKET_IFNAME=${DOLLAR}GLOO_SOCKET_IFNAME bind=${DOLLAR}GLOO_BIND_IP"
+                  case "${DOLLAR}{GLOO_BIND_IP:-}" in
+                    ""|127.*) echo "[decode] FATAL: GLOO_SOCKET_IFNAME=${DOLLAR}GLOO_SOCKET_IFNAME has no routable IPv4 (got '${DOLLAR}GLOO_BIND_IP'); the cross-node DP-padding all-reduce would bind loopback. Exiting for a clean restart."; exit 1 ;;
+                  esac
+                  # No warmup subshell here, unlike lws-ep's decode leader - see header.
+                  exec python3 -m dynamo.vllm \
+                    --model ${MODEL_PATH} \
+                    --served-model-name ${MODEL_NAME} \
+                    --tensor-parallel-size ${GPU_PER_WORKER} \
+                    --data-parallel-size ${EP_DP_SIZE} \
+                    --enable-expert-parallel \
+                    --pipeline-parallel-size 1 \
+                    --max-model-len 8192 \
+                    --gpu-memory-utilization 0.92 \
+                    --enforce-eager \
+                    --trust-remote-code ${MOE_BACKEND_FLAG} \
+                    ${MAMBA_FLAGS} \
+                    --load-format runai_streamer \
+                    --disaggregation-mode decode \
+                    --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"],"kv_lease_duration":${KV_LEASE_DURATION}}}'
+              env:
+                # Read only by the duplicate-address preflight in args above.
+                - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+                - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
+                - { name: VLLM_LOGGING_LEVEL, value: INFO }
+                - { name: VLLM_SSM_CONV_STATE_LAYOUT, value: DS }
+                - { name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS, value: "1800" }
+                # 550B BF16 weight loading from Lustre exceeds the default 600s engine timeout.
+                - { name: VLLM_ENGINE_READY_TIMEOUT_S, value: "2400" }
+                - { name: FLASHINFER_DISABLE_VERSION_CHECK, value: "1" }
+                # NVFP4 on sm100: vllm_omni's Quack/CuTeDSL FP8 scaled-mm monkey-patch defaults
+                # ON, but its tuned-compile helper cannot spawn inside vLLM's daemonic TP workers
+                # ("daemonic processes are not allowed to have children") -> exception + FlashInfer
+                # fallback on EVERY GEMM call, nothing caches, and decode crawls at ~0.05-0.1 tok/s
+                # while looking "stuck". Force it off; BF16 never enters this path (no-op there).
+                - { name: VLLM_OMNI_USE_QUACK_FP8, value: "0" }
+                - { name: FI_PROVIDER, value: efa }
+                - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
+                - { name: FI_EFA_FORK_SAFE, value: "1" }
+                - { name: FI_HMEM_CUDA_USE_DMABUF, value: "1" }
+                - { name: NIXL_LIBFABRIC_MAX_RAILS, value: "1" }
+                - { name: NIXL_SKIP_TOPOLOGY_CHECK, value: "1" }
+                - { name: NCCL_NET_PLUGIN, value: ofi }
+                - { name: NCCL_TUNER_PLUGIN, value: ofi }
+                - { name: OFI_NCCL_FORCE_NUM_RAILS, value: "4" }
+                - { name: NCCL_RUNTIME_CONNECT, value: "0" }
+                - { name: NCCL_NVLS_ENABLE, value: "0" }
+                - { name: NCCL_CUMEM_ENABLE, value: "1" }
+                - { name: NCCL_SOCKET_IFNAME, value: "^lo,docker,veth,eni" }
+              # NOTE: no ports/startupProbe on a multinode component (see header).
+              volumeMounts:
+                - { name: fsx-pvc, mountPath: /shared }
+                - { name: gdrdrv, mountPath: /dev/gdrdrv }
+              resources:
+                requests: { cpu: "${CPU_PER_WORKER}", memory: ${MEM_PER_WORKER}, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+                limits:   { cpu: "${CPU_PER_WORKER}", memory: ${MEM_PER_WORKER}, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd-grove-ep.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd-grove-ep.yaml-template
@@ -134,7 +134,7 @@ spec:
               # NOTE: no readinessProbe here - the operator injects its own frontend probe.
     # ---- Prefill: DP${EP_DP_SIZE} x TP${GPU_PER_WORKER}, EP degree
     # EP_DP_SIZE * GPU_PER_WORKER; one DP rank per node, its own EP group ------
-    - name: VllmPrefillWorker
+    - name: prefill
       type: prefill
       replicas: 1
       # Operator-managed /dev/shm tmpfs (CRD field; the only knob the operator
@@ -246,7 +246,7 @@ spec:
                 limits:   { cpu: "${CPU_PER_WORKER}", memory: ${MEM_PER_WORKER}, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
     # ---- Decode: its OWN DP${EP_DP_SIZE} x TP${GPU_PER_WORKER} EP group, same
     # width, independent coordinator. PP stays 1 (EP does not need PP). --------
-    - name: VllmDecodeWorker
+    - name: decode
       type: decode
       replicas: 1
       sharedMemorySize: 64Gi

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd-grove-pp2.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd-grove-pp2.yaml-template
@@ -1,0 +1,373 @@
+# =============================================================================
+# Nemotron-3 Ultra disagg SYMMETRIC PP2 via Grove — DynamoGraphDeployment, v1beta1
+# =============================================================================
+#
+# Author: Anton Alexander
+#
+# The lws-pp2 topology — prefill AND decode each TP${GPU_PER_WORKER} x
+# PP${NODE_COUNT_PER_WORKER} across ${NODE_COUNT_PER_WORKER} nodes, KV
+# prefill->decode over EFA RDMA via NIXL LIBFABRIC — rendered through Grove:
+# BOTH worker components carry `multinode.nodeCount`, so the operator turns
+# each role into a PodCliqueScalingGroup (leader + worker cliques) and
+# kai-scheduler gang-schedules the whole graph (frontend + 2 x prefill pods +
+# 2 x decode pods) as one PodGang. 2 * ${NODE_COUNT_PER_WORKER} GPU nodes,
+# 32 GPUs at the defaults.
+#
+#   MANIFEST_TYPE=dgd-grove-pp2 ./run.sh
+#
+# Prerequisites (both in this repo, apply in order):
+#   1. eks/deployment/nvidia-dynamo  — Dynamo platform >= 1.4.0 (operator/etcd/NATS)
+#   2. eks/deployment/grove          — standalone Grove + KAI releases; its deploy.sh
+#      flips global.grove.enabled + global.kai-scheduler.enabled on the platform
+#      release so the operator renders DGDs through Grove.
+#
+# IMAGE — HARD REQUIREMENT, unlike the other Grove headers' "try stock first":
+#   PP>1 disagg on a hybrid-Mamba model NEEDS TAG=":1.4.0-patched" (the
+#   ../dynamo-vllm-efa image WITH its patches/ layer). Stock vLLM 0.26
+#   (vllm-runtime:1.4.0-efa) hard-gates PP>1 + hybrid-KV at worker init —
+#   nixl base_worker.py raises NotImplementedError before serving anything —
+#   so the stock-tag fallback the dgd-grove header suggests DOES NOT APPLY
+#   here. The patches/ layer is the 0.26-era successor of vLLM PR#48263,
+#   PP2-prefill+PP2-decode byte-parity proven on B200 (see the Dockerfile
+#   header and lws-pp2 evidence).
+#
+# RANK BOOTSTRAP (the whole delta vs lws-pp2): the operator injects it.
+#   On a DGD created by a >= 1.0.0 operator the default is vLLM native
+#   multiprocessing — the operator appends
+#     --distributed-executor-backend mp --nnodes N --master-addr <leader-clique
+#     hostname> --master-port 29500 --node-rank <rank> [--headless]
+#   directly after `python3 -m dynamo.vllm` in THIS script (regex anchored on
+#   the python...vllm token), plus a wait-for-leader initContainer on worker
+#   ranks. The per-DGD annotation
+#     nvidia.com/vllm-distributed-executor-backend: "ray"
+#   (on the component podTemplate metadata) flips it to the Ray bootstrap that
+#   lws-pp2 wires by hand. We carry VLLM_USE_RAY_COMPILED_DAG=0 either way: a
+#   no-op under mp, and the known Ray-cgraph hybrid-Mamba deadlock guard if you
+#   flip to ray.
+#   INJECTION LAND MINE: because the operator regex-targets `python3 ... vllm`,
+#   do NOT add `python3 -c "import vllm; ..."` preflight lines to this script
+#   (lws-pp2 carries them; here they would catch the injection and corrupt the
+#   -c string). Keep exactly ONE python...vllm token in this args block.
+#
+# VALIDATION STATUS (be honest before quoting numbers):
+#   - Grove chain + this operator + 550B disagg PP1: PROVEN live 2026-08-20
+#     (dgd-grove.yaml-template header, KV-over-EFA verified).
+#   - Symmetric PP2 (both roles) on the patched image: PROVEN live under LWS
+#     (lws-pp2, Ray bootstrap, valid aiperf run 2026-08-23).
+#   - THIS combination — PP2 both roles under the operator's multinode
+#     bootstrap (mp by default) — is UNVALIDATED until a live smoke. The mp
+#     path structurally avoids the Ray-cgraph decode deadlock, but hybrid-Mamba
+#     PP2 decode has never been run through it. Smoke before benchmarking.
+#
+# Gotchas carried from the learnings corpus:
+#   - /dev/shm sizes ONLY via the component-level `sharedMemorySize` CRD field
+#     (nil = 8Gi; a podTemplate mount at /dev/shm is silently dropped). 64Gi is
+#     the live-verified 550B value — do not shrink it.
+#   - runtimeVersionOverride: the 1.4.0 admission webhook REJECTS a DGD whose
+#     main image tag is not parseable semver ("runtimeVersionOverride Required").
+#     ":1.4.0-patched" and ":1.3.1-patched" parse, so the default needs nothing;
+#     if you point TAG at a custom build (e.g. an ECR test tag like
+#     "dynamo140-pp-v1"), uncomment `runtimeVersionOverride` on all three
+#     components with the canonical MAJOR.MINOR.PATCH of the baked runtime.
+#   - Multi-pod crash-loop triage (gang deployments): a deterministic engine
+#     failure shows up as leader restart -> stranded rendezvous (8/16 ranks) ->
+#     ~600s c10d timeout -> gang recreate -> repeat. The Gloo/TCPStore errors
+#     are SECONDARY; find the attempt that got FURTHEST and read ITS
+#     previous-container log for the real cause.
+#   - Benchmarking artifacts: ../test/test-aiperf.sh files results under
+#     .../aiperf/<deploy>/${DOLLAR}{MANIFEST_TYPE}/ from ../test/.env — set
+#     MANIFEST_TYPE=dgd-grove-pp2 there too, or this run's artifacts land under
+#     the PREVIOUS manifest's path (the stale-MANIFEST_TYPE trap; verify with
+#     run-meta.json observed.workloads, never the path label).
+#
+# The cold-start warmup block lws-pp2's decode leader carries is intentionally
+# ABSENT here, same reasoning as agg/dgd-grove.yaml-template: in a clique the
+# warmer would launch on every rank pod and its leader-only health gate has not
+# been validated through the operator's multinode wiring. BF16 (the default)
+# never needed it; add it back leader-guarded once a live run establishes which
+# pod answers the dyn-system port.
+#
+# No explicit ports/probes on the worker components: in a multinode clique the
+# SAME container spec lands on leader AND worker rank pods; only the leader
+# answers the health port, so a template probe would hold every worker rank
+# NotReady forever. The operator injects multinode-aware probes.
+# =============================================================================
+---
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: ${DEPLOYMENT_NAME}
+  namespace: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/part-of: ${DEPLOYMENT_NAME}
+spec:
+  backendFramework: vllm
+  env:
+    - { name: DYNAMO_BACKEND, value: vllm }
+    - { name: ETCD_ENDPOINTS, value: "${ETCD_URL}" }
+    - { name: NATS_SERVER,    value: "${NATS_URL}" }
+    # /tmp, NOT /shared: pods run uid 1000 and /shared is root-owned - the frontend
+    # dies registering the model ("Failed to create cache directory /shared/hf_cache/hub:
+    # Permission denied") and /v1/models stays empty -> every request 404s.
+    - { name: HF_HOME,        value: /tmp/hf_cache }
+  components:
+    # ---- Frontend (router, CPU-only; its own PodClique in the gang) --------
+    # Verbatim from dgd-grove.yaml-template.
+    - name: Frontend
+      type: frontend
+      replicas: 1
+      # runtimeVersionOverride: "1.4.0"   # uncomment for a non-semver custom TAG (see header)
+      podTemplate:
+        spec:
+          nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_FRONTEND} }
+          volumes:
+            - { name: fsx-pvc, persistentVolumeClaim: { claimName: fsx-pvc } }
+          containers:
+            # The name MUST be "main" - that is the container the operator merges its
+            # image/command/env/ports/probe defaults into.
+            - name: main
+              image: ${REGISTRY}${IMAGE}${TAG}
+              imagePullPolicy: Always
+              command: ["/bin/bash", "-c"]
+              args:
+                - |-
+                  if [ -n "${DOLLAR}{POD_IP:-}" ] && [ "${DOLLAR}{POD_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
+                    echo "[frontend] FATAL: pod IP ${DOLLAR}POD_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                    echo "[frontend]        Cluster DNS cannot answer for this pod, so NATS/etcd are unreachable."
+                    echo "[frontend]        RESTARTING WILL NOT HELP - the sandbox keeps the address. Remedy:"
+                    echo "[frontend]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                    exit 1
+                  fi
+                  if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+                  exec python3 -m dynamo.frontend --http-port 8000 --http-host 0.0.0.0
+              env:
+                - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+                - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
+              ports: [{ containerPort: 8000, name: http }]
+              # The frontend reads the model dir (config/tokenizer, not weights) to build the
+              # preprocessor when workers register a local path - without this mount the model
+              # never appears in /v1/models.
+              volumeMounts:
+                - { name: fsx-pvc, mountPath: /shared }
+              resources:
+                requests: { cpu: "2", memory: 4Gi }
+                limits:   { cpu: "4", memory: 8Gi }
+              # NOTE: no readinessProbe here - the operator injects its own frontend probe.
+    # ---- Prefill: ONE engine, TP${GPU_PER_WORKER} x PP${NODE_COUNT_PER_WORKER}
+    # across ${NODE_COUNT_PER_WORKER} nodes (leader + worker cliques) ----------
+    - name: VllmPrefillWorker
+      type: prefill
+      replicas: 1
+      # Operator-managed /dev/shm tmpfs (CRD field; the only knob the operator
+      # honors - podTemplate mounts at /dev/shm are silently dropped). 64Gi is
+      # the value verified injected in the live 550B Grove run.
+      sharedMemorySize: 64Gi
+      # runtimeVersionOverride: "1.4.0"   # uncomment for a non-semver custom TAG (see header)
+      multinode:
+        nodeCount: ${NODE_COUNT_PER_WORKER}
+      podTemplate:
+        spec:
+          nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_WORKER} }
+          tolerations:
+            - { key: nvidia.com/gpu, operator: Exists, effect: NoSchedule }
+            - { key: vpc.amazonaws.com/efa, operator: Exists, effect: NoSchedule }
+          affinity:
+            # Keyed to the operator-applied label (VERIFIED present on Grove-rendered
+            # pods; app.kubernetes.io/part-of passthrough is not).
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchLabels:
+                      nvidia.com/dynamo-graph-deployment-name: ${DEPLOYMENT_NAME}
+                  topologyKey: kubernetes.io/hostname
+          volumes:
+            - { name: fsx-pvc, persistentVolumeClaim: { claimName: fsx-pvc } }
+            - { name: gdrdrv, hostPath: { path: /dev/gdrdrv, type: CharDevice } }
+          containers:
+            - name: main
+              image: ${REGISTRY}${IMAGE}${TAG}
+              imagePullPolicy: Always
+              securityContext: { capabilities: { add: ["IPC_LOCK"] } }
+              command: ["/bin/bash", "-c"]
+              args:
+                - |-
+                  set -u
+                  unset HPCX_DIR HPCX_MPI_DIR HPCX_HOME HPCX_UCX_DIR HPCX_SHARP_DIR \
+                        HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
+                  if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+                  if [ -n "${DOLLAR}{POD_IP:-}" ] && [ "${DOLLAR}{POD_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
+                    echo "[prefill] FATAL: pod IP ${DOLLAR}POD_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                    echo "[prefill]        Cluster DNS cannot answer for this pod, so NATS/etcd are unreachable."
+                    echo "[prefill]        RESTARTING WILL NOT HELP - the sandbox keeps the address. Remedy:"
+                    echo "[prefill]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                    exit 1
+                  fi
+                  # Gloo bind interface: cross-node CPU groups (torch dist bootstrap) must not
+                  # bind loopback. Same derive-and-FATAL guard the lws PP templates carry.
+                  export GLOO_SOCKET_IFNAME=${DOLLAR}{GLOO_SOCKET_IFNAME:-${DOLLAR}(ip -o -4 route show default | awk '{print ${DOLLAR}5; exit}')}
+                  GLOO_BIND_IP=${DOLLAR}(ip -o -4 addr show dev "${DOLLAR}GLOO_SOCKET_IFNAME" 2>/dev/null | awk '{print ${DOLLAR}4; exit}' | cut -d/ -f1)
+                  echo "[prefill] GLOO_SOCKET_IFNAME=${DOLLAR}GLOO_SOCKET_IFNAME bind=${DOLLAR}GLOO_BIND_IP"
+                  case "${DOLLAR}{GLOO_BIND_IP:-}" in
+                    ""|127.*) echo "[prefill] FATAL: GLOO_SOCKET_IFNAME=${DOLLAR}GLOO_SOCKET_IFNAME has no routable IPv4 (got '${DOLLAR}GLOO_BIND_IP'); cross-node Gloo would bind loopback. Exiting for a clean restart."; exit 1 ;;
+                  esac
+                  # TP stays inside each node; PP spans the clique members - the engine shape
+                  # proven E2E for the 550B on lws-pp2. The rank bootstrap (mp/ray flags,
+                  # master addr, node rank) is INJECTED by the operator right after the
+                  # dynamo.vllm token below - keep this the only python...vllm line (header).
+                  exec python3 -m dynamo.vllm \
+                    --model ${MODEL_PATH} \
+                    --served-model-name ${MODEL_NAME} \
+                    --tensor-parallel-size ${GPU_PER_WORKER} \
+                    --pipeline-parallel-size ${NODE_COUNT_PER_WORKER} \
+                    --max-model-len 8192 \
+                    --gpu-memory-utilization 0.92 \
+                    --enforce-eager \
+                    --trust-remote-code ${MOE_BACKEND_FLAG} \
+                    ${MAMBA_FLAGS} \
+                    --load-format runai_streamer \
+                    --disaggregation-mode prefill \
+                    --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"],"kv_lease_duration":${KV_LEASE_DURATION}}}'
+              env:
+                # Read only by the duplicate-address preflight in args above.
+                - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+                - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
+                - { name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS, value: "1800" }
+                - { name: VLLM_LOGGING_LEVEL, value: INFO }
+                - { name: VLLM_SSM_CONV_STATE_LAYOUT, value: DS }
+                - { name: FLASHINFER_DISABLE_VERSION_CHECK, value: "1" }
+                # Ray-cgraph hybrid-Mamba PP deadlock guard from lws-pp2: no-op under the
+                # operator's default mp bootstrap, load-bearing if you flip the
+                # vllm-distributed-executor-backend annotation to ray (header).
+                - { name: VLLM_USE_RAY_COMPILED_DAG, value: "0" }
+                # NVFP4 on sm100: vllm_omni's Quack/CuTeDSL FP8 scaled-mm monkey-patch defaults
+                # ON, but its tuned-compile helper cannot spawn inside vLLM's daemonic TP workers
+                # ("daemonic processes are not allowed to have children") -> exception + FlashInfer
+                # fallback on EVERY GEMM call, nothing caches, and decode crawls at ~0.05-0.1 tok/s
+                # while looking "stuck". Force it off; BF16 never enters this path (no-op there).
+                - { name: VLLM_OMNI_USE_QUACK_FP8, value: "0" }
+                - { name: FI_PROVIDER, value: efa }
+                - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
+                - { name: FI_EFA_FORK_SAFE, value: "1" }
+                - { name: FI_HMEM_CUDA_USE_DMABUF, value: "1" }
+                - { name: FI_EFA_ENABLE_SHM, value: "0" }
+                - { name: FI_EFA_ENABLE_SHM_TRANSFER, value: "0" }
+                - { name: NIXL_LIBFABRIC_MAX_RAILS, value: "1" }
+                - { name: NIXL_SKIP_TOPOLOGY_CHECK, value: "1" }
+                - { name: NCCL_NET_PLUGIN, value: ofi }
+                - { name: NCCL_TUNER_PLUGIN, value: ofi }
+                - { name: OFI_NCCL_FORCE_NUM_RAILS, value: "4" }
+                # lws-pp2's proven NCCL trio for the cross-node PP engine, carried verbatim.
+                - { name: NCCL_RUNTIME_CONNECT, value: "0" }
+                - { name: NCCL_NVLS_ENABLE, value: "1" }
+                - { name: NCCL_CUMEM_ENABLE, value: "1" }
+              # NOTE: no ports/startupProbe on a multinode component (see header).
+              volumeMounts:
+                - { name: fsx-pvc, mountPath: /shared }
+                - { name: gdrdrv, mountPath: /dev/gdrdrv }
+              resources:
+                requests: { cpu: "${CPU_PER_WORKER}", memory: ${MEM_PER_WORKER}, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+                limits:   { cpu: "${CPU_PER_WORKER}", memory: ${MEM_PER_WORKER}, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+    # ---- Decode: ONE engine, TP${GPU_PER_WORKER} x PP${NODE_COUNT_PER_WORKER}
+    # across ${NODE_COUNT_PER_WORKER} nodes. PP2 decode is exactly what the
+    # patched image + lws-pp2 proved; on stock 0.26 this component cannot start
+    # (header). ---------------------------------------------------------------
+    - name: VllmDecodeWorker
+      type: decode
+      replicas: 1
+      sharedMemorySize: 64Gi
+      # runtimeVersionOverride: "1.4.0"   # uncomment for a non-semver custom TAG (see header)
+      multinode:
+        nodeCount: ${NODE_COUNT_PER_WORKER}
+      podTemplate:
+        spec:
+          nodeSelector: { node.kubernetes.io/instance-type: ${INSTANCE_TYPE_WORKER} }
+          tolerations:
+            - { key: nvidia.com/gpu, operator: Exists, effect: NoSchedule }
+            - { key: vpc.amazonaws.com/efa, operator: Exists, effect: NoSchedule }
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchLabels:
+                      nvidia.com/dynamo-graph-deployment-name: ${DEPLOYMENT_NAME}
+                  topologyKey: kubernetes.io/hostname
+          volumes:
+            - { name: fsx-pvc, persistentVolumeClaim: { claimName: fsx-pvc } }
+            - { name: gdrdrv, hostPath: { path: /dev/gdrdrv, type: CharDevice } }
+          containers:
+            - name: main
+              image: ${REGISTRY}${IMAGE}${TAG}
+              imagePullPolicy: Always
+              securityContext: { capabilities: { add: ["IPC_LOCK"] } }
+              command: ["/bin/bash", "-c"]
+              args:
+                - |-
+                  set -u
+                  unset HPCX_DIR HPCX_MPI_DIR HPCX_HOME HPCX_UCX_DIR HPCX_SHARP_DIR \
+                        HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR HPCX_HCOLL_DIR HPCX_MPI_TESTS_DIR
+                  if [ -f /opt/dynamo/venv/bin/activate ]; then source /opt/dynamo/venv/bin/activate; fi
+                  if [ -n "${DOLLAR}{POD_IP:-}" ] && [ "${DOLLAR}{POD_IP:-}" = "${DOLLAR}{NODE_IP:-}" ]; then
+                    echo "[decode] FATAL: pod IP ${DOLLAR}POD_IP == node IP ${DOLLAR}NODE_IP with hostNetwork=false."
+                    echo "[decode]        Cluster DNS cannot answer for this pod, so NATS/etcd are unreachable."
+                    echo "[decode]        RESTARTING WILL NOT HELP - the sandbox keeps the address. Remedy:"
+                    echo "[decode]        kubectl -n ${NAMESPACE} delete pod ${DOLLAR}HOSTNAME"
+                    exit 1
+                  fi
+                  export GLOO_SOCKET_IFNAME=${DOLLAR}{GLOO_SOCKET_IFNAME:-${DOLLAR}(ip -o -4 route show default | awk '{print ${DOLLAR}5; exit}')}
+                  GLOO_BIND_IP=${DOLLAR}(ip -o -4 addr show dev "${DOLLAR}GLOO_SOCKET_IFNAME" 2>/dev/null | awk '{print ${DOLLAR}4; exit}' | cut -d/ -f1)
+                  echo "[decode] GLOO_SOCKET_IFNAME=${DOLLAR}GLOO_SOCKET_IFNAME bind=${DOLLAR}GLOO_BIND_IP"
+                  case "${DOLLAR}{GLOO_BIND_IP:-}" in
+                    ""|127.*) echo "[decode] FATAL: GLOO_SOCKET_IFNAME=${DOLLAR}GLOO_SOCKET_IFNAME has no routable IPv4 (got '${DOLLAR}GLOO_BIND_IP'); cross-node Gloo would bind loopback. Exiting for a clean restart."; exit 1 ;;
+                  esac
+                  # No warmup subshell here, unlike lws-pp2's decode leader - see header.
+                  exec python3 -m dynamo.vllm \
+                    --model ${MODEL_PATH} \
+                    --served-model-name ${MODEL_NAME} \
+                    --tensor-parallel-size ${GPU_PER_WORKER} \
+                    --pipeline-parallel-size ${NODE_COUNT_PER_WORKER} \
+                    --max-model-len 8192 \
+                    --gpu-memory-utilization 0.92 \
+                    --enforce-eager \
+                    --trust-remote-code ${MOE_BACKEND_FLAG} \
+                    ${MAMBA_FLAGS} \
+                    --load-format runai_streamer \
+                    --disaggregation-mode decode \
+                    --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"],"kv_lease_duration":${KV_LEASE_DURATION}}}'
+              env:
+                # Read only by the duplicate-address preflight in args above.
+                - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+                - { name: NODE_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
+                - { name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS, value: "1800" }
+                - { name: VLLM_LOGGING_LEVEL, value: INFO }
+                - { name: VLLM_SSM_CONV_STATE_LAYOUT, value: DS }
+                - { name: FLASHINFER_DISABLE_VERSION_CHECK, value: "1" }
+                # Ray-cgraph hybrid-Mamba PP deadlock guard from lws-pp2 (see prefill note).
+                - { name: VLLM_USE_RAY_COMPILED_DAG, value: "0" }
+                # NVFP4 on sm100: vllm_omni's Quack/CuTeDSL FP8 scaled-mm monkey-patch defaults
+                # ON, but its tuned-compile helper cannot spawn inside vLLM's daemonic TP workers
+                # ("daemonic processes are not allowed to have children") -> exception + FlashInfer
+                # fallback on EVERY GEMM call, nothing caches, and decode crawls at ~0.05-0.1 tok/s
+                # while looking "stuck". Force it off; BF16 never enters this path (no-op there).
+                - { name: VLLM_OMNI_USE_QUACK_FP8, value: "0" }
+                - { name: FI_PROVIDER, value: efa }
+                - { name: FI_EFA_USE_DEVICE_RDMA, value: "1" }
+                - { name: FI_EFA_FORK_SAFE, value: "1" }
+                - { name: FI_HMEM_CUDA_USE_DMABUF, value: "1" }
+                - { name: FI_EFA_ENABLE_SHM, value: "0" }
+                - { name: FI_EFA_ENABLE_SHM_TRANSFER, value: "0" }
+                - { name: NIXL_LIBFABRIC_MAX_RAILS, value: "1" }
+                - { name: NIXL_SKIP_TOPOLOGY_CHECK, value: "1" }
+                - { name: NCCL_NET_PLUGIN, value: ofi }
+                - { name: NCCL_TUNER_PLUGIN, value: ofi }
+                - { name: OFI_NCCL_FORCE_NUM_RAILS, value: "4" }
+                # lws-pp2's proven NCCL trio for the cross-node PP engine, carried verbatim.
+                - { name: NCCL_RUNTIME_CONNECT, value: "0" }
+                - { name: NCCL_NVLS_ENABLE, value: "1" }
+                - { name: NCCL_CUMEM_ENABLE, value: "1" }
+              # NOTE: no ports/startupProbe on a multinode component (see header).
+              volumeMounts:
+                - { name: fsx-pvc, mountPath: /shared }
+                - { name: gdrdrv, mountPath: /dev/gdrdrv }
+              resources:
+                requests: { cpu: "${CPU_PER_WORKER}", memory: ${MEM_PER_WORKER}, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }
+                limits:   { cpu: "${CPU_PER_WORKER}", memory: ${MEM_PER_WORKER}, nvidia.com/gpu: "${GPU_PER_WORKER}", vpc.amazonaws.com/efa: "${EFA_PER_WORKER}" }

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd-grove-pp2.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd-grove-pp2.yaml-template
@@ -55,9 +55,11 @@
 #   - Symmetric PP2 (both roles) on the patched image: PROVEN live under LWS
 #     (lws-pp2, Ray bootstrap, valid aiperf run 2026-08-23).
 #   - THIS combination — PP2 both roles under the operator's multinode
-#     bootstrap (mp by default) — is UNVALIDATED until a live smoke. The mp
-#     path structurally avoids the Ray-cgraph decode deadlock, but hybrid-Mamba
-#     PP2 decode has never been run through it. Smoke before benchmarking.
+#     bootstrap (mp by default) — PROVEN live 2026-08-24: hybrid-Mamba PP2
+#     decode ran clean through the mp path (no Ray-cgraph deadlock), greedy
+#     output byte-identical to the lws-pp2 control, warm aiperf c=10
+#     ISL1024/OSL512 100 req 0 err: TTFT p50 369 ms / ITL p50 51.8 ms /
+#     190.1 output tok/s (within ~4-6% of the lws-pp2 pin capture).
 #
 # Gotchas carried from the learnings corpus:
 #   - /dev/shm sizes ONLY via the component-level `sharedMemorySize` CRD field

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd-grove-pp2.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd-grove-pp2.yaml-template
@@ -171,15 +171,11 @@ spec:
           tolerations:
             - { key: nvidia.com/gpu, operator: Exists, effect: NoSchedule }
             - { key: vpc.amazonaws.com/efa, operator: Exists, effect: NoSchedule }
-          affinity:
-            # Keyed to the operator-applied label (VERIFIED present on Grove-rendered
-            # pods; app.kubernetes.io/part-of passthrough is not).
-            podAntiAffinity:
-              requiredDuringSchedulingIgnoredDuringExecution:
-                - labelSelector:
-                    matchLabels:
-                      nvidia.com/dynamo-graph-deployment-name: ${DEPLOYMENT_NAME}
-                  topologyKey: kubernetes.io/hostname
+          # No worker anti-affinity, deliberately: each worker requests all 8 GPUs,
+          # so two workers can never share a node anyway -- and a whole-DGD
+          # anti-affinity key makes the gang UNSCHEDULABLE on GPU-only clusters
+          # (4 workers + co-located frontend mutually anti-affine on 4 nodes;
+          # measured kai-scheduler reject, B200 HyperPod 2026-08-24).
           volumes:
             - { name: fsx-pvc, persistentVolumeClaim: { claimName: fsx-pvc } }
             - { name: gdrdrv, hostPath: { path: /dev/gdrdrv, type: CharDevice } }
@@ -284,13 +280,11 @@ spec:
           tolerations:
             - { key: nvidia.com/gpu, operator: Exists, effect: NoSchedule }
             - { key: vpc.amazonaws.com/efa, operator: Exists, effect: NoSchedule }
-          affinity:
-            podAntiAffinity:
-              requiredDuringSchedulingIgnoredDuringExecution:
-                - labelSelector:
-                    matchLabels:
-                      nvidia.com/dynamo-graph-deployment-name: ${DEPLOYMENT_NAME}
-                  topologyKey: kubernetes.io/hostname
+          # No worker anti-affinity, deliberately: each worker requests all 8 GPUs,
+          # so two workers can never share a node anyway -- and a whole-DGD
+          # anti-affinity key makes the gang UNSCHEDULABLE on GPU-only clusters
+          # (4 workers + co-located frontend mutually anti-affine on 4 nodes;
+          # measured kai-scheduler reject, B200 HyperPod 2026-08-24).
           volumes:
             - { name: fsx-pvc, persistentVolumeClaim: { claimName: fsx-pvc } }
             - { name: gdrdrv, hostPath: { path: /dev/gdrdrv, type: CharDevice } }

--- a/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd-grove-pp2.yaml-template
+++ b/Container-Root/eks/deployment/inference/agentic-ai/nemotron/ultra/disagg/dgd-grove-pp2.yaml-template
@@ -155,7 +155,7 @@ spec:
               # NOTE: no readinessProbe here - the operator injects its own frontend probe.
     # ---- Prefill: ONE engine, TP${GPU_PER_WORKER} x PP${NODE_COUNT_PER_WORKER}
     # across ${NODE_COUNT_PER_WORKER} nodes (leader + worker cliques) ----------
-    - name: VllmPrefillWorker
+    - name: prefill
       type: prefill
       replicas: 1
       # Operator-managed /dev/shm tmpfs (CRD field; the only knob the operator
@@ -271,7 +271,7 @@ spec:
     # across ${NODE_COUNT_PER_WORKER} nodes. PP2 decode is exactly what the
     # patched image + lws-pp2 proved; on stock 0.26 this component cannot start
     # (header). ---------------------------------------------------------------
-    - name: VllmDecodeWorker
+    - name: decode
       type: decode
       replicas: 1
       sharedMemorySize: 64Gi


### PR DESCRIPTION
## What

Adds the two remaining LWS-proven engine shapes as Grove-rendered `v1beta1` `DynamoGraphDeployment` variants for Nemotron-3 Ultra 550B (follow-up to #94, which added `dgd-grove` at TP8/PP-per-role):

| New template | Shape | Nodes | LWS sibling |
|---|---|---|---|
| `disagg/dgd-grove-pp2.yaml-template` | symmetric PP2: prefill AND decode TP8/PP2, both workers `multinode.nodeCount: 2` | 4 | `disagg/lws-pp2` |
| `disagg/dgd-grove-ep.yaml-template` | wide EP per role: prefill + decode each DP2×TP8 (`--enable-expert-parallel`, EP16) | 4 | `disagg/lws-ep` |
| `agg/dgd-grove-ep.yaml-template` | wide EP: DP2×TP8, EP16 | 2 | `agg/lws-ep` |

Plus `.env` additions (both dirs) and README matrix rows. Same `run.sh`/`stop.sh` flow: `MANIFEST_TYPE=dgd-grove-pp2` (or `dgd-grove-ep`) names the template.

Key differences from the LWS siblings, documented in the template headers:
- The Dynamo operator (>= 1.4.0 + Grove/KAI) injects the multinode rank bootstrap (PP legs) and the DP coordination flags (`--data-parallel-hybrid-lb --data-parallel-size-local 1 --data-parallel-start-rank <rank> --data-parallel-address <leader-clique> --data-parallel-rpc-port`) on the EP legs — the templates deliberately do NOT carry those flags (duplicates would corrupt the injection).
- `dgd-grove-pp2` hard-gates the `:1.4.0-patched` image (stock vLLM 0.26 refuses PP>1 + hybrid-KV-cache-manager).
- Grove component names shortened to fit the 45-char pod-name admission limit; whole-DGD worker anti-affinity dropped from multinode variants (each role's ranks must co-schedule freely across the gang).

## Render gate (cluster-free, re-run after final edits — PASS)

6 keys × BF16+NVFP4 rendered through the same `source .env | envsubst` path `run.sh` uses:
1. YAML parses (all files, both variants)
2. `--moe-backend flashinfer_cutlass` count per launch site (BF16), 0 for NVFP4
3. no unrendered template vars survive
4. `bash -n` on every embedded launch script
5. **arg-parity: each DGD role's rendered vLLM args identical to its lws sibling's** modulo the documented operator-injected allowlist — 5/5 roles PASS (agg-ep worker 13 args, disagg-ep prefill/decode 16, pp2 prefill/decode 14)
6. `dgd-grove-pp2` renders image `:1.4.0-patched`

## Live E2E validation (2026-08-24, 4× p6e B200 nodes, one scenario at a time)

All three variants deployed via `run.sh`, served Nemotron-3 Ultra 550B BF16, and were benchmarked with the same aiperf harness as the LWS cells (c=10, ISL1024/OSL512, 100 req; warm = 2nd run; error_summary empty in every run):

| Variant | TTFT p50 | ITL p50 | Output tok/s | Correctness |
|---|---|---|---|---|
| `disagg/dgd-grove-pp2` | 368.6 ms | 51.8 ms | 190.1 | greedy output byte-identical to the `lws-pp2` capture (same image pin); within ~4–6% of the lws-pp2 warm row |
| `disagg/dgd-grove-ep` | 722.3 ms | 109.1 ms | 90.6 | greedy output byte-identical to the `lws-pp2` control (no lws-ep capture exists; cross-parallelism coherence check) |
| `agg/dgd-grove-ep` | 379.0 ms | 108.5 ms | 91.6 | greedy output byte-identical to the agg `deployment` pin capture |

Proof details (from live pod args/logs, captured before teardown):
- **pp2**: all 4 GPU pods TP8/PP2 `--nnodes 2` with `--kv-transfer-config` (NixlConnector, LIBFABRIC backend instantiated ×8 TP workers per pod), Grove-injected rank bootstrap (`GROVE_PCSG_NAME` master-addr, `GROVE_PCLQ_POD_INDEX` node-rank), decode-side NIXL compatibility handshake passed. Per-transfer byte counters were not captured before teardown, so the KV-transfer evidence is the config + handshake + the byte-identical greedy decode vs the lws-pp2 control (a functional KV proof for this hybrid-Mamba model — stale SSM state produces divergent text).
- **disagg-ep**: all 4 rank pods `--enable-expert-parallel` + DP2×TP8 with the operator-injected hybrid-lb DP wiring visible verbatim in live args; worker ranks EP0–EP15 in logs; NIXL compatibility handshake on both decode DP ranks.
- **agg-ep**: both rank pods same EP16 wiring (`--data-parallel-start-rank` 0 / Grove-index-derived), `EngineCore_DP0` and `EngineCore_DP1` both initialized.

Teardown verified after the final leg: 0 model pods, 0 DynamoGraphDeployments, 0/8 GPUs allocated on all 4 nodes.

## Commits

- `a7c3df2` add the three templates + `.env` + README rows
- `a94837e` shorten component names to Grove's 45-char pod-name limit (found at first live apply — the admission webhook rejects longer gang pod names)
- `ade6424` drop whole-DGD worker anti-affinity from multinode variants (found at live apply — it blocked same-role rank co-scheduling)
- `71a2a65` flip the template headers + README rows from unproven to the measured verdicts